### PR TITLE
[codex] Make Markdown tooling deterministic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/install-husky.mjs
+++ b/.github/workflows/install-husky.mjs
@@ -1,0 +1,22 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+if (
+  process.env.CI === 'true' ||
+  process.env.HUSKY === '0' ||
+  process.env.NODE_ENV === 'production'
+) {
+  process.exit(0);
+}
+
+const { default: husky } = await import('husky');
+const workflowsDir = dirname(fileURLToPath(import.meta.url));
+
+process.chdir(resolve(workflowsDir, '../..'));
+
+const message = husky();
+
+if (message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/.github/workflows/lint-staged-markdown.mjs
+++ b/.github/workflows/lint-staged-markdown.mjs
@@ -1,0 +1,95 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const requiredNodeMajor = 20;
+const currentNodeMajor = Number(process.versions.node.split('.')[0]);
+
+if (!Number.isInteger(currentNodeMajor) || currentNodeMajor < requiredNodeMajor) {
+  console.error('pre-commit: Node.js 20 or newer is required to lint staged Markdown.');
+  console.error(`Current version: ${process.version || 'unknown'}`);
+  console.error('If you use a Node version manager with a GUI Git client, add its initialization to');
+  console.error('~/.config/husky/init.sh, which Husky sources before running hooks.');
+  console.error('To bypass this one commit only, use: git commit --no-verify');
+  process.exit(1);
+}
+
+const workflowsDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(workflowsDir, '../..');
+const maxBuffer = 100 * 1024 * 1024;
+
+const runGit = (args) => {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer,
+    windowsHide: true
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error((result.stderr || '').trim() || `git ${args[0]} failed with exit code ${result.status}`);
+  }
+
+  return result.stdout;
+};
+
+const parseNulDelimitedPaths = (value) => value.split('\0').filter(Boolean);
+const toAbsolutePosixPath = (repoRelativePath) => resolve(repoRoot, repoRelativePath).split(sep).join('/');
+
+let stagedMarkdownPaths;
+
+try {
+  stagedMarkdownPaths = parseNulDelimitedPaths(
+    runGit(['diff', '--cached', '--name-only', '--diff-filter=ACMR', '-z', '--', '*.md'])
+  );
+} catch (error) {
+  console.error(error);
+  console.error('pre-commit: Failed to inspect staged Markdown files.');
+  process.exit(2);
+}
+
+if (stagedMarkdownPaths.length === 0) {
+  process.exit(0);
+}
+
+const stagedMarkdownByAbsolutePosixPath = {};
+
+try {
+  for (const repoRelativePath of stagedMarkdownPaths) {
+    stagedMarkdownByAbsolutePosixPath[toAbsolutePosixPath(repoRelativePath)] = runGit(['show', `:${repoRelativePath}`]);
+  }
+} catch (error) {
+  console.error(error);
+  console.error('pre-commit: Failed to read staged Markdown content from Git.');
+  process.exit(2);
+}
+
+let exitCode;
+
+try {
+  const { main: markdownlintCli2 } = await import('markdownlint-cli2');
+  exitCode = await markdownlintCli2({
+    directory: repoRoot,
+    argv: ['--config', '.github/workflows/.markdownlint.jsonc'],
+    nonFileContents: stagedMarkdownByAbsolutePosixPath,
+    logMessage: console.log,
+    logError: console.error
+  });
+} catch (error) {
+  console.error(error);
+  console.error('pre-commit: Markdown lint tooling failed to run.');
+  console.error('Try reinstalling dev dependencies: npm --prefix .github/workflows ci');
+  process.exit(2);
+}
+
+if (exitCode !== 0) {
+  console.error('');
+  console.error('pre-commit: Markdown lint failed for staged Markdown.');
+  console.error('To check all Markdown files, run: npm --prefix .github/workflows run lint:md');
+}
+
+process.exitCode = exitCode;

