### PR TITLE
Clarify standalone and vendored style guide applicability

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -2,14 +2,22 @@
 
 # PowerShell Writing Style
 
-**Version:** 2.22.20260629.0
+**Version:** 2.23.20260726.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-06-29
+- **Last Updated:** 2026-07-26
 - **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
+
+## Applicability and Portability
+
+- This guide is self-contained and intended for standalone use or vendoring into another repository.
+- Apply each requirement according to its scope tag and any explicit conditions.
+- Requirements tied to an optional toolchain, file type, or repository feature apply when the adopting project uses or intentionally adopts that surface.
+- Additional repository-wide instructions in the adopting repository continue to apply; this guide creates no exception to them.
+- Resolve actual conflicts through the adopting repository's documented precedence rules.
 
 ## Keywords
 

--- a/STYLE_GUIDE_CHAT.md
+++ b/STYLE_GUIDE_CHAT.md
@@ -5,14 +5,22 @@
 
 # PowerShell Writing Style
 
-**Version:** 2.22.20260629.0
+**Version:** 2.23.20260726.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-06-29
+- **Last Updated:** 2026-07-26
 - **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
+
+## Applicability and Portability
+
+- This guide is self-contained and intended for standalone use or vendoring into another repository.
+- Apply each requirement according to its scope tag and any explicit conditions.
+- Requirements tied to an optional toolchain, file type, or repository feature apply when the adopting project uses or intentionally adopts that surface.
+- Additional repository-wide instructions in the adopting repository continue to apply; this guide creates no exception to them.
+- Resolve actual conflicts through the adopting repository's documented precedence rules.
 
 ## Keywords
 

--- a/STYLE_GUIDE_FULL.md
+++ b/STYLE_GUIDE_FULL.md
@@ -2,14 +2,28 @@
 
 # PowerShell Writing Style
 
-**Version:** 2.22.20260629.0
+**Version:** 2.23.20260726.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-06-29
+- **Last Updated:** 2026-07-26
 - **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
+
+## Applicability and Portability
+
+The style guide is maintained as an independent, self-contained standard so the same text remains usable by itself and when vendored into different repositories. Vendoring the guide adds its applicable requirements to an adopting project's instructions; it does not make those independently maintained requirements interpretations of another document. Two documents may contain overlapping rules because they address the same engineering concern or converge on the same practice. That overlap, even at the same normative level, does not by itself show that either document derives its authority or meaning from the other.
+
+Repository-specific provenance mappings, citations, and file references are integration details. They depend on the adopting repository's actual instruction set, paths, versions, and precedence model, so they belong in that repository's integration guidance. Keeping those mappings downstream prevents stale or inapplicable dependencies from entering the portable guide and allows standalone consumers to apply it without companion files.
+
+Applicable instructions normally accumulate: matching or complementary rules can all be followed. The adopting repository's precedence rules are needed only when requirements actually conflict and cannot be satisfied together. This distinction preserves both the guide's independent authority and the adopting repository's control over its own instruction hierarchy.
+
+- This guide is self-contained and intended for standalone use or vendoring into another repository.
+- Apply each requirement according to its scope tag and any explicit conditions.
+- Requirements tied to an optional toolchain, file type, or repository feature apply when the adopting project uses or intentionally adopts that surface.
+- Additional repository-wide instructions in the adopting repository continue to apply; this guide creates no exception to them.
+- Resolve actual conflicts through the adopting repository's documented precedence rules.
 
 ## Keywords
 

