### PR TITLE
[codex] Clarify style guide helper and Write-* rules

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -2,13 +2,13 @@
 
 # PowerShell Writing Style
 
-**Version:** 2.21.20260623.0
+**Version:** 2.22.20260629.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-06-23
+- **Last Updated:** 2026-06-29
 - **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
 
 ## Keywords
@@ -72,9 +72,9 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[All]** Functions **SHOULD** provide multiple examples with input, output, and explanation → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Every possible output/return value **MUST** be documented in .OUTPUTS with exact type and meaning; integer status codes **MUST** include full code-to-meaning mapping; output examples **MUST** be placed in .EXAMPLE blocks → [Help Content Quality: High Standards](#help-content-quality-high-standards)
 - **[All]** Positional parameter support **MUST** be documented in .NOTES → [Help Content Quality: High Standards](#help-content-quality-high-standards)
-- **[All]** Private/internal helper functions' `.NOTES` **MUST** begin with a private-helper banner → [Private/Internal Helper Function Documentation](#privateinternal-helper-function-documentation)
-- **[Modern]** Functions omitted from module manifest `FunctionsToExport` are treated as private/internal helpers → [Private/Internal Helper Function Documentation](#privateinternal-helper-function-documentation)
-- **[All]** Positional parameter documentation for private/internal helpers **SHOULD** state it is an internal-caller contract only → [Positional Parameter Support](#positional-parameter-support)
+- **[All]** Script/module/tool-specific private/internal helper functions' `.NOTES` **MUST** begin with a private-helper banner; distributable/vendored helpers with a per-function license region and clear cross-project reuse intent are exempt → [Private/Internal Helper Function Documentation](#privateinternal-helper-function-documentation)
+- **[Modern]** Functions omitted from module manifest `FunctionsToExport` are treated as private/internal helpers unless the distributable/vendored-helper exemption applies → [Private/Internal Helper Function Documentation](#privateinternal-helper-function-documentation)
+- **[All]** Positional parameter documentation for script/module/tool-specific private/internal helpers **SHOULD** state it is an internal-caller contract only; distributable/vendored helpers document a stable distributable contract → [Positional Parameter Support](#positional-parameter-support)
 - **[All]** Version number **MUST** be included in .NOTES (format: Major.Minor.YYYYMMDD.Revision) → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** Version build component **MUST** be current date in YYYYMMDD format → [Function and Script Versioning](#function-and-script-versioning)
 - **[All]** `.NOTES` `Revision` **MUST** reset to `0` when `Major`, `Minor`, or `Build` changes; otherwise increment (`N + 1`) for same-day updates → [Function and Script Versioning](#function-and-script-versioning)
@@ -97,6 +97,7 @@ Scope tags: **[All]** = all PowerShell versions, **[Modern]** = PowerShell v2.0+
 - **[v1.0]** Functions **MUST** return single integer status code (0=success, 1-5=partial, -1=failure) → [Return Semantics: Explicit Status Codes](#return-semantics-explicit-status-codes)
 - **[v1.0]** Exception: Test-* functions **MAY** return Boolean when no practical error handling needed → [Return Semantics: Explicit Status Codes](#return-semantics-explicit-status-codes)
 - **[v1.0]** Positional parameters **SHOULD** be supported for v1.0 usability → [Positional Parameter Support](#positional-parameter-support)
+- **[All]** One positional message/payload argument to covered `Write-*` cmdlets is an allowed syntax exception; additional options **SHOULD** be named → [Positional Parameter Support](#positional-parameter-support)
 - **[v1.0]** v1.0-targeted functions **MUST** use trap-based error handling (not try/catch) → [Core Error Suppression Mechanism](#core-error-suppression-mechanism)
 - **[Modern]** Modern functions and scripts **MUST** use [CmdletBinding()] attribute → [Rule: "Modern Advanced" Function/Script Requirements (v2.0+)](#rule-modern-advanced-functionscript-requirements-v20)
 - **[Modern]** Modern functions and scripts **MUST** use [OutputType()] declaring singular primary type → [Rule: "Modern Advanced" Function/Script Requirements (v2.0+)](#rule-modern-advanced-functionscript-requirements-v20)
@@ -844,9 +845,13 @@ Lines within `.EXAMPLE` blocks that are intended to render as PowerShell comment
 
 ### Private/Internal Helper Function Documentation
 
-**[All]** If a function is intended only for internal use and is not part of the script, module, or tool's public API surface, its `.NOTES` section **MUST** begin with a clear private-helper banner. That banner **MUST** state that the function is not part of the public API surface, and **MUST** warn that parameters, return shape, and positional contract may change without notice.
+**[All]** If a function exists only to serve a specific script, module, or tool and is not part of that script, module, or tool's public API surface, its `.NOTES` section **MUST** begin with a clear private-helper banner. That banner **MUST** state that the function is not part of the public API surface, and **MUST** warn that parameters, return shape, and positional contract may change without notice.
 
-**[Modern]** In module-based code, a function intentionally omitted from the module manifest's `FunctionsToExport` is treated as a private/internal helper for purposes of the documentation requirements above.
+**[Modern]** In module-based code, a function intentionally omitted from the module manifest's `FunctionsToExport` is treated as a private/internal helper for purposes of the documentation requirements above unless the distributable/vendored-helper exemption applies.
+
+A **distributable/vendored helper** is a reusable helper function that carries its own per-function `#region License` block and has clear cross-project reuse intent rather than existing as script/module/tool-specific glue. A per-function license region is a strong distributability signal for this exemption, but it is not standalone proof: if reuse intent is unclear, document the function's distributable intent or treat the function as a script/module/tool-specific internal helper. A `Version:` line by itself is not sufficient for the exemption, because ordinary internal helpers also carry version metadata.
+
+Distributable/vendored helpers are exempt from the `PRIVATE/INTERNAL HELPER` banner, even when placed under `Private/` and omitted from `FunctionsToExport`. When they document positional parameters, they document a stable distributable contract rather than using the private-helper "internal-caller contract only; subject to change" header. Export visibility and API stability are separate concerns; an unexported helper can still have a stable distributable contract.
 
 All other comment-based help requirements (`.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER`, `.EXAMPLE`, `.INPUTS`, `.OUTPUTS`, `.NOTES`) still apply to private/internal helpers — the banner is an addition, not a replacement.
 
@@ -896,6 +901,57 @@ function Convert-RawRecord {
         [ref]$ReferenceToResultObject,
         [hashtable]$RawRecord
     )
+
+    # Implementation omitted for brevity
+}
+```
+
+**Compliant - distributable/vendored helper exempt from the private-helper banner:**
+
+```powershell
+function Convert-DelimitedRecord {
+    # .SYNOPSIS
+    # Converts one delimited record into a normalized object.
+    #
+    # .DESCRIPTION
+    # Parses a delimited record using a caller-provided delimiter and returns
+    # a normalized [pscustomobject]. This helper is versioned and licensed for
+    # reuse across projects, so its parameter order is a stable distributable
+    # contract even when a consuming module does not export it.
+    #
+    # .PARAMETER RecordText
+    # The delimited record text to parse.
+    #
+    # .PARAMETER Delimiter
+    # The delimiter that separates fields in the record.
+    #
+    # .EXAMPLE
+    # $objRecord = Convert-DelimitedRecord 'alpha,beta' ','
+    #
+    # # Returns a normalized record object.
+    #
+    # .INPUTS
+    # None. You can't pipe objects to this function.
+    #
+    # .OUTPUTS
+    # [pscustomobject] Normalized record object.
+    #
+    # .NOTES
+    # This distributable helper supports positional parameters
+    # (stable distributable contract):
+    #
+    #   Position 0: RecordText
+    #   Position 1: Delimiter
+    #
+    # Version: 1.0.20260629.0
+    param (
+        [string]$RecordText,
+        [string]$Delimiter
+    )
+
+    #region License ########################################################
+    # MIT License or other per-function license text.
+    #endregion License ########################################################
 
     # Implementation omitted for brevity
 }
@@ -1207,7 +1263,19 @@ Process-String ([ref]$r) ([ref]$e) $str
 Process-String ([ref]$r) ([ref]$e) $str $psver
 ```
 
-**Important distinction:** While functions **SHOULD** support positional parameters in their declarations (for flexibility and v1.0 usability), function **calls** throughout the codebase **SHOULD** use named parameters for clarity and maintainability. The PSScriptAnalyzer configuration enforces this via the `PSAvoidUsingPositionalParameters` rule.
+**Important distinction:** While functions **SHOULD** support positional parameters in their declarations (for flexibility and v1.0 usability), function **calls** throughout the codebase **SHOULD** use named parameters for clarity and maintainability. PSScriptAnalyzer's `PSAvoidUsingPositionalParameters` rule is documented as flagging commands called with three or more positional parameters.
+
+**[All]** As an explicit syntax exception to the general preference that calls use named parameters, one positional message/payload argument passed to a covered `Write-*` cmdlet is idiomatic and acceptable when the cmdlet is available in the target runtime and otherwise permitted by this guide. Because this uses only one positional message/payload argument, it is below the documented analyzer threshold described above. Additional options **SHOULD** be named:
+
+```powershell
+Write-Warning 'No managed devices were returned.'
+Write-Error 'Invalid object' -ErrorId B1 -TargetObject $_
+Write-Information 'Scan complete.' -Tags 'Audit'
+```
+
+The covered allow-list is `Write-Verbose`, `Write-Warning`, `Write-Debug`, `Write-Error`, and `Write-Information` (the last only when targeting PowerShell 5.0+ and otherwise permitted by this guide). For `Write-Error`, this exception covers the default message form (`Write-Error 'message'`) only; positional `-Exception` and positional `-ErrorRecord` payloads remain governed by the general named-parameter preference. For `Write-Error`, cmdlet-specific options such as `-Category`, `-ErrorId`, and `-TargetObject` **SHOULD** be named. For `Write-Information`, cmdlet-specific options such as `-Tags` **SHOULD** be named. Common parameters supported by the target runtime, such as `-WarningAction` and, on PowerShell 5.0+, `-InformationAction`, **SHOULD** likewise be named as common parameters.
+
+This exception does not cover `Write-Output`, `Write-Host`, or `Write-Progress`, and no other stream-writing cmdlets are included by implication. A blanket "always `-Message`" rule is not adopted because the canonical first message/payload parameter varies across the family, and `Write-Output` has no `-Message` parameter or alias. This clarifies call syntax only; it does not change existing output rules, including v1.0 explicit return-code patterns, modern streaming-output guidance, success-stream guidance, or the `Write-Host` prohibition.
 
 This enables:
 
@@ -1234,7 +1302,7 @@ Guidance for this format:
 1. The header line **SHOULD** be `# This function/script supports positional parameters:` followed by each position listed on its own indented line as `#   Position N: ParameterName`.
 2. Only list parameters that are expected to be used positionally. For functions or scripts with many optional parameters, listing only the mandatory or commonly-used positional parameters is acceptable.
 3. The parameter name **SHOULD** match the declared parameter name without the `-` prefix (e.g., `VectorRows`, not `-VectorRows`), since the `.NOTES` section documents the parameter's identity, not its call syntax.
-4. **[All]** If positional parameter behavior is documented for a private/internal helper, that documentation **SHOULD** clearly state that it is an internal-caller contract only and is subject to change. For example, the header line **SHOULD** read `# This function supports positional parameters` / `# (internal-caller contract only; subject to change):` instead of the standard header.
+4. **[All]** If positional parameter behavior is documented for a script/module/tool-specific private/internal helper, that documentation **SHOULD** clearly state that it is an internal-caller contract only and is subject to change. For example, the header line **SHOULD** read `# This function supports positional parameters` / `# (internal-caller contract only; subject to change):` instead of the standard header. Distributable/vendored helpers are exempt from this private-helper header and **SHOULD** document positional parameters as a stable distributable contract instead.
 
 #### [Modern] Enforcing a Subset-Only Positional Contract
 

--- a/STYLE_GUIDE_RATIONALE.md
+++ b/STYLE_GUIDE_RATIONALE.md
@@ -29,6 +29,7 @@ This companion document preserves the extended rationale, design philosophy, and
   - [Advanced Feature Emulation (v1.0-Native)](#advanced-feature-emulation-v10-native)
   - [Options for Return Mechanism: Comparison](#options-for-return-mechanism-comparison)
   - [Enforcing Subset-Only Positional Contracts in Modern Functions](#enforcing-subset-only-positional-contracts-in-modern-functions)
+  - [One Positional Write Cmdlet Message/Payload Argument](#one-positional-write-cmdlet-messagepayload-argument)
   - [ValidateRange for Constrained Numeric Parameters](#validaterange-for-constrained-numeric-parameters)
   - [Summary: Function Design as Reliability Engineering](#summary-function-design-as-reliability-engineering)
 - [Error Handling Rationale](#error-handling-rationale)
@@ -305,6 +306,12 @@ Private/internal helper functions receive the same full comment-based help treat
 2. **Positional contracts differ in stability.** A public function's positional parameter ordering is a stable contract; an internal helper's ordering may be changed freely as the implementation evolves. Explicitly labeling the positional documentation as an internal-caller contract prevents external callers from relying on ordering that was never guaranteed.
 3. **Module manifests are not the only scoping mechanism.** While `FunctionsToExport` in a module manifest (`.psd1`) is the primary mechanism in module-based code, the concept of private/internal helpers is broader: standalone scripts, multi-function `.ps1` files, and v1.0-targeted code all have internal helpers that are not governed by a manifest. The banner rule therefore applies at the `[All]` scope.
 
+The review distinction behind this rule is between module-specific implementation glue and vendored reusable helpers. A helper that exists only so one script, module, or tool can do its work is an implementation detail even when it has excellent help. A vendored helper, by contrast, may be kept unexported by a consuming module while still carrying a stable, versioned, reusable contract of its own. Export visibility and API stability are therefore related but not identical.
+
+`FunctionsToExport` and `Export-ModuleMember` control which members a module exports to callers. They do not prove that a reusable helper is unstable, and they do not hide source code or prevent a reader from copying, reviewing, or invoking an unexported implementation. This is why a function omitted from `FunctionsToExport` remains a private-helper signal for module-specific code, but not an absolute classification rule for vendored/distributable helpers.
+
+The exemption test uses two signals together: a per-function `#region License` block and clear cross-project reuse intent. The license region is strong evidence that the function is carried as a distributable unit with its own provenance, but it is not enough by itself because boilerplate can be copied without a real reusable contract. Conversely, a `Version:` line alone is insufficient because ordinary internal helpers also carry version metadata for change tracking. If reuse intent is unclear in review, the author should either document the distributable intent or apply the private-helper banner and internal-caller positional wording.
+
 The banner is deliberately placed at the top of `.NOTES` so it is the first thing a reader encounters after the behavioral documentation sections. It does not reduce documentation quality; it adds a single, high-signal annotation that protects both the author's refactoring freedom and consumers' expectations.
 
 ---
@@ -402,6 +409,40 @@ When `[CmdletBinding()]` is declared without specifying `PositionalBinding`, Pow
 2. **Documentation/implementation mismatch.** When `.NOTES` documents only a subset of parameters as positional (e.g., `Position 0: InputMode`, `Position 1: OutputPath`) but the runtime actually permits positional binding for all parameters, callers may unknowingly pass values to unintended parameters. This silent divergence between the documented contract and the runtime behavior undermines trust in the function's interface.
 
 `PositionalBinding = $false` eliminates both risks by requiring the author to opt in to positional binding explicitly via `[Parameter(Position = N)]` on each intended positional parameter. Parameters without an explicit `Position` attribute become name-only, regardless of their declaration order.
+
+---
+
+### One Positional Write Cmdlet Message/Payload Argument
+
+> For the corresponding normative rule, see [Positional Parameter Support](STYLE_GUIDE.md#positional-parameter-support) in the main guide.
+
+The guide keeps the general preference for named arguments at call sites, but it treats one positional message/payload argument to a small allow-list of `Write-*` cmdlets as an idiomatic syntax exception. Microsoft Learn shows positional message/payload examples for these cmdlets and also uses named-parameter examples on some pages. It also shows the mixed shape the guide endorses: one positional message plus named options, such as `Write-Error "Invalid object" -ErrorId B1 -TargetObject $_` and `Write-Warning "This is only a test warning." -WarningAction Inquire`.
+
+PSScriptAnalyzer's `PSAvoidUsingPositionalParameters` rule is documented as an Information-severity rule that detects commands called with three or more positional parameters. The guide cites that documented threshold rather than asserting exact runtime behavior, and the exception remains intentionally narrower than the general named-argument preference.
+
+The first message/payload parameter is not named consistently across the relevant command family:
+
+| Cmdlet | First message/payload parameter for the discussed form | `-Message` binding | Availability and boundary notes |
+| --- | --- | --- | --- |
+| `Write-Verbose` | `-Message` at Position 0 | Real parameter | Listed in the archived Windows PowerShell 1.0 cmdlet set; covered by the syntax exception when otherwise permitted. |
+| `Write-Warning` | `-Message` at Position 0 | Real parameter | Listed in the archived Windows PowerShell 1.0 cmdlet set; covered by the syntax exception when otherwise permitted. |
+| `Write-Debug` | `-Message` at Position 0 | Real parameter | Listed in the archived Windows PowerShell 1.0 cmdlet set; covered by the syntax exception when otherwise permitted. |
+| `Write-Error` | Default `NoException` parameter set: `-Message` at Position 0 | Real parameter | Listed in the archived Windows PowerShell 1.0 cmdlet set; only the default message form is covered. `-Exception` and `-ErrorRecord` are also Position 0 in other parameter sets, but those payloads are outside this syntax exception. |
+| `Write-Information` | `-MessageData` at Position 0 | `Message` and `Msg` aliases | Introduced with the Information stream in Windows PowerShell 5.0; covered only for targets that support it and when otherwise permitted. `-Tags` is cmdlet-specific. |
+| `Write-Output` | `-InputObject` at Position 0 | No `-Message` parameter or alias | Listed in the archived Windows PowerShell 1.0 cmdlet set; not covered. Use remains governed by the guide's output and success-stream rules. |
+| `Write-Host` | `-Object` at Position 0 | `Message` and `Msg` aliases | Listed in the archived Windows PowerShell 1.0 cmdlet set; discussed only for parameter-name comparison because the guide prohibits `Write-Host`. |
+
+This variation is why the guide does not adopt a blanket "always `-Message`" rule. Such a rule would be wrong for `Write-Information`, meaningless for `Write-Output`, and misleading for `Write-Host`, which remains prohibited.
+
+Additional options should be named regardless of whether they are cmdlet-specific or common parameters. `-Category`, `-ErrorId`, and `-TargetObject` are `Write-Error` parameters; `-Tags` is a `Write-Information` parameter. `-WarningAction` and, on PowerShell 5.0+, `-InformationAction` are common parameters supported by the target runtime rather than parameters specific to `Write-Warning` or `Write-Information`, but the same "name additional options" guidance applies.
+
+`Write-Information` writes structured data to the Information stream and is distinct from the prohibited `Write-Host`, which the guide bans for host-only display. Allow-listing `Write-Information` when the target runtime supports it therefore does not conflict with prohibiting `Write-Host`.
+
+Excluding `Write-Output` from this idiom does not create a named-parameter requirement for `Write-Output` calls. Any use of `Write-Output` remains governed by the guide's output and success-stream rules, including the preference for returning or emitting success-stream objects according to the surrounding function model.
+
+`Write-Progress` is also outside the exception. Its positional parameters (`Activity` at Position 0, `Status` at Position 1, and `Id` at Position 2) describe progress state rather than a simple one-message/payload idiom.
+
+For availability, use the archived Windows PowerShell 1.0 cmdlet list as archived evidence that `Write-Output`, `Write-Error`, `Write-Warning`, `Write-Verbose`, `Write-Debug`, and `Write-Host` existed in that runtime. `Write-Information` and the Information stream were introduced in Windows PowerShell 5.0. The current `about_Output_Streams` table is useful stream documentation, but it should not be used by itself to infer cmdlet availability because it documents output streams and associated write cmdlets, not the full historical cmdlet set for every target runtime.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #141.

- Add the distributable/vendored-helper exemption for the private-helper banner and private positional-contract wording.
- Add the allowed one positional message/payload argument syntax exception for covered `Write-*` cmdlets.
- Expand rationale with the visibility-vs-stability distinction and per-cmdlet `Write-*` parameter details.
- Bump the style guide metadata to `2.22.20260629.0` / `2026-06-29`.

## Validation

- `npm --prefix .github/workflows ci`
- `npm --prefix .github/workflows run lint:md`
- `npm --prefix .github/workflows run lint:md:nested`
- Pre-commit markdownlint hook on the staged files

Note: `npm ci` completed successfully and reported existing npm audit findings in workflow dependencies.