--- a/.github/workflows/lint-staged-markdown.mjs
+++ b/.github/workflows/lint-staged-markdown.mjs
@@ -43,6 +43,10 @@ const toAbsolutePosixPath = (repoRelativePath) => resolve(repoRoot, repoRelative
 let stagedMarkdownPaths;
 
 try {
+  // Git pathspec wildcards match across directory separators, unlike shell globs,
+  // so the `*.md` pathspec selects staged Markdown in every subdirectory (e.g.
+  // docs/ISSUE_EVALUATION_PROMPT.md, samples/*.md), not just the repository root.
+  // See https://git-scm.com/docs/gitglossary (def_pathspec).
   stagedMarkdownPaths = parseNulDelimitedPaths(
     runGit(['diff', '--cached', '--name-only', '--diff-filter=ACMR', '-z', '--', '*.md'])
   );

--- a/.github/workflows/package.json
+++ b/.github/workflows/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint:md": "cd ../.. && markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#.github/workflows/node_modules\" --config .github/workflows/.markdownlint.jsonc",
     "lint:md:nested": "node lint-nested-markdown.js",
-    "prepare": "husky install || true"
+    "prepare": "node install-husky.mjs"
   },
   "repository": {
     "type": "git",

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,21 +1,20 @@
 #!/bin/sh
 
-# Get list of staged markdown files
-STAGED_MD_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.md$' || true)
-
-if [ -n "$STAGED_MD_FILES" ]; then
-  echo "Running markdownlint on staged files..."
-  npx markdownlint-cli2 $STAGED_MD_FILES
-  LINT_EXIT_CODE=$?
-  
-  if [ $LINT_EXIT_CODE -ne 0 ]; then
-    echo ""
-    echo "❌ Markdownlint failed. Please fix the errors above before committing."
-    echo "To see all errors: npm run lint:md"
-    exit 1
-  fi
-  
-  echo "✅ Markdownlint passed for staged files."
+if ! command -v node >/dev/null 2>&1; then
+  echo "pre-commit: Node.js is required to lint staged Markdown but was not found on PATH." >&2
+  echo "If you use a Node version manager with a GUI Git client, add its initialization to" >&2
+  echo "~/.config/husky/init.sh, which Husky sources before running hooks." >&2
+  echo "To bypass this one commit only, use: git commit --no-verify" >&2
+  exit 1
 fi
 
-exit 0
+if ! node -e "process.exit(Number(process.versions.node.split('.')[0]) >= 20 ? 0 : 1)" >/dev/null 2>&1; then
+  echo "pre-commit: Node.js 20 or newer is required to lint staged Markdown." >&2
+  echo "Current version: $(node -v 2>/dev/null || echo unknown)" >&2
+  echo "If you use a Node version manager with a GUI Git client, add its initialization to" >&2
+  echo "~/.config/husky/init.sh, which Husky sources before running hooks." >&2
+  echo "To bypass this one commit only, use: git commit --no-verify" >&2
+  exit 1
+fi
+
+node .github/workflows/lint-staged-markdown.mjs


### PR DESCRIPTION
## Summary

Fixes #137.

This makes the repository's local Markdown tooling deterministic across environments by:

- installing Husky from the repository root via the nested workflow package prepare script
- replacing the shell/npx staged Markdown hook with a guarded Node delegate
- linting exact staged Markdown blobs through the repository-pinned `markdownlint-cli2` dependency and CI markdownlint config
- adding repository line-ending attributes so text files check out with LF

## Why

The previous hook depended on shell word splitting, `npx`, working-tree file contents, and a nested-package Husky install path. That could leave hooks inert locally, lint different content than the commit, or behave differently across Windows/macOS/Linux checkouts.

## Validation

- `npm --prefix .github/workflows run lint:md`
- `npm --prefix .github/workflows run lint:md:nested`
- `npm --prefix .github/workflows ci`
- `git diff --check`
- `git hook run pre-commit --ignore-missing`
- Manual staged-content hook checks for special paths, config parity, staged-invalid/working-clean, and staged-clean/working-invalid cases
- Temp-index `git add --renormalize .` check for unexpected line-ending churn