--- a/STYLE_GUIDE_RATIONALE.md
+++ b/STYLE_GUIDE_RATIONALE.md
@@ -5,6 +5,8 @@ This companion document preserves the extended rationale, design philosophy, and
 ## Table of Contents
 
 - [Executive Summary: Author Profile](#executive-summary-author-profile)
+- [Applicability and Portability Rationale](#applicability-and-portability-rationale)
+  - [Applicability and Portability](#applicability-and-portability)
 - [Code Layout and Formatting Rationale](#code-layout-and-formatting-rationale)
   - [File Encoding](#file-encoding)
   - [Programmatic File Writing Encoding](#programmatic-file-writing-encoding)
@@ -68,6 +70,20 @@ The author's code writing style can be characterized as a highly disciplined "Po
 This explains the systematic avoidance of features introduced in v2.0 or later in v1.0-targeted scripts, such as advanced functions with the [CmdletBinding()] attribute, structured try/catch error handling, common parameters like -Verbose or -Debug, begin/process/end blocks, and modern output streams. Instead, the style relies on PowerShell's foundational mechanics, such as simple function declarations, strongly typed param blocks, explicit return statements for single values, and a custom error detection pattern using trap statements and global preference toggling.
 
 Within these constraints, the author adheres closely to community best practices for readability, naming, documentation, and maintainability. Functions are designed as reusable tools with a single purpose—e.g., performing targeted data transformations or validations. Outputs are explicit and controlled: a status code (e.g., an integer indicating full success, partial success, or failure) is typically returned, while complex results are passed via reference parameters only when necessary to modify data in the caller's scope, avoiding unnecessary use of [ref] for read-only objects since it provides no performance benefits in PowerShell. Error handling is "fail-controlled," suppressing issues to allow graceful recovery without halting execution. The code is robust, thoroughly documented, and predictable across versions, making it ideal for tools in legacy or mixed environments. Performance is balanced with readability, favoring script constructs over pipelines. If the v1.0 constraint were lifted (e.g., due to modern dependencies), the style would evolve to incorporate features like pipeline-friendly objects and structured errors while retaining strong typing and documentation for clarity.
+
+---
+
+## Applicability and Portability Rationale
+
+### Applicability and Portability
+
+> For the operational guidance, see [Applicability and Portability](STYLE_GUIDE.md#applicability-and-portability) in the main guide.
+
+The style guide is maintained as an independent, self-contained standard so the same text remains usable by itself and when vendored into different repositories. Vendoring the guide adds its applicable requirements to an adopting project's instructions; it does not make those independently maintained requirements interpretations of another document. Two documents may contain overlapping rules because they address the same engineering concern or converge on the same practice. That overlap, even at the same normative level, does not by itself show that either document derives its authority or meaning from the other.
+
+Repository-specific provenance mappings, citations, and file references are integration details. They depend on the adopting repository's actual instruction set, paths, versions, and precedence model, so they belong in that repository's integration guidance. Keeping those mappings downstream prevents stale or inapplicable dependencies from entering the portable guide and allows standalone consumers to apply it without companion files.
+
+Applicable instructions normally accumulate: matching or complementary rules can all be followed. The adopting repository's precedence rules are needed only when requirements actually conflict and cannot be satisfied together. This distinction preserves both the guide's independent authority and the adopting repository's control over its own instruction hierarchy.
 
 ---
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -2,14 +2,22 @@
 
 # PowerShell Writing Style
 
-**Version:** 2.22.20260629.0
+**Version:** 2.23.20260726.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-06-29
+- **Last Updated:** 2026-07-26
 - **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
+
+## Applicability and Portability
+
+- This guide is self-contained and intended for standalone use or vendoring into another repository.
+- Apply each requirement according to its scope tag and any explicit conditions.
+- Requirements tied to an optional toolchain, file type, or repository feature apply when the adopting project uses or intentionally adopts that surface.
+- Additional repository-wide instructions in the adopting repository continue to apply; this guide creates no exception to them.
+- Resolve actual conflicts through the adopting repository's documented precedence rules.
 
 ## Keywords
 

--- a/powershell.instructions.md
+++ b/powershell.instructions.md
@@ -7,14 +7,22 @@ description: "PowerShell coding standards"
 
 # PowerShell Writing Style
 
-**Version:** 2.22.20260629.0
+**Version:** 2.23.20260726.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-06-29
+- **Last Updated:** 2026-07-26
 - **Scope:** PowerShell coding standards for all `.ps1` files in this repository — style, formatting, naming, error handling, documentation, and compatibility patterns for both legacy (v1.0) and modern (v2.0+) codebases.
+
+## Applicability and Portability
+
+- This guide is self-contained and intended for standalone use or vendoring into another repository.
+- Apply each requirement according to its scope tag and any explicit conditions.
+- Requirements tied to an optional toolchain, file type, or repository feature apply when the adopting project uses or intentionally adopts that surface.
+- Additional repository-wide instructions in the adopting repository continue to apply; this guide creates no exception to them.
+- Resolve actual conflicts through the adopting repository's documented precedence rules.
 
 ## Keywords
 


### PR DESCRIPTION
## Summary

- add a concise applicability and portability section for standalone and vendored use
- explain why overlapping rules do not establish an interpretation relationship and why downstream provenance mappings remain downstream
- advance the guide version and date, then regenerate all four consumer artifacts

## Why

The consumer-facing guide did not state how scope tags, optional surfaces, additional repository-wide instructions, and repository precedence rules interact when the guide is used standalone or vendored. This left coding agents without a self-contained operating model and risked introducing downstream-specific citations into portable artifacts.

## Impact

Adopting repositories can apply the guide without companion files while retaining control of their own instruction hierarchy. Existing normative levels and the three rules called out in the issue remain unchanged.

## Validation

- `./.github/workflows/Generate-StyleGuideArtifacts.ps1`
- `npm run lint:md`
- `npm run lint:md:nested`
- targeted acceptance and diff checks

Closes #143