### PR TITLE
Add operational metadata section to style guide documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 -->
+
 # Contributing to PSStyleGuide
 
 Thank you for your interest in contributing to the PSStyleGuide repository! This document describes the conventions used in this project to help you place new content in the right location.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,24 @@ Place the following content in `STYLE_GUIDE_RATIONALE.md`:
 
 When a rule is added or changed in `STYLE_GUIDE.md`, add or update corresponding rationale in `STYLE_GUIDE_RATIONALE.md` when useful.
 
+### Operational metadata in consumer-facing guide files
+
+Consumer-facing guide files **may** include a concise top-of-document metadata block when the fields help humans, tooling, or LLM-based coding agents identify how to consume the document.
+
+For `STYLE_GUIDE.md`, the allowed metadata fields are:
+
+- `Status`
+- `Owner`
+- `Last Updated`
+- `Scope`
+
+Operational metadata is subject to the following constraints:
+
+- Metadata must remain concise and operational.
+- Extended explanation, history, tradeoffs, and rationale still belong in `STYLE_GUIDE_RATIONALE.md` or other contributor-facing files.
+- Consumer-facing guide files still must not cross-reference other repository files (see [No-cross-referencing norm](#no-cross-referencing-norm)).
+- Do not add a `Related` field or other cross-reference-oriented metadata to consumer-facing guide metadata.
+
 ## No-cross-referencing norm
 
 Consumer-facing style guide files must not cross-reference other files in this repository, including each other. The consumer-facing files are:

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,8 +1,15 @@
+<!-- markdownlint-disable MD013 -->
+
 # PowerShell Writing Style
 
-**Version:** 2.17.20260422.3
+**Version:** 2.18.20260509.0
 
-**Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
+## Metadata
+
+- **Status:** Active
+- **Owner:** Repository Maintainers
+- **Last Updated:** 2026-05-09
+- **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
 ## Keywords
 

--- a/STYLE_GUIDE_CHAT.md
+++ b/STYLE_GUIDE_CHAT.md
@@ -1,11 +1,18 @@
 # PowerShell Writing Style Guide - Formatted for Copy-Paste Into LLM Chat
 
 ````markdown
+<!-- markdownlint-disable MD013 -->
+
 # PowerShell Writing Style
 
-**Version:** 2.17.20260422.3
+**Version:** 2.18.20260509.0
 
-**Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
+## Metadata
+
+- **Status:** Active
+- **Owner:** Repository Maintainers
+- **Last Updated:** 2026-05-09
+- **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
 ## Keywords
 

--- a/STYLE_GUIDE_FULL.md
+++ b/STYLE_GUIDE_FULL.md
@@ -1,8 +1,15 @@
+<!-- markdownlint-disable MD013 -->
+
 # PowerShell Writing Style
 
-**Version:** 2.17.20260422.3
+**Version:** 2.18.20260509.0
 
-**Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
+## Metadata
+
+- **Status:** Active
+- **Owner:** Repository Maintainers
+- **Last Updated:** 2026-05-09
+- **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
 ## Keywords
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,8 +1,15 @@
+<!-- markdownlint-disable MD013 -->
+
 # PowerShell Writing Style
 
-**Version:** 2.17.20260422.3
+**Version:** 2.18.20260509.0
 
-**Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
+## Metadata
+
+- **Status:** Active
+- **Owner:** Repository Maintainers
+- **Last Updated:** 2026-05-09
+- **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
 ## Keywords
 

--- a/powershell.instructions.md
+++ b/powershell.instructions.md
@@ -3,11 +3,18 @@ applyTo:  "**/*.ps1"
 description: "PowerShell coding standards"
 ---
 
+<!-- markdownlint-disable MD013 -->
+
 # PowerShell Writing Style
 
-**Version:** 2.17.20260422.3
+**Version:** 2.18.20260509.0
 
-**Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
+## Metadata
+
+- **Status:** Active
+- **Owner:** Repository Maintainers
+- **Last Updated:** 2026-05-09
+- **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
 ## Keywords
 


### PR DESCRIPTION
## Summary
This PR adds a structured metadata section to consumer-facing style guide documents to help humans, tooling, and LLM-based coding agents identify and consume the documents more effectively.

## Key Changes
- **Updated CONTRIBUTING.md** with new guidelines for operational metadata in consumer-facing guide files, including:
  - Allowed metadata fields: `Status`, `Owner`, `Last Updated`, and `Scope`
  - Constraints ensuring metadata remains concise and operational
  - Clarification that extended explanations belong in contributor-facing files
  - Prohibition on cross-reference-oriented metadata fields

- **Added metadata section to all style guide documents**:
  - `STYLE_GUIDE.md`
  - `STYLE_GUIDE.md` (full version)
  - `STYLE_GUIDE_CHAT.md`
  - `copilot-instructions.md`
  - `powershell.instructions.md`
  
  Each now includes a structured "Metadata" section with:
  - Status: Active
  - Owner: Repository Maintainers
  - Last Updated: 2026-05-09
  - Scope: (existing scope description)

- **Version bump** from 2.17.20260422.3 to 2.18.20260509.0 across all documents

- **Added markdownlint directive** (`<!-- markdownlint-disable MD013 -->`) to all documents to accommodate longer lines in the metadata section

## Implementation Details
- The metadata is presented as a bulleted list under a "Metadata" heading for consistency and readability
- The `Scope` field preserves the existing detailed scope description
- All changes maintain backward compatibility with existing document structure
- The metadata approach follows the new guidelines established in CONTRIBUTING.md

https://claude.ai/code/session_01Qc1LqjucUr5gLGi4XvzxGp