### PR TITLE
Update style guide version and documentation references

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.1
+**Version:** 2.2.20260412.2
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -627,7 +627,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 ### Help Content Quality: High Standards
 
-1. **Behavioral Contracts**: Every possible return code documented with **exact meaning** and **example**.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** and **example**; when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.
@@ -1409,7 +1409,7 @@ try {
 
 ### Reference Implementation
 
-Full `Test-FileWriteability` implementation: <https://github.com/franklesniak/PowerShell_Resources/blob/main/Test-FileWriteability.ps1>
+Full `Test-FileWriteability` implementation: <https://github.com/franklesniak/PowerShell_Resources/blob/master/Test-FileWriteability.ps1>
 
 ## Operating System Compatibility Checks
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.2
+**Version:** 2.2.20260412.3
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -51,7 +51,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** All return codes **MUST** be documented with exact meanings in .OUTPUTS → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented with exact meaning and example in .OUTPUTS; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)

--- a/STYLE_GUIDE_CHAT.md
+++ b/STYLE_GUIDE_CHAT.md
@@ -3,7 +3,7 @@
 ````markdown
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.1
+**Version:** 2.2.20260412.2
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -630,7 +630,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 ### Help Content Quality: High Standards
 
-1. **Behavioral Contracts**: Every possible return code documented with **exact meaning** and **example**.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** and **example**; when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.
@@ -1412,7 +1412,7 @@ try {
 
 ### Reference Implementation
 
-Full `Test-FileWriteability` implementation: <https://github.com/franklesniak/PowerShell_Resources/blob/main/Test-FileWriteability.ps1>
+Full `Test-FileWriteability` implementation: <https://github.com/franklesniak/PowerShell_Resources/blob/master/Test-FileWriteability.ps1>
 
 ## Operating System Compatibility Checks
 

--- a/STYLE_GUIDE_CHAT.md
+++ b/STYLE_GUIDE_CHAT.md
@@ -3,7 +3,7 @@
 ````markdown
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.2
+**Version:** 2.2.20260412.3
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -54,7 +54,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** All return codes **MUST** be documented with exact meanings in .OUTPUTS → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented with exact meaning and example in .OUTPUTS; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)

--- a/STYLE_GUIDE_FULL.md
+++ b/STYLE_GUIDE_FULL.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.2
+**Version:** 2.2.20260412.3
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -59,7 +59,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** All return codes **MUST** be documented with exact meanings in .OUTPUTS → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented with exact meaning and example in .OUTPUTS; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)

--- a/STYLE_GUIDE_FULL.md
+++ b/STYLE_GUIDE_FULL.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.1
+**Version:** 2.2.20260412.2
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -817,7 +817,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 Comprehensive help also demonstrates **State Transparency**: showing **exact contents** of output variables after execution, so callers know precisely what to expect.
 
-1. **Behavioral Contracts**: Every possible return code documented with **exact meaning** and **example**.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** and **example**; when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.
@@ -1843,7 +1843,7 @@ try {
 
 For scripts requiring the comprehensive `.NET` approach, a full implementation of the `Test-FileWriteability` function is available at:
 
-<https://github.com/franklesniak/PowerShell_Resources/blob/main/Test-FileWriteability.ps1>
+<https://github.com/franklesniak/PowerShell_Resources/blob/master/Test-FileWriteability.ps1>
 
 This implementation includes:
 
@@ -1852,7 +1852,7 @@ This implementation includes:
 - Full documentation and examples
 - Support for PowerShell v1.0+
 
-Full `Test-FileWriteability` implementation: <https://github.com/franklesniak/PowerShell_Resources/blob/main/Test-FileWriteability.ps1>
+Full `Test-FileWriteability` implementation: <https://github.com/franklesniak/PowerShell_Resources/blob/master/Test-FileWriteability.ps1>
 
 ## Operating System Compatibility Checks
 

--- a/STYLE_GUIDE_RATIONALE.md
+++ b/STYLE_GUIDE_RATIONALE.md
@@ -975,7 +975,7 @@ The `.NET` `try/catch` alternative approach:
 
 For scripts requiring the comprehensive `.NET` approach, a full implementation of the `Test-FileWriteability` function is available at:
 
-<https://github.com/franklesniak/PowerShell_Resources/blob/main/Test-FileWriteability.ps1>
+<https://github.com/franklesniak/PowerShell_Resources/blob/master/Test-FileWriteability.ps1>
 
 This implementation includes:
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.1
+**Version:** 2.2.20260412.2
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -627,7 +627,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 ### Help Content Quality: High Standards
 
-1. **Behavioral Contracts**: Every possible return code documented with **exact meaning** and **example**.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** and **example**; when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.
@@ -1409,7 +1409,7 @@ try {
 
 ### Reference Implementation
 
-Full `Test-FileWriteability` implementation: <https://github.com/franklesniak/PowerShell_Resources/blob/main/Test-FileWriteability.ps1>
+Full `Test-FileWriteability` implementation: <https://github.com/franklesniak/PowerShell_Resources/blob/master/Test-FileWriteability.ps1>
 
 ## Operating System Compatibility Checks
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.2
+**Version:** 2.2.20260412.3
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -51,7 +51,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** All return codes **MUST** be documented with exact meanings in .OUTPUTS → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented with exact meaning and example in .OUTPUTS; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)

--- a/powershell.instructions.md
+++ b/powershell.instructions.md
@@ -5,7 +5,7 @@ description: "PowerShell coding standards"
 
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.2
+**Version:** 2.2.20260412.3
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -56,7 +56,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** All return codes **MUST** be documented with exact meanings in .OUTPUTS → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented with exact meaning and example in .OUTPUTS; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)

--- a/powershell.instructions.md
+++ b/powershell.instructions.md
@@ -5,7 +5,7 @@ description: "PowerShell coding standards"
 
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.1
+**Version:** 2.2.20260412.2
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -632,7 +632,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 ### Help Content Quality: High Standards
 
-1. **Behavioral Contracts**: Every possible return code documented with **exact meaning** and **example**.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** and **example**; when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.
@@ -1414,7 +1414,7 @@ try {
 
 ### Reference Implementation
 
-Full `Test-FileWriteability` implementation: <https://github.com/franklesniak/PowerShell_Resources/blob/main/Test-FileWriteability.ps1>
+Full `Test-FileWriteability` implementation: <https://github.com/franklesniak/PowerShell_Resources/blob/master/Test-FileWriteability.ps1>
 
 ## Operating System Compatibility Checks
 


### PR DESCRIPTION
## Summary
This PR updates the PowerShell style guide documentation with clarifications to help documentation standards and corrects external repository references.

## Key Changes
- **Version bump**: Updated all style guide documents from version 2.2.20260412.1 to 2.2.20260412.2
- **Documentation clarity**: Enhanced the "Behavioral Contracts" requirement to explicitly state that documentation should cover "every possible output/return value" (not just return codes) and include full mapping of integer status codes to their meanings when used
- **Repository reference fix**: Corrected GitHub repository branch references from `main` to `master` in the `Test-FileWriteability` implementation links across multiple documents

## Files Modified
- STYLE_GUIDE_FULL.md
- STYLE_GUIDE.md
- STYLE_GUIDE_CHAT.md
- copilot-instructions.md
- powershell.instructions.md
- STYLE_GUIDE_RATIONALE.md

## Notable Details
The documentation enhancement clarifies that behavioral contracts should document all possible outputs (not limited to return codes) and explicitly requires status code mapping documentation when integer codes are used. This improves clarity for developers implementing functions according to the style guide.

https://claude.ai/code/session_01Qhyjco3vr78bSgWPGQa9Us