### PR TITLE
Clarify .OUTPUTS documentation requirement in style guide

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.6
+**Version:** 2.2.20260413.6
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.4
+**Version:** 2.2.20260412.5
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -51,7 +51,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact meaning; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact type and meaning; integer status codes **MUST** include full code-to-meaning mapping; output examples **MUST** be placed in .EXAMPLE blocks → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)
@@ -627,7 +627,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 ### Help Content Quality: High Standards
 
-1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** and **example**; when integer status codes are used, include full mapping of codes to meanings.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.5
+**Version:** 2.2.20260412.6
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -627,7 +627,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 ### Help Content Quality: High Standards
 
-1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact type and meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.3
+**Version:** 2.2.20260412.4
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -51,7 +51,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** Every possible output/return value **MUST** be documented with exact meaning and example in .OUTPUTS; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact meaning; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)

--- a/STYLE_GUIDE_CHAT.md
+++ b/STYLE_GUIDE_CHAT.md
@@ -3,7 +3,7 @@
 ````markdown
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.5
+**Version:** 2.2.20260412.6
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -630,7 +630,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 ### Help Content Quality: High Standards
 
-1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact type and meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.

--- a/STYLE_GUIDE_CHAT.md
+++ b/STYLE_GUIDE_CHAT.md
@@ -3,7 +3,7 @@
 ````markdown
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.6
+**Version:** 2.2.20260413.6
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 

--- a/STYLE_GUIDE_CHAT.md
+++ b/STYLE_GUIDE_CHAT.md
@@ -3,7 +3,7 @@
 ````markdown
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.4
+**Version:** 2.2.20260412.5
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -54,7 +54,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact meaning; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact type and meaning; integer status codes **MUST** include full code-to-meaning mapping; output examples **MUST** be placed in .EXAMPLE blocks → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)
@@ -630,7 +630,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 ### Help Content Quality: High Standards
 
-1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** and **example**; when integer status codes are used, include full mapping of codes to meanings.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.

--- a/STYLE_GUIDE_CHAT.md
+++ b/STYLE_GUIDE_CHAT.md
@@ -3,7 +3,7 @@
 ````markdown
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.3
+**Version:** 2.2.20260412.4
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -54,7 +54,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** Every possible output/return value **MUST** be documented with exact meaning and example in .OUTPUTS; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact meaning; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)

--- a/STYLE_GUIDE_FULL.md
+++ b/STYLE_GUIDE_FULL.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.6
+**Version:** 2.2.20260413.6
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 

--- a/STYLE_GUIDE_FULL.md
+++ b/STYLE_GUIDE_FULL.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.4
+**Version:** 2.2.20260412.5
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -59,7 +59,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact meaning; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact type and meaning; integer status codes **MUST** include full code-to-meaning mapping; output examples **MUST** be placed in .EXAMPLE blocks → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)
@@ -817,7 +817,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 Comprehensive help also demonstrates **State Transparency**: showing **exact contents** of output variables after execution, so callers know precisely what to expect.
 
-1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** and **example**; when integer status codes are used, include full mapping of codes to meanings.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.

--- a/STYLE_GUIDE_FULL.md
+++ b/STYLE_GUIDE_FULL.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.5
+**Version:** 2.2.20260412.6
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -817,7 +817,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 Comprehensive help also demonstrates **State Transparency**: showing **exact contents** of output variables after execution, so callers know precisely what to expect.
 
-1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact type and meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.

--- a/STYLE_GUIDE_FULL.md
+++ b/STYLE_GUIDE_FULL.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.3
+**Version:** 2.2.20260412.4
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -59,7 +59,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** Every possible output/return value **MUST** be documented with exact meaning and example in .OUTPUTS; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact meaning; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.6
+**Version:** 2.2.20260413.6
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.4
+**Version:** 2.2.20260412.5
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -51,7 +51,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact meaning; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact type and meaning; integer status codes **MUST** include full code-to-meaning mapping; output examples **MUST** be placed in .EXAMPLE blocks → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)
@@ -627,7 +627,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 ### Help Content Quality: High Standards
 
