### PR TITLE
[codex] Clarify revision counting

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -2,13 +2,13 @@
 
 # PowerShell Writing Style
 
-**Version:** 2.20.20260604.0
+**Version:** 2.20.20260621.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-06-04
+- **Last Updated:** 2026-06-21
 - **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
 ## Keywords
@@ -77,6 +77,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Positional parameter documentation for private/internal helpers **SHOULD** state it is an internal-caller contract only → [Positional Parameter Support](#positional-parameter-support)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)
+- **[All]** `.NOTES` `Revision` **MUST** reset to `0` when `Major`, `Minor`, or `Build` changes; otherwise increment (`N + 1`) for same-day updates → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Inline comments **SHOULD** focus on "why" not "what" → [Inline Comments: Purpose and Placement](#inline-comments-purpose-and-placement)
 - **[All]** Code **SHOULD** use #region / #endregion for logical code folding → [Structural Documentation: Regions and Licensing](#structural-documentation-regions-and-licensing)
 - **[All]** The param() block **MUST** be placed before license region (if applicable) → [Structural Documentation: Regions and Licensing](#structural-documentation-regions-and-licensing)
@@ -955,6 +956,8 @@ function Get-Example {
 
 All distributable functions and scripts **MUST** include a version number in the `.NOTES` section of their comment-based help. This version number provides critical change tracking and **MUST** follow a strict, `[System.Version]`-compatible format: `Major.Minor.Build.Revision`.
 
+For this section, the **previously published version** means the most recent `.NOTES` version published for the same distributable function or script before this change. In repository work, this is the version already on the branch the change lands on, not an in-progress value produced earlier in the same change. For a brand-new function or script, there is no previously published version.
+
 - **`Major`**: Increment the **Major** version (e.g., `1.0.20251103.0` to `2.0.20251230.0`) **any time a breaking change is introduced**. Breaking changes include:
   - Removing or renaming a function, parameter, or public interface
   - Changing parameter types in incompatible ways
@@ -966,11 +969,16 @@ All distributable functions and scripts **MUST** include a version number in the
   - Enhancing existing functionality without changing interfaces
   - Performance improvements that don't affect behavior
 - **`Build`**: This component **MUST** be an integer in the format **`YYYYMMDD`**, representing the date the code was last modified. This date **MUST** be updated to the **current date** for *any* modification, however minor.
-- **`Revision`**: This component is typically `0` for the first commit of the day. It **SHOULD** be **bumped any time a minor change is made on the same date a change has already been made**. Revisions are typically reserved for:
-  - Trivial edits (typos, formatting, comments)
-  - Bug fixes that don't change functionality
+- **`Revision`**: This component is typically `0` for the first published version of a given distributable function or script at a given `Major.Minor.Build`. It counts same-day published updates of the same function or script relative to the previously published version, not work-in-progress iterations or commits. When a `.NOTES` version is assigned or updated, after applying the required `Major`, `Minor`, and `Build` values above, `Revision` **MUST** be `0` if the resulting `Major.Minor.Build` differs from the previously published version's `Major.Minor.Build` or if there is no previously published version. If the previously published version already records the same `Major.Minor.Build` at revision `N`, `Revision` **MUST** be `N + 1`. Same-day updates at the same `Major.Minor.Build` that increment `Revision` can include, but are not limited to:
+  - Trivial edits, such as typos, formatting, or comment fixes
+  - Bug fixes that do not require a `Major` or `Minor` version bump
   - Documentation-only updates
-  - Multiple commits on the same day
+
+| Case | Previously published version | This change | Reason |
+| --- | --- | --- | --- |
+| Same-day update | `1.2.20260619.0` | `1.2.20260619.1` | Same `Major.Minor.Build`, so `N + 1`. |
+| Same-day breaking change | `1.2.20260619.1` | `2.0.20260619.0` | `Major` changed, so reset to `0`. |
+| Next-day update | `1.2.20260619.1` | `1.2.20260620.0` | `Build` date changed, so reset to `0`. |
 
 **Compliant Example:**
 
@@ -980,6 +988,8 @@ All distributable functions and scripts **MUST** include a version number in the
 ```
 
 This example assumes that the current date is December 30, 2025. In any code you write, use the current date in place of December 30, 2025.
+
+<!-- rationale-anchor: function-and-script-versioning-revision-counting -->
 
 ---
 

--- a/STYLE_GUIDE_CHAT.md
+++ b/STYLE_GUIDE_CHAT.md
@@ -5,13 +5,13 @@
 
 # PowerShell Writing Style
 
-**Version:** 2.20.20260604.0
+**Version:** 2.20.20260621.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-06-04
+- **Last Updated:** 2026-06-21
 - **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
 ## Keywords
@@ -80,6 +80,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Positional parameter documentation for private/internal helpers **SHOULD** state it is an internal-caller contract only → [Positional Parameter Support](#positional-parameter-support)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)
+- **[All]** `.NOTES` `Revision` **MUST** reset to `0` when `Major`, `Minor`, or `Build` changes; otherwise increment (`N + 1`) for same-day updates → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Inline comments **SHOULD** focus on "why" not "what" → [Inline Comments: Purpose and Placement](#inline-comments-purpose-and-placement)
 - **[All]** Code **SHOULD** use #region / #endregion for logical code folding → [Structural Documentation: Regions and Licensing](#structural-documentation-regions-and-licensing)
 - **[All]** The param() block **MUST** be placed before license region (if applicable) → [Structural Documentation: Regions and Licensing](#structural-documentation-regions-and-licensing)
@@ -958,6 +959,8 @@ function Get-Example {
 
 All distributable functions and scripts **MUST** include a version number in the `.NOTES` section of their comment-based help. This version number provides critical change tracking and **MUST** follow a strict, `[System.Version]`-compatible format: `Major.Minor.Build.Revision`.
 
+For this section, the **previously published version** means the most recent `.NOTES` version published for the same distributable function or script before this change. In repository work, this is the version already on the branch the change lands on, not an in-progress value produced earlier in the same change. For a brand-new function or script, there is no previously published version.
+
 - **`Major`**: Increment the **Major** version (e.g., `1.0.20251103.0` to `2.0.20251230.0`) **any time a breaking change is introduced**. Breaking changes include:
   - Removing or renaming a function, parameter, or public interface
   - Changing parameter types in incompatible ways
@@ -969,11 +972,16 @@ All distributable functions and scripts **MUST** include a version number in the
   - Enhancing existing functionality without changing interfaces
   - Performance improvements that don't affect behavior
 - **`Build`**: This component **MUST** be an integer in the format **`YYYYMMDD`**, representing the date the code was last modified. This date **MUST** be updated to the **current date** for *any* modification, however minor.
-- **`Revision`**: This component is typically `0` for the first commit of the day. It **SHOULD** be **bumped any time a minor change is made on the same date a change has already been made**. Revisions are typically reserved for:
-  - Trivial edits (typos, formatting, comments)
-  - Bug fixes that don't change functionality
+- **`Revision`**: This component is typically `0` for the first published version of a given distributable function or script at a given `Major.Minor.Build`. It counts same-day published updates of the same function or script relative to the previously published version, not work-in-progress iterations or commits. When a `.NOTES` version is assigned or updated, after applying the required `Major`, `Minor`, and `Build` values above, `Revision` **MUST** be `0` if the resulting `Major.Minor.Build` differs from the previously published version's `Major.Minor.Build` or if there is no previously published version. If the previously published version already records the same `Major.Minor.Build` at revision `N`, `Revision` **MUST** be `N + 1`. Same-day updates at the same `Major.Minor.Build` that increment `Revision` can include, but are not limited to:
+  - Trivial edits, such as typos, formatting, or comment fixes
+  - Bug fixes that do not require a `Major` or `Minor` version bump
   - Documentation-only updates
-  - Multiple commits on the same day
+
+| Case | Previously published version | This change | Reason |
+| --- | --- | --- | --- |
+| Same-day update | `1.2.20260619.0` | `1.2.20260619.1` | Same `Major.Minor.Build`, so `N + 1`. |
+| Same-day breaking change | `1.2.20260619.1` | `2.0.20260619.0` | `Major` changed, so reset to `0`. |
+| Next-day update | `1.2.20260619.1` | `1.2.20260620.0` | `Build` date changed, so reset to `0`. |
 
 **Compliant Example:**
 
@@ -983,6 +991,8 @@ All distributable functions and scripts **MUST** include a version number in the
 ```
 
 This example assumes that the current date is December 30, 2025. In any code you write, use the current date in place of December 30, 2025.
+
+<!-- rationale-anchor: function-and-script-versioning-revision-counting -->
 
 ---
 

--- a/STYLE_GUIDE_FULL.md
+++ b/STYLE_GUIDE_FULL.md
@@ -2,13 +2,13 @@
 
 # PowerShell Writing Style
 
-**Version:** 2.20.20260604.0
+**Version:** 2.20.20260621.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-06-04
+- **Last Updated:** 2026-06-21
 - **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
 ## Keywords
@@ -85,6 +85,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Positional parameter documentation for private/internal helpers **SHOULD** state it is an internal-caller contract only → [Positional Parameter Support](#positional-parameter-support)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)
+- **[All]** `.NOTES` `Revision` **MUST** reset to `0` when `Major`, `Minor`, or `Build` changes; otherwise increment (`N + 1`) for same-day updates → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Inline comments **SHOULD** focus on "why" not "what" → [Inline Comments: Purpose and Placement](#inline-comments-purpose-and-placement)
 - **[All]** Code **SHOULD** use #region / #endregion for logical code folding → [Structural Documentation: Regions and Licensing](#structural-documentation-regions-and-licensing)
 - **[All]** The param() block **MUST** be placed before license region (if applicable) → [Structural Documentation: Regions and Licensing](#structural-documentation-regions-and-licensing)
@@ -1259,6 +1260,8 @@ function Get-Example {
 
 All distributable functions and scripts **MUST** include a version number in the `.NOTES` section of their comment-based help. This version number provides critical change tracking and **MUST** follow a strict, `[System.Version]`-compatible format: `Major.Minor.Build.Revision`.
 
+For this section, the **previously published version** means the most recent `.NOTES` version published for the same distributable function or script before this change. In repository work, this is the version already on the branch the change lands on, not an in-progress value produced earlier in the same change. For a brand-new function or script, there is no previously published version.
+
 - **`Major`**: Increment the **Major** version (e.g., `1.0.20251103.0` to `2.0.20251230.0`) **any time a breaking change is introduced**. Breaking changes include:
   - Removing or renaming a function, parameter, or public interface
   - Changing parameter types in incompatible ways
@@ -1270,11 +1273,16 @@ All distributable functions and scripts **MUST** include a version number in the
   - Enhancing existing functionality without changing interfaces
   - Performance improvements that don't affect behavior
 - **`Build`**: This component **MUST** be an integer in the format **`YYYYMMDD`**, representing the date the code was last modified. This date **MUST** be updated to the **current date** for *any* modification, however minor.
-- **`Revision`**: This component is typically `0` for the first commit of the day. It **SHOULD** be **bumped any time a minor change is made on the same date a change has already been made**. Revisions are typically reserved for:
-  - Trivial edits (typos, formatting, comments)
-  - Bug fixes that don't change functionality
+- **`Revision`**: This component is typically `0` for the first published version of a given distributable function or script at a given `Major.Minor.Build`. It counts same-day published updates of the same function or script relative to the previously published version, not work-in-progress iterations or commits. When a `.NOTES` version is assigned or updated, after applying the required `Major`, `Minor`, and `Build` values above, `Revision` **MUST** be `0` if the resulting `Major.Minor.Build` differs from the previously published version's `Major.Minor.Build` or if there is no previously published version. If the previously published version already records the same `Major.Minor.Build` at revision `N`, `Revision` **MUST** be `N + 1`. Same-day updates at the same `Major.Minor.Build` that increment `Revision` can include, but are not limited to:
+  - Trivial edits, such as typos, formatting, or comment fixes
+  - Bug fixes that do not require a `Major` or `Minor` version bump
   - Documentation-only updates
-  - Multiple commits on the same day
+
+| Case | Previously published version | This change | Reason |
+| --- | --- | --- | --- |
+| Same-day update | `1.2.20260619.0` | `1.2.20260619.1` | Same `Major.Minor.Build`, so `N + 1`. |
+| Same-day breaking change | `1.2.20260619.1` | `2.0.20260619.0` | `Major` changed, so reset to `0`. |
+| Next-day update | `1.2.20260619.1` | `1.2.20260620.0` | `Build` date changed, so reset to `0`. |
 
 **Compliant Example:**
 
@@ -1284,6 +1292,14 @@ All distributable functions and scripts **MUST** include a version number in the
 ```
 
 This example assumes that the current date is December 30, 2025. In any code you write, use the current date in place of December 30, 2025.
+
+### Function and Script Versioning: Revision Counting
+
+The `.NOTES` version is consumed by `[System.Version]` comparison and used as provenance for a distributable function or script. A nondeterministic `Revision` value can make otherwise ordered versions ambiguous or incorrectly ordered, so the reset and increment calculation is a **MUST** rather than a **SHOULD**. RFC 2119 reserves imperatives for interoperation requirements and behavior whose inconsistency can cause harm; ambiguous version ordering is that kind of harm. The requirement is scoped to the calculation performed when a version is assigned or updated. It does not dictate how often a project publishes or versions a function or script.
+
+`Revision` is the lowest-precedence component in the repository's `[System.Version]`-compatible `Major.Minor.Build.Revision` policy. It resets to `0` whenever any higher-order component changes: `Major`, `Minor`, or `Build`. If the previously published version already carries the same `Major.Minor.Build` at revision `N`, the next published same-day update for that same function or script uses `N + 1`. This is repository policy, informed by Semantic Versioning's reset-by-higher-precedence pattern by analogy and applied to the lowest-precedence `System.Version` component.
+
+The **previously published version** is the most recent `.NOTES` version published for that same distributable function or script before the current change. In pull-request workflows, that means the version recorded on the base branch the change merges into. Because the base branch can receive other changes before a pull request merges, evaluate the value when finalizing the change rather than when starting branch work. If automated merge machinery, such as a merge queue, changes the target branch after finalization, treat any resulting provenance drift as follow-up work instead of complicating the author-facing rule. For a brand-new function or script, there is no previously published version, so `Revision` starts at `0`.
 
 ---
 

--- a/STYLE_GUIDE_RATIONALE.md
+++ b/STYLE_GUIDE_RATIONALE.md
@@ -22,6 +22,7 @@ This companion document preserves the extended rationale, design philosophy, and
   - [Parameter Documentation Placement: Strategic Choice](#parameter-documentation-placement-strategic-choice)
   - [Help Format Options: Comparison](#help-format-options-comparison)
   - [Private/Internal Helper Function Documentation](#privateinternal-helper-function-documentation)
+  - [Function and Script Versioning: Revision Counting](#function-and-script-versioning-revision-counting)
   - [Summary: Documentation as Complete Specification](#summary-documentation-as-complete-specification)
 - [Function Design Rationale](#function-design-rationale)
   - [Overview of Function Architecture](#overview-of-function-architecture)
@@ -305,6 +306,18 @@ Private/internal helper functions receive the same full comment-based help treat
 3. **Module manifests are not the only scoping mechanism.** While `FunctionsToExport` in a module manifest (`.psd1`) is the primary mechanism in module-based code, the concept of private/internal helpers is broader: standalone scripts, multi-function `.ps1` files, and v1.0-targeted code all have internal helpers that are not governed by a manifest. The banner rule therefore applies at the `[All]` scope.
 
 The banner is deliberately placed at the top of `.NOTES` so it is the first thing a reader encounters after the behavioral documentation sections. It does not reduce documentation quality; it adds a single, high-signal annotation that protects both the author's refactoring freedom and consumers' expectations.
+
+---
+
+### Function and Script Versioning: Revision Counting
+
+> For the normative revision rule, see [Function and Script Versioning](STYLE_GUIDE.md#function-and-script-versioning) in the main guide.
+
+The `.NOTES` version is consumed by `[System.Version]` comparison and used as provenance for a distributable function or script. A nondeterministic `Revision` value can make otherwise ordered versions ambiguous or incorrectly ordered, so the reset and increment calculation is a **MUST** rather than a **SHOULD**. RFC 2119 reserves imperatives for interoperation requirements and behavior whose inconsistency can cause harm; ambiguous version ordering is that kind of harm. The requirement is scoped to the calculation performed when a version is assigned or updated. It does not dictate how often a project publishes or versions a function or script.
+
+`Revision` is the lowest-precedence component in the repository's `[System.Version]`-compatible `Major.Minor.Build.Revision` policy. It resets to `0` whenever any higher-order component changes: `Major`, `Minor`, or `Build`. If the previously published version already carries the same `Major.Minor.Build` at revision `N`, the next published same-day update for that same function or script uses `N + 1`. This is repository policy, informed by Semantic Versioning's reset-by-higher-precedence pattern by analogy and applied to the lowest-precedence `System.Version` component.
+
+The **previously published version** is the most recent `.NOTES` version published for that same distributable function or script before the current change. In pull-request workflows, that means the version recorded on the base branch the change merges into. Because the base branch can receive other changes before a pull request merges, evaluate the value when finalizing the change rather than when starting branch work. If automated merge machinery, such as a merge queue, changes the target branch after finalization, treat any resulting provenance drift as follow-up work instead of complicating the author-facing rule. For a brand-new function or script, there is no previously published version, so `Revision` starts at `0`.
 
 ---
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -2,13 +2,13 @@
 
 # PowerShell Writing Style
 
-**Version:** 2.20.20260604.0
+**Version:** 2.20.20260621.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-06-04
+- **Last Updated:** 2026-06-21
 - **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
 ## Keywords
@@ -77,6 +77,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Positional parameter documentation for private/internal helpers **SHOULD** state it is an internal-caller contract only → [Positional Parameter Support](#positional-parameter-support)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)
+- **[All]** `.NOTES` `Revision` **MUST** reset to `0` when `Major`, `Minor`, or `Build` changes; otherwise increment (`N + 1`) for same-day updates → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Inline comments **SHOULD** focus on "why" not "what" → [Inline Comments: Purpose and Placement](#inline-comments-purpose-and-placement)
 - **[All]** Code **SHOULD** use #region / #endregion for logical code folding → [Structural Documentation: Regions and Licensing](#structural-documentation-regions-and-licensing)
 - **[All]** The param() block **MUST** be placed before license region (if applicable) → [Structural Documentation: Regions and Licensing](#structural-documentation-regions-and-licensing)
@@ -955,6 +956,8 @@ function Get-Example {
 
 All distributable functions and scripts **MUST** include a version number in the `.NOTES` section of their comment-based help. This version number provides critical change tracking and **MUST** follow a strict, `[System.Version]`-compatible format: `Major.Minor.Build.Revision`.
 
+For this section, the **previously published version** means the most recent `.NOTES` version published for the same distributable function or script before this change. In repository work, this is the version already on the branch the change lands on, not an in-progress value produced earlier in the same change. For a brand-new function or script, there is no previously published version.
+
 - **`Major`**: Increment the **Major** version (e.g., `1.0.20251103.0` to `2.0.20251230.0`) **any time a breaking change is introduced**. Breaking changes include:
   - Removing or renaming a function, parameter, or public interface
   - Changing parameter types in incompatible ways
@@ -966,11 +969,16 @@ All distributable functions and scripts **MUST** include a version number in the
   - Enhancing existing functionality without changing interfaces
   - Performance improvements that don't affect behavior
 - **`Build`**: This component **MUST** be an integer in the format **`YYYYMMDD`**, representing the date the code was last modified. This date **MUST** be updated to the **current date** for *any* modification, however minor.
-- **`Revision`**: This component is typically `0` for the first commit of the day. It **SHOULD** be **bumped any time a minor change is made on the same date a change has already been made**. Revisions are typically reserved for:
-  - Trivial edits (typos, formatting, comments)
-  - Bug fixes that don't change functionality
+- **`Revision`**: This component is typically `0` for the first published version of a given distributable function or script at a given `Major.Minor.Build`. It counts same-day published updates of the same function or script relative to the previously published version, not work-in-progress iterations or commits. When a `.NOTES` version is assigned or updated, after applying the required `Major`, `Minor`, and `Build` values above, `Revision` **MUST** be `0` if the resulting `Major.Minor.Build` differs from the previously published version's `Major.Minor.Build` or if there is no previously published version. If the previously published version already records the same `Major.Minor.Build` at revision `N`, `Revision` **MUST** be `N + 1`. Same-day updates at the same `Major.Minor.Build` that increment `Revision` can include, but are not limited to:
+  - Trivial edits, such as typos, formatting, or comment fixes
+  - Bug fixes that do not require a `Major` or `Minor` version bump
   - Documentation-only updates
-  - Multiple commits on the same day
+
+| Case | Previously published version | This change | Reason |
+| --- | --- | --- | --- |
+| Same-day update | `1.2.20260619.0` | `1.2.20260619.1` | Same `Major.Minor.Build`, so `N + 1`. |
+| Same-day breaking change | `1.2.20260619.1` | `2.0.20260619.0` | `Major` changed, so reset to `0`. |
+| Next-day update | `1.2.20260619.1` | `1.2.20260620.0` | `Build` date changed, so reset to `0`. |
 
 **Compliant Example:**
 
@@ -980,6 +988,8 @@ All distributable functions and scripts **MUST** include a version number in the
 ```
 
 This example assumes that the current date is December 30, 2025. In any code you write, use the current date in place of December 30, 2025.
+
+<!-- rationale-anchor: function-and-script-versioning-revision-counting -->
 
 ---
 

--- a/powershell.instructions.md
+++ b/powershell.instructions.md
@@ -7,13 +7,13 @@ description: "PowerShell coding standards"
 
 # PowerShell Writing Style
 
-**Version:** 2.20.20260604.0
+**Version:** 2.20.20260621.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-06-04
+- **Last Updated:** 2026-06-21
 - **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
 ## Keywords
@@ -82,6 +82,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Positional parameter documentation for private/internal helpers **SHOULD** state it is an internal-caller contract only → [Positional Parameter Support](#positional-parameter-support)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)
+- **[All]** `.NOTES` `Revision` **MUST** reset to `0` when `Major`, `Minor`, or `Build` changes; otherwise increment (`N + 1`) for same-day updates → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Inline comments **SHOULD** focus on "why" not "what" → [Inline Comments: Purpose and Placement](#inline-comments-purpose-and-placement)
 - **[All]** Code **SHOULD** use #region / #endregion for logical code folding → [Structural Documentation: Regions and Licensing](#structural-documentation-regions-and-licensing)
 - **[All]** The param() block **MUST** be placed before license region (if applicable) → [Structural Documentation: Regions and Licensing](#structural-documentation-regions-and-licensing)
@@ -960,6 +961,8 @@ function Get-Example {
 
 All distributable functions and scripts **MUST** include a version number in the `.NOTES` section of their comment-based help. This version number provides critical change tracking and **MUST** follow a strict, `[System.Version]`-compatible format: `Major.Minor.Build.Revision`.
 
+For this section, the **previously published version** means the most recent `.NOTES` version published for the same distributable function or script before this change. In repository work, this is the version already on the branch the change lands on, not an in-progress value produced earlier in the same change. For a brand-new function or script, there is no previously published version.
+
 - **`Major`**: Increment the **Major** version (e.g., `1.0.20251103.0` to `2.0.20251230.0`) **any time a breaking change is introduced**. Breaking changes include:
   - Removing or renaming a function, parameter, or public interface
   - Changing parameter types in incompatible ways
@@ -971,11 +974,16 @@ All distributable functions and scripts **MUST** include a version number in the
   - Enhancing existing functionality without changing interfaces
   - Performance improvements that don't affect behavior
 - **`Build`**: This component **MUST** be an integer in the format **`YYYYMMDD`**, representing the date the code was last modified. This date **MUST** be updated to the **current date** for *any* modification, however minor.
-- **`Revision`**: This component is typically `0` for the first commit of the day. It **SHOULD** be **bumped any time a minor change is made on the same date a change has already been made**. Revisions are typically reserved for:
-  - Trivial edits (typos, formatting, comments)
-  - Bug fixes that don't change functionality
+- **`Revision`**: This component is typically `0` for the first published version of a given distributable function or script at a given `Major.Minor.Build`. It counts same-day published updates of the same function or script relative to the previously published version, not work-in-progress iterations or commits. When a `.NOTES` version is assigned or updated, after applying the required `Major`, `Minor`, and `Build` values above, `Revision` **MUST** be `0` if the resulting `Major.Minor.Build` differs from the previously published version's `Major.Minor.Build` or if there is no previously published version. If the previously published version already records the same `Major.Minor.Build` at revision `N`, `Revision` **MUST** be `N + 1`. Same-day updates at the same `Major.Minor.Build` that increment `Revision` can include, but are not limited to:
+  - Trivial edits, such as typos, formatting, or comment fixes
+  - Bug fixes that do not require a `Major` or `Minor` version bump
   - Documentation-only updates
-  - Multiple commits on the same day
+
+| Case | Previously published version | This change | Reason |
+| --- | --- | --- | --- |
+| Same-day update | `1.2.20260619.0` | `1.2.20260619.1` | Same `Major.Minor.Build`, so `N + 1`. |
+| Same-day breaking change | `1.2.20260619.1` | `2.0.20260619.0` | `Major` changed, so reset to `0`. |
+| Next-day update | `1.2.20260619.1` | `1.2.20260620.0` | `Build` date changed, so reset to `0`. |
 
 **Compliant Example:**
 
@@ -985,6 +993,8 @@ All distributable functions and scripts **MUST** include a version number in the
 ```
 
 This example assumes that the current date is December 30, 2025. In any code you write, use the current date in place of December 30, 2025.
+
+<!-- rationale-anchor: function-and-script-versioning-revision-counting -->
 
 ---
 


### PR DESCRIPTION
## Summary

- Clarifies `.NOTES` `Revision` counting in `STYLE_GUIDE.md` so it resets to `0` when `Major`, `Minor`, or `Build` changes and otherwise increments from the previously published same-day version.
- Adds an illustrative revision-counting table, a Quick Reference Checklist item, and the matching rationale anchor.
- Adds rationale for using `MUST`, reset behavior, and the meaning of "previously published version".
- Regenerates `copilot-instructions.md`, `powershell.instructions.md`, `STYLE_GUIDE_CHAT.md`, and `STYLE_GUIDE_FULL.md` from the source docs.

Closes #135

## Validation

- `pwsh -File ./.github/workflows/Generate-StyleGuideArtifacts.ps1`
- `npm ci`
- `npm run lint:md`
- `npm run lint:md:nested`
- Verified issue reference URLs returned `200`.

## Notes

`npm ci` reported existing npm audit advisories. `git diff --check` also flags the generated `powershell.instructions.md` frontmatter line endings written by the existing generator; generated output was left as produced by the script.