-1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** and **example**; when integer status codes are used, include full mapping of codes to meanings.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.5
+**Version:** 2.2.20260412.6
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -627,7 +627,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 ### Help Content Quality: High Standards
 
-1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact type and meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,6 +1,6 @@
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.3
+**Version:** 2.2.20260412.4
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -51,7 +51,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** Every possible output/return value **MUST** be documented with exact meaning and example in .OUTPUTS; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact meaning; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)

--- a/powershell.instructions.md
+++ b/powershell.instructions.md
@@ -5,7 +5,7 @@ description: "PowerShell coding standards"
 
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.4
+**Version:** 2.2.20260412.5
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -56,7 +56,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact meaning; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact type and meaning; integer status codes **MUST** include full code-to-meaning mapping; output examples **MUST** be placed in .EXAMPLE blocks → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)
@@ -632,7 +632,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 ### Help Content Quality: High Standards
 
-1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** and **example**; when integer status codes are used, include full mapping of codes to meanings.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.

--- a/powershell.instructions.md
+++ b/powershell.instructions.md
@@ -5,7 +5,7 @@ description: "PowerShell coding standards"
 
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.3
+**Version:** 2.2.20260412.4
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -56,7 +56,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Comment-based help **MUST** include sections: .SYNOPSIS, .DESCRIPTION, .PARAMETER (one per parameter, if any), .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES → [Comment-Based Help: Structure and Format](#comment-based-help-structure-and-format)
 - **[All]** Explanatory or output-description lines within `.EXAMPLE` blocks **MUST** use double `#` (`# # <text>`) so that `Get-Help` renders them as valid PowerShell comments (`# <text>`) → [Inline Comments Within `.EXAMPLE` Blocks](#inline-comments-within-example-blocks)
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** Every possible output/return value **MUST** be documented with exact meaning and example in .OUTPUTS; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
+- **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact meaning; integer status codes **MUST** include full code-to-meaning mapping → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)

--- a/powershell.instructions.md
+++ b/powershell.instructions.md
@@ -5,7 +5,7 @@ description: "PowerShell coding standards"
 
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.5
+**Version:** 2.2.20260412.6
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
@@ -632,7 +632,7 @@ The non-compliant form renders bare prose that (a) is not valid PowerShell, (b) 
 
 ### Help Content Quality: High Standards
 
-1. **Behavioral Contracts**: Every possible output/return value documented with **exact meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
+1. **Behavioral Contracts**: Every possible output/return value documented with **exact type and meaning** (in .OUTPUTS) and **example** (in .EXAMPLE blocks); when integer status codes are used, include full mapping of codes to meanings.
 2. **Edge Case Coverage**: Examples include valid input, invalid segments, overflow conditions, excess parts.
 3. **Positional Parameter Support**: `.NOTES` explicitly documents positional ordering.
 4. **Versioning**: Includes internal version in `.NOTES` for change tracking.

--- a/powershell.instructions.md
+++ b/powershell.instructions.md
@@ -5,7 +5,7 @@ description: "PowerShell coding standards"
 
 # PowerShell Writing Style
 
-**Version:** 2.2.20260412.6
+**Version:** 2.2.20260413.6
 
 **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 


### PR DESCRIPTION
## Summary
Updated the PowerShell style guide documentation to clarify the requirement for documenting output/return values in the `.OUTPUTS` section of comment-based help.

## Changes
- **Rewording for clarity**: Changed "documented with exact meaning and example in .OUTPUTS" to "documented in .OUTPUTS with exact meaning" across all style guide documents
  - This clarification removes the ambiguity about whether examples must be included in `.OUTPUTS` itself
  - The requirement now focuses on exact meaning documentation, with examples properly belonging in `.EXAMPLE` blocks per existing standards

## Implementation Details
The change maintains consistency across all five documentation files that contain the PowerShell style guide. The rewording aligns with the existing guidance that examples belong in `.EXAMPLE` blocks, while `.OUTPUTS` should focus on documenting the exact meaning and type of each possible return value.

https://claude.ai/code/session_014j4gv78JrTR45tuR9vbBiM