### PR TITLE
Use published metadata endpoints for validation (#176)

### DIFF
--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -7,13 +7,13 @@ description: "Documentation standards:  contract-first, traceable, drift-resista
 
 # Documentation Writing Style
 
-**Version:** 1.6.20260901.0
+**Version:** 1.6.20260902.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-09-01
+- **Last Updated:** 2026-09-02
 - **Scope:** Defines documentation standards for Markdown (`**/*.md`) and Cursor Markdown rule (`**/*.mdc`) files in this repository, including specs, design docs, runbooks, ADRs, instruction files, and developer documentation. Does not cover code comments or inline documentation in source files.
 - **Related:** [Repository Copilot Instructions](../copilot-instructions.md)
 
@@ -110,15 +110,23 @@ Tier 2 documents MAY adopt YAML front matter later if a real tool consumes it, s
 
 This subsection applies to Tier 1 documents and to any other document that intentionally carries the metadata header block. The fields referenced in this subsection (`Last Updated`, and the optional `Version` line) are defined in the Tier 1 bullet list above; this subsection adds normative synchronization rules for those fields and does not redefine their semantics.
 
-- When a commit modifies the rendered content or documentation meaning of a document that carries the metadata header block, the `Last Updated` field in that document MUST be bumped to the current UTC date in `YYYY-MM-DD` form as part of the same commit.
-- If the document also carries a `**Version:** <major>.<minor>.<YYYYMMDD>.<revision>` line, the embedded `<YYYYMMDD>` segment MUST be updated in the same commit so that it matches the new `Last Updated` value.
+For this subsection:
+
+- The published baseline is the pre-change version already present on the branch where the change will land. For a pull request, it is the document on the pull request base branch. For a direct push, it is the document at the before revision of the pushed branch.
+- The finalization point is the last author- or agent-controlled update before the change is merged, added to an automated merge queue, or pushed directly to that branch. Metadata is evaluated between the published baseline and the finalization point. Internal topic, work-in-progress, and iteration commits are not separate published transitions. If automated merge machinery changes the target branch after the finalization point, the landed value is not a violation of this rule; correct any resulting metadata drift in a follow-up change.
+
+- When the change modifies the rendered content or documentation meaning of a document that carries the metadata header block, the `Last Updated` field in the final document MUST be the current UTC date in `YYYY-MM-DD` form at the finalization point.
+- If the document also carries a `**Version:** <major>.<minor>.<YYYYMMDD>.<revision>` line, the embedded `<YYYYMMDD>` segment MUST match the final `Last Updated` value.
 - Revision convention for the `<revision>` segment of `**Version:**`:
-  - The `<YYYYMMDD>` value MUST NOT move backward relative to the visible parent commit.
-  - When a same-day commit modifies the document, `<revision>` MUST be greater than the visible parent revision. It SHOULD increment by `1` when the commit history preserves each source change (for example, `...20260502.0` → `...20260502.1`).
-  - When `<YYYYMMDD>` moves to a later date in an ordinary commit, `<revision>` SHOULD reset to `0`.
-  - A squash or another history-rewriting operation MAY preserve a higher terminal revision from the source history. This exception applies when the date moves forward or when multiple same-day source changes become one visible commit.
-  - `<major>` and `<minor>` are out of scope for this synchronization rule and follow the document's own semantic-versioning conventions.
-- Exemption for trivial mechanical changes. The bump MAY be omitted for commits that do not alter rendered content or documentation meaning, including pure file-mode changes, line-ending normalization, end-of-file newline fixes, or trailing-whitespace-only fixes produced by pre-commit hooks. The trailing-whitespace exemption MUST NOT be applied when the change removes or alters a Markdown hard line break (two or more trailing spaces, or a trailing backslash, immediately before a newline), because such whitespace is rendering-significant; in that case the change alters rendered content and the bump is required.
+  - `<revision>` counts published updates relative to the published baseline. It is evaluated at the finalization point, not for each internal commit.
+  - After setting `<major>.<minor>` under the document's own conventions and `<YYYYMMDD>` to the current UTC date, `<revision>` MUST be `0` when the resulting `<major>.<minor>.<YYYYMMDD>` differs from the published baseline's `<major>.<minor>.<YYYYMMDD>`, including when no published baseline exists.
+  - When the published baseline already carries the same `<major>.<minor>.<YYYYMMDD>` at revision `N`, the final `<revision>` MUST be `N + 1`.
+  - Intra-PR iteration commits target the single correct final revision. Re-check the published baseline at the finalization point.
+  - Examples:
+    - Same-day published update that keeps the same `<major>.<minor>`: published baseline `1.6.20260502.0` to final `1.6.20260502.1`.
+    - Next-day update: published baseline `1.6.20260502.1`, change finalized on 2026-05-03 UTC, to final `1.6.20260503.0`.
+  - This synchronization rule does not govern when `<major>` or `<minor>` are incremented. Those segments continue to follow the document's own semantic-versioning conventions. For `<revision>` computation, treat `**Version:**` as an ordered four-segment tuple: `<major>`, `<minor>`, `<YYYYMMDD>`, and `<revision>`. `<revision>` is the lowest-precedence segment and MUST reset to `0` whenever a higher-order segment changes relative to the published baseline.
+- Exemption for trivial mechanical changes. The bump MAY be omitted when the published change does not alter rendered content or documentation meaning, including pure file-mode changes, line-ending normalization, end-of-file newline fixes, or trailing-whitespace-only fixes produced by pre-commit hooks. The trailing-whitespace exemption MUST NOT be applied when the change removes or alters a Markdown hard line break (two or more trailing spaces, or a trailing backslash, immediately before a newline), because such whitespace is rendering-significant; in that case the change alters rendered content and the bump is required.
 - This rule applies to all documents in the repository that carry the metadata header block, including but not limited to `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.hermes.md`, and `.cursor/rules/*.mdc`.
 
 ### Non-Normative Historical Artifacts
@@ -268,7 +276,6 @@ PSStyleGuide does not track request-template files or a placeholder-check workfl
 - The literal example `https://github.com/OWNER/REPO/...` MAY appear only as clearly labeled didactic text in an inline code span or fenced code block. It MUST NOT appear as a live unresolved link target.
 - Placeholder text in copyable shell examples MUST remain literal and safe. The shell rules below prohibit command-substitution metacharacters in such placeholder text.
 - `.github/instructions/docs.instructions.md` owns these documentation rules.
-- `.github/workflows/Test-AgentInstructions.ps1` is a non-owner enforcement mechanism. It checks the named owner at the exact input revision and rejects stale repository-specific documentation claims.
 
 #### Template-substitution marker boundaries and replacement surfaces
 
@@ -300,7 +307,8 @@ Decision records exist to prevent re-litigating decisions.
 
 - File naming pattern: `docs/decisions/NNNN-short-title.md`
 - Decision records MUST include:
-  - The Tier 1 **Status**, **Owner**, **Last Updated**, and **Scope** metadata fields.
+  - The single Tier 1 **Status** metadata field. For decision records, its value MUST be Proposed | Accepted | Superseded | Deprecated. A decision record MUST NOT add a separate narrative status field or section.
+  - The Tier 1 **Owner**, **Last Updated**, and **Scope** metadata fields.
   - **Context**
   - **Decision**
   - **Consequences:** positive and negative

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -7,13 +7,13 @@ description: "Documentation standards:  contract-first, traceable, drift-resista
 
 # Documentation Writing Style
 
-**Version:** 1.6.20260830.0
+**Version:** 1.6.20260831.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-08-30
+- **Last Updated:** 2026-08-31
 - **Scope:** Defines documentation standards for Markdown (`**/*.md`) and Cursor Markdown rule (`**/*.mdc`) files in this repository, including specs, design docs, runbooks, ADRs, instruction files, and developer documentation. Does not cover code comments or inline documentation in source files.
 - **Related:** [Repository Copilot Instructions](../copilot-instructions.md)
 
@@ -58,7 +58,7 @@ This repository classifies documents into two tiers based on their primary audie
 
 The metadata header block is **REQUIRED** for documents whose primary purpose is governance, specification, instruction, process, runbook, or ADR-style design rationale. Tier 1 covers, for example:
 
-- Repository-level instruction files matching `.github/instructions/*.instructions.md`. The repository's `.github/copilot-instructions.md` remains governed instruction content but is an explicit exception to the visible metadata-header requirement and MUST remain listed explicitly as `RequiresMetadata = $false` in the validator catalog.
+- Repository-level instruction files matching `.github/instructions/*.instructions.md`. The repository's `.github/copilot-instructions.md` remains governed instruction content but is an explicit exception to the visible metadata-header requirement.
 - Root agent entry-point files such as `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.hermes.md`, and future equivalents.
 - Cursor project rules matching `.cursor/rules/*.mdc`.
 - ADR-style or formal design-decision records, regardless of where they live (`.github/`, `docs/`, or another documented ADR/design-decision location).
@@ -68,7 +68,7 @@ The metadata header block is **REQUIRED** for documents whose primary purpose is
 
 The Tier 1 metadata header block consists of these fields:
 
-- **Status:** Draft | Active | Deprecated **(REQUIRED)**
+- **Status:** Draft | Proposed | Active | Accepted | Superseded | Deprecated **(REQUIRED)**
 - **Owner:** Person or team **(REQUIRED)**
 - **Last Updated:** YYYY-MM-DD **(REQUIRED)**
 - **Scope:** What this doc covers (and does not cover) **(REQUIRED)**
@@ -267,7 +267,7 @@ PSStyleGuide does not track request-template files or a placeholder-check workfl
 - When a durable document requires an absolute PSStyleGuide link, the link MUST use `https://github.com/franklesniak/PSStyleGuide/` and MUST identify a real target.
 - The literal example `https://github.com/OWNER/REPO/...` MAY appear only as clearly labeled didactic text in an inline code span or fenced code block. It MUST NOT appear as a live unresolved link target.
 - Placeholder text in copyable shell examples MUST remain literal and safe. The shell rules below prohibit command-substitution metacharacters in such placeholder text.
-- `.github/instructions/docs.instructions.md` owns these documentation rules. `.github/workflows/Test-AgentInstructions.ps1` validates these named owners at the exact input revision and rejects stale repository-specific source or enforcement claims.
+- `.github/instructions/docs.instructions.md` owns these documentation rules.
 
 #### Template-substitution marker boundaries and replacement surfaces
 
@@ -300,7 +300,6 @@ Decision records exist to prevent re-litigating decisions.
 - File naming pattern: `docs/decisions/NNNN-short-title.md`
 - Decision records MUST include:
   - The Tier 1 **Status**, **Owner**, **Last Updated**, and **Scope** metadata fields.
-  - A separate narrative decision status or history, such as Proposed, Accepted, Superseded, or Deprecated.
   - **Context**
   - **Decision**
   - **Consequences:** positive and negative
@@ -413,7 +412,7 @@ Before merging, verify:
   - An explicit `**Assumption:**` labeled entry.
   - A cross-reference to another requirement or section that defines the value.
   This rule applies to unresolved requirements/specification content only. It does not ban legitimate template-substitution placeholders, didactic examples, migration notes, or code-comment TODO examples elsewhere in the repository.
-- Authors and reviewers MUST manually inspect Markdown under `docs/**` for unresolved placeholder forms, including case-insensitive `TBD`, `TODO:`, `FIXME`, `XXX`, `to be determined`, and `(default ... to be determined)`. Remediate normative occurrences with a measurable value, an explicit `**Open Question:**` entry, an explicit `**Assumption:**` entry, or a cross-reference to another requirement. Fenced examples, HTML comments, changelog history, and clearly labeled didactic examples are allowed only when context makes clear that they are not unresolved repository requirements.
+- Remediate normative occurrences with a measurable value, an explicit `**Open Question:**` entry, an explicit `**Assumption:**` entry, or a cross-reference to another requirement. Fenced examples, HTML comments, changelog history, and clearly labeled didactic examples are allowed only when context makes clear that they are not unresolved repository requirements.
 - Contradictory statements between the spec and other docs
 - Vague guarantees without measurable definitions
 - Unowned open questions ("someone should figure out…")

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -315,6 +315,8 @@ Decision records exist to prevent re-litigating decisions.
   - **Alternatives Considered**
   - **Date:** YYYY-MM-DD
 
+Published legacy decision records that predate this lifecycle rule MAY retain their existing status representation while their bytes remain unchanged. The next change to such a record MUST migrate it to the single Tier 1 Status metadata field and MUST remove each separate narrative status field or section.
+
 ADRs MUST be short and specific. If an ADR grows into a design doc, split it.
 
 ## Requirements Documentation Standards

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -7,13 +7,13 @@ description: "Documentation standards:  contract-first, traceable, drift-resista
 
 # Documentation Writing Style
 
-**Version:** 1.6.20260830.0
+**Version:** 1.6.20260901.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-08-30
+- **Last Updated:** 2026-09-01
 - **Scope:** Defines documentation standards for Markdown (`**/*.md`) and Cursor Markdown rule (`**/*.mdc`) files in this repository, including specs, design docs, runbooks, ADRs, instruction files, and developer documentation. Does not cover code comments or inline documentation in source files.
 - **Related:** [Repository Copilot Instructions](../copilot-instructions.md)
 
@@ -58,7 +58,7 @@ This repository classifies documents into two tiers based on their primary audie
 
 The metadata header block is **REQUIRED** for documents whose primary purpose is governance, specification, instruction, process, runbook, or ADR-style design rationale. Tier 1 covers, for example:
 
-- Repository-level instruction files matching `.github/instructions/*.instructions.md`. The repository's `.github/copilot-instructions.md` remains governed instruction content but is an explicit exception to the visible metadata-header requirement and MUST remain listed explicitly as `RequiresMetadata = $false` in the validator catalog.
+- Repository-level instruction files matching `.github/instructions/*.instructions.md`. The repository's `.github/copilot-instructions.md` remains governed instruction content but is an explicit exception to the visible metadata-header requirement.
 - Root agent entry-point files such as `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.hermes.md`, and future equivalents.
 - Cursor project rules matching `.cursor/rules/*.mdc`.
 - ADR-style or formal design-decision records, regardless of where they live (`.github/`, `docs/`, or another documented ADR/design-decision location).
@@ -68,7 +68,7 @@ The metadata header block is **REQUIRED** for documents whose primary purpose is
 
 The Tier 1 metadata header block consists of these fields:
 
-- **Status:** Draft | Active | Deprecated **(REQUIRED)**
+- **Status:** Draft | Proposed | Active | Accepted | Superseded | Deprecated **(REQUIRED)**
 - **Owner:** Person or team **(REQUIRED)**
 - **Last Updated:** YYYY-MM-DD **(REQUIRED)**
 - **Scope:** What this doc covers (and does not cover) **(REQUIRED)**
@@ -267,7 +267,8 @@ PSStyleGuide does not track request-template files or a placeholder-check workfl
 - When a durable document requires an absolute PSStyleGuide link, the link MUST use `https://github.com/franklesniak/PSStyleGuide/` and MUST identify a real target.
 - The literal example `https://github.com/OWNER/REPO/...` MAY appear only as clearly labeled didactic text in an inline code span or fenced code block. It MUST NOT appear as a live unresolved link target.
 - Placeholder text in copyable shell examples MUST remain literal and safe. The shell rules below prohibit command-substitution metacharacters in such placeholder text.
-- `.github/instructions/docs.instructions.md` owns these documentation rules. `.github/workflows/Test-AgentInstructions.ps1` validates these named owners at the exact input revision and rejects stale repository-specific source or enforcement claims.
+- `.github/instructions/docs.instructions.md` owns these documentation rules.
+- `.github/workflows/Test-AgentInstructions.ps1` is a non-owner enforcement mechanism. It checks the named owner at the exact input revision and rejects stale repository-specific documentation claims.
 
 #### Template-substitution marker boundaries and replacement surfaces
 
@@ -300,7 +301,6 @@ Decision records exist to prevent re-litigating decisions.
 - File naming pattern: `docs/decisions/NNNN-short-title.md`
 - Decision records MUST include:
   - The Tier 1 **Status**, **Owner**, **Last Updated**, and **Scope** metadata fields.
-  - A separate narrative decision status or history, such as Proposed, Accepted, Superseded, or Deprecated.
   - **Context**
   - **Decision**
   - **Consequences:** positive and negative
@@ -413,7 +413,7 @@ Before merging, verify:
   - An explicit `**Assumption:**` labeled entry.
   - A cross-reference to another requirement or section that defines the value.
   This rule applies to unresolved requirements/specification content only. It does not ban legitimate template-substitution placeholders, didactic examples, migration notes, or code-comment TODO examples elsewhere in the repository.
-- Authors and reviewers MUST manually inspect Markdown under `docs/**` for unresolved placeholder forms, including case-insensitive `TBD`, `TODO:`, `FIXME`, `XXX`, `to be determined`, and `(default ... to be determined)`. Remediate normative occurrences with a measurable value, an explicit `**Open Question:**` entry, an explicit `**Assumption:**` entry, or a cross-reference to another requirement. Fenced examples, HTML comments, changelog history, and clearly labeled didactic examples are allowed only when context makes clear that they are not unresolved repository requirements.
+- Remediate normative occurrences with a measurable value, an explicit `**Open Question:**` entry, an explicit `**Assumption:**` entry, or a cross-reference to another requirement. Fenced examples, HTML comments, changelog history, and clearly labeled didactic examples are allowed only when context makes clear that they are not unresolved repository requirements.
 - Contradictory statements between the spec and other docs
 - Vague guarantees without measurable definitions
 - Unowned open questions ("someone should figure out…")

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -7,7 +7,7 @@ description: "Documentation standards:  contract-first, traceable, drift-resista
 
 # Documentation Writing Style
 
-**Version:** 1.6.20260902.0
+**Version:** 1.6.20260902.1
 
 ## Metadata
 

--- a/.github/workflows/Test-AgentInstructions.SelfTest.ps1
+++ b/.github/workflows/Test-AgentInstructions.SelfTest.ps1
@@ -29,7 +29,7 @@
 # None. The script throws when a self-test fails.
 #
 # .NOTES
-# Version: 1.2.20260902.0
+# Version: 1.2.20260902.1
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([void])]
@@ -281,6 +281,9 @@ try {
         -OtherRefEvidenceJson $strRootEvidence
     if (@($objZeroContext.IntroducedCommitRevisions).Count -ne 0 -or
         @($objZeroContext.BoundaryRevisions).Count -ne 0 -or
+        (Get-CreatedRefMetadataBaselineRevision `
+            -Context $objZeroContext -HeadRevision $strRootCommit) -cne
+            $strRootCommit -or
         @(Read-GitPublishedEndpointChangedPath `
             -RepositoryRootPath $strTopologyRoot `
             -BaselineRevision ('0' * 40) -FinalRevision $strRootCommit `
@@ -365,6 +368,9 @@ try {
     if (@($objOneContext.IntroducedCommitRevisions).Count -ne 1 -or
         @($objOneContext.BoundaryRevisions).Count -ne 1 -or
         $objOneContext.BoundaryRevisions[0] -cne $strRootCommit -or
+        (Get-CreatedRefMetadataBaselineRevision `
+            -Context $objOneContext -HeadRevision $strOneCommit) -cne
+            $strRootCommit -or
         $arrOnePaths.Count -ne 1 -or $arrOnePaths[0] -cne 'one.txt') {
         throw 'The one-introduced created-ref fixture found an incorrect boundary.'
     }
@@ -397,6 +403,9 @@ try {
             -MaximumBytes $MaximumBytes)
     if (@($objManyContext.IntroducedCommitRevisions).Count -ne 2 -or
         @($objManyContext.BoundaryRevisions).Count -ne 1 -or
+        (Get-CreatedRefMetadataBaselineRevision `
+            -Context $objManyContext -HeadRevision $strTwoCommit) -cne
+            $strRootCommit -or
         [string]::Join("`n", $arrManyPaths) -cne "one.txt`ntwo.txt") {
         throw 'The many-introduced created-ref fixture lost changed paths.'
     }
@@ -459,6 +468,19 @@ try {
         [string]::Join("`n", $arrMergePaths) -cne "left.txt`nright.txt") {
         throw 'The merge created-ref fixture lost a parent boundary.'
     }
+    try {
+        [void] (Get-CreatedRefMetadataBaselineRevision `
+                -Context $objMergeContext -HeadRevision $strMergeCommit)
+        throw 'An ambiguous multi-boundary metadata baseline was accepted.'
+    }
+    catch {
+        if (-not $_.Exception.Message.Contains(
+                'lacks one unambiguous metadata baseline',
+                [StringComparison]::Ordinal
+            )) {
+            throw
+        }
+    }
 
     $strRootPayload = ConvertTo-Json -Depth 4 -Compress -InputObject `
         ([object[]] @((ConvertTo-CreatedPushCommitEvidenceObject `
@@ -477,6 +499,10 @@ try {
                 $objGenuineRootContext.IntroducedCommitRevisions `
             -MaximumBytes $MaximumBytes)
     if (-not $objGenuineRootContext.IsGenuineRootIntroduction -or
+        -not [string]::IsNullOrEmpty(
+            (Get-CreatedRefMetadataBaselineRevision `
+                -Context $objGenuineRootContext -HeadRevision $strRootCommit)
+        ) -or
         $arrGenuineRootPaths.Count -ne 1 -or
         $arrGenuineRootPaths[0] -cne 'root.txt') {
         throw 'The genuine-root created-ref fixture did not use the final tree.'

--- a/.github/workflows/Test-AgentInstructions.SelfTest.ps1
+++ b/.github/workflows/Test-AgentInstructions.SelfTest.ps1
@@ -56,7 +56,8 @@ function ConvertTo-CreatedPushCommitEvidenceObject {
     [OutputType([pscustomobject])]
     param(
         [Parameter(Mandatory)][string] $Id,
-        [Parameter(Mandatory)][bool] $Distinct
+        [Parameter(Mandatory)][bool] $Distinct,
+        [string] $Timestamp = ''
     )
 
     return [pscustomobject]@{
@@ -64,7 +65,7 @@ function ConvertTo-CreatedPushCommitEvidenceObject {
         tree_id = $Id
         distinct = $Distinct
         message = ''
-        timestamp = ''
+        timestamp = $Timestamp
         url = ''
         author = [pscustomobject]@{
             name = ''
@@ -274,6 +275,22 @@ try {
             -EventHeadRevision $strOneCommit `
             -EventHeadDistinct 'true').Count -ne 1) {
         throw 'The Actions-shaped commit fixture was not accepted.'
+    }
+    foreach ($strTimestampFixture in @(
+            '2026-09-01T13:41:43-05:00',
+            '2026-09-01T18:41:43Z',
+            '2026-09-01T13:41:43'
+        )) {
+        $strTimestampPayload = ConvertTo-Json -Depth 4 -Compress -InputObject `
+            ([object[]] @((ConvertTo-CreatedPushCommitEvidenceObject `
+                        -Id $strOneCommit -Distinct $true `
+                        -Timestamp $strTimestampFixture)))
+        if (@(Read-CreatedPushCommitEvidence `
+                -PushCommitEvidenceJson $strTimestampPayload `
+                -EventHeadRevision $strOneCommit `
+                -EventHeadDistinct 'true').Count -ne 1) {
+            throw "The '$strTimestampFixture' timestamp fixture was not accepted."
+        }
     }
     $objForwardCompatibleCommit = ConvertFrom-Json -InputObject (
         ConvertTo-Json -Depth 4 -Compress -InputObject $objOnePayloadCommit
@@ -503,6 +520,18 @@ try {
         -Id ('g' * 40) -Distinct $true
     $objNotDistinctHeadCommit = ConvertTo-CreatedPushCommitEvidenceObject `
         -Id $strOneCommit -Distinct $false
+    $strMalformedTimestampPayload = $strOnePayload.Replace(
+        '"timestamp":""',
+        '"timestamp":0'
+    )
+    $strDuplicatePropertyPayload = $strOnePayload.Replace(
+        '"id":"' + $strOneCommit + '"',
+        '"id":"' + $strOneCommit + '","id":"' + $strOneCommit + '"'
+    )
+    $strMissingPropertyPayload = $strOnePayload.Replace(
+        '"timestamp":"","url"',
+        '"url"'
+    )
     $arrEvidenceParserRejections = @(
         [pscustomobject]@{
             Name = 'malformed JSON'
@@ -514,6 +543,27 @@ try {
         [pscustomobject]@{
             Name = 'malformed commit object'
             Json = '[{}]'
+            Head = $strOneCommit
+            Distinct = 'true'
+            Expected = 'invalid object shape'
+        },
+        [pscustomobject]@{
+            Name = 'malformed timestamp token'
+            Json = $strMalformedTimestampPayload
+            Head = $strOneCommit
+            Distinct = 'true'
+            Expected = 'invalid identity or scalar'
+        },
+        [pscustomobject]@{
+            Name = 'duplicate raw property'
+            Json = $strDuplicatePropertyPayload
+            Head = $strOneCommit
+            Distinct = 'true'
+            Expected = 'duplicate property'
+        },
+        [pscustomobject]@{
+            Name = 'missing required property'
+            Json = $strMissingPropertyPayload
             Head = $strOneCommit
             Distinct = 'true'
             Expected = 'invalid object shape'

--- a/.github/workflows/Test-AgentInstructions.SelfTest.ps1
+++ b/.github/workflows/Test-AgentInstructions.SelfTest.ps1
@@ -29,7 +29,7 @@
 # None. The script throws when a self-test fails.
 #
 # .NOTES
-# Version: 1.2.20260831.0
+# Version: 1.2.20260902.0
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([void])]
@@ -116,8 +116,51 @@ $strHigherTerminalRevision = $strFinal.Replace(
 if (@(Get-PublishedEndpointMetadataFailure `
     -Name 'fixture.md' -CurrentContent $strHigherTerminalRevision `
     -ParentContent $strBaseline -ExpectedUtcDate '2026-08-31' `
+    -IsNewDocumentTransition $false) -cnotcontains
+    ('fixture.md Version revision must be exactly 0 when a published-baseline ' +
+        'major, minor, or date segment changes.')) {
+    throw 'The extracted higher-order revision reset did not fail closed.'
+}
+
+$strSameTupleFinal = $strBaseline.Replace(
+    '**Version:** 1.0.20260830.0',
+    '**Version:** 1.0.20260830.1'
+).Replace('Published baseline.', 'Published final on the same tuple.')
+if (@(Get-PublishedEndpointMetadataFailure `
+    -Name 'fixture.md' -CurrentContent $strSameTupleFinal `
+    -ParentContent $strBaseline -ExpectedUtcDate '2026-08-30' `
     -IsNewDocumentTransition $false).Count -ne 0) {
-    throw 'The extracted higher terminal revision was rejected.'
+    throw 'The extracted exact same-tuple revision increment was rejected.'
+}
+$strSkippedSameTupleRevision = $strSameTupleFinal.Replace(
+    '**Version:** 1.0.20260830.1',
+    '**Version:** 1.0.20260830.2'
+)
+if (@(Get-PublishedEndpointMetadataFailure `
+    -Name 'fixture.md' -CurrentContent $strSkippedSameTupleRevision `
+    -ParentContent $strBaseline -ExpectedUtcDate '2026-08-30' `
+    -IsNewDocumentTransition $false) -cnotcontains
+    ('fixture.md Version revision must be exactly 1 after a rendered-content ' +
+        'change with an unchanged published-baseline major, minor, and date tuple.')) {
+    throw 'The extracted skipped same-tuple revision did not fail closed.'
+}
+
+if (@(Get-PublishedEndpointMetadataFailure -Name 'fixture.md' `
+        -CurrentContent $strFinal -ParentContent $null -ExpectedUtcDate '' `
+        -IsNewDocumentTransition $true `
+        -RequireExpectedUtcDateForRenderedChange $false).Count -ne 0) {
+    throw 'The extracted baseline-absent revision zero was rejected.'
+}
+$strNewDocumentNonzeroRevision = $strFinal.Replace(
+    '**Version:** 1.0.20260831.0',
+    '**Version:** 1.0.20260831.1'
+)
+if (@(Get-PublishedEndpointMetadataFailure -Name 'fixture.md' `
+        -CurrentContent $strNewDocumentNonzeroRevision -ParentContent $null `
+        -ExpectedUtcDate '' -IsNewDocumentTransition $true `
+        -RequireExpectedUtcDateForRenderedChange $false) -cnotcontains
+    'fixture.md Version revision must be exactly 0 when no published baseline exists.') {
+    throw 'The extracted baseline-absent nonzero revision did not fail closed.'
 }
 
 $strSameTupleRollback = $strBaseline.Replace(

--- a/.github/workflows/Test-AgentInstructions.SelfTest.ps1
+++ b/.github/workflows/Test-AgentInstructions.SelfTest.ps1
@@ -51,6 +51,34 @@ if ($arrDeclaredOutputTypes.Count -ne 1 -or
 }
 $script:strMaximumMetadataUtcDate = $MaximumMetadataUtcDate
 
+function ConvertTo-CreatedPushCommitEvidenceObject {
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][string] $Id,
+        [Parameter(Mandatory)][bool] $Distinct
+    )
+
+    return [pscustomobject]@{
+        id = $Id
+        tree_id = $Id
+        distinct = $Distinct
+        message = ''
+        timestamp = ''
+        url = ''
+        author = [pscustomobject]@{
+            name = ''
+            email = ''
+            username = $null
+        }
+        committer = [pscustomobject]@{
+            name = ''
+            email = ''
+            username = $null
+        }
+    }
+}
+
 $strBaseline = @(
     '# Endpoint fixture'
     '**Version:** 1.0.20260830.0'
@@ -205,8 +233,7 @@ try {
         -RepositoryRootPath $strTopologyRoot `
         -DestinationRef 'refs/heads/new-zero' `
         -HeadRevision $strRootCommit -EventHeadRevision $strRootCommit `
-        -EventHeadDistinct 'false' -PushCommitCount '0' `
-        -PushDistinctCommitCount '0' -PushCommitEvidenceJson '[]' `
+        -EventHeadDistinct 'false' -PushCommitEvidenceJson '[]' `
         -OtherRefEvidenceJson $strRootEvidence
     if (@($objZeroContext.IntroducedCommitRevisions).Count -ne 0 -or
         @($objZeroContext.BoundaryRevisions).Count -ne 0 -or
@@ -227,14 +254,45 @@ try {
     & git -C $strTopologyRoot add -- one.txt
     & git -C $strTopologyRoot commit --quiet -m one
     $strOneCommit = ([string] (& git -C $strTopologyRoot rev-parse HEAD)).Trim()
-    $strOnePayload = ConvertTo-Json -Compress -InputObject `
-        ([object[]] @($strOneCommit))
+    $objOnePayloadCommit = ConvertTo-CreatedPushCommitEvidenceObject `
+        -Id $strOneCommit -Distinct $true
+    $strOnePayload = ConvertTo-Json -Depth 4 -Compress -InputObject `
+        ([object[]] @($objOnePayloadCommit))
+    $arrLiveShapeProperties = @($objOnePayloadCommit.PSObject.Properties.Name)
+    if ($arrLiveShapeProperties.Count -ne 8 -or
+        @(@('id', 'tree_id', 'distinct', 'message', 'timestamp', 'url',
+                'author', 'committer') | Where-Object {
+                $arrLiveShapeProperties -cnotcontains $_
+            }).Count -ne 0 -or
+        @(@('added', 'removed', 'modified') | Where-Object {
+                $arrLiveShapeProperties -ccontains $_
+            }).Count -ne 0) {
+        throw 'The Actions-shaped commit fixture has an invalid property inventory.'
+    }
+    if (@(Read-CreatedPushCommitEvidence `
+            -PushCommitEvidenceJson $strOnePayload `
+            -EventHeadRevision $strOneCommit `
+            -EventHeadDistinct 'true').Count -ne 1) {
+        throw 'The Actions-shaped commit fixture was not accepted.'
+    }
+    $objForwardCompatibleCommit = ConvertFrom-Json -InputObject (
+        ConvertTo-Json -Depth 4 -Compress -InputObject $objOnePayloadCommit
+    )
+    $objForwardCompatibleCommit | Add-Member -NotePropertyName future_field `
+        -NotePropertyValue 'bounded and ignored'
+    $strForwardCompatiblePayload = ConvertTo-Json -Depth 4 -Compress `
+        -InputObject ([object[]] @($objForwardCompatibleCommit))
+    if (@(Read-CreatedPushCommitEvidence `
+            -PushCommitEvidenceJson $strForwardCompatiblePayload `
+            -EventHeadRevision $strOneCommit `
+            -EventHeadDistinct 'true').Count -ne 1) {
+        throw 'A bounded extra inert commit field was not ignored deliberately.'
+    }
     $objOneContext = Get-CreatedRefBoundaryContext `
         -RepositoryRootPath $strTopologyRoot `
         -DestinationRef 'refs/heads/new-one' `
         -HeadRevision $strOneCommit -EventHeadRevision $strOneCommit `
-        -EventHeadDistinct 'true' -PushCommitCount '1' `
-        -PushDistinctCommitCount '1' -PushCommitEvidenceJson $strOnePayload `
+        -EventHeadDistinct 'true' -PushCommitEvidenceJson $strOnePayload `
         -OtherRefEvidenceJson $strRootEvidence
     $arrOnePaths = @(Read-GitPublishedEndpointChangedPath `
             -RepositoryRootPath $strTopologyRoot `
@@ -259,14 +317,15 @@ try {
     & git -C $strTopologyRoot add -- two.txt
     & git -C $strTopologyRoot commit --quiet -m two
     $strTwoCommit = ([string] (& git -C $strTopologyRoot rev-parse HEAD)).Trim()
-    $strManyPayload = ConvertTo-Json -Compress -InputObject `
-        ([object[]] @($strOneCommit, $strTwoCommit))
+    $objTwoPayloadCommit = ConvertTo-CreatedPushCommitEvidenceObject `
+        -Id $strTwoCommit -Distinct $true
+    $strManyPayload = ConvertTo-Json -Depth 4 -Compress -InputObject `
+        ([object[]] @($objOnePayloadCommit, $objTwoPayloadCommit))
     $objManyContext = Get-CreatedRefBoundaryContext `
         -RepositoryRootPath $strTopologyRoot `
         -DestinationRef 'refs/heads/new-many' `
         -HeadRevision $strTwoCommit -EventHeadRevision $strTwoCommit `
-        -EventHeadDistinct 'true' -PushCommitCount '2' `
-        -PushDistinctCommitCount '2' -PushCommitEvidenceJson $strManyPayload `
+        -EventHeadDistinct 'true' -PushCommitEvidenceJson $strManyPayload `
         -OtherRefEvidenceJson $strRootEvidence
     $arrManyPaths = @(Read-GitPublishedEndpointChangedPath `
             -RepositoryRootPath $strTopologyRoot `
@@ -318,14 +377,14 @@ try {
         }
     )
     $strMergeEvidence = ConvertTo-Json -Compress -InputObject $arrMergeEvidence
-    $strMergePayload = ConvertTo-Json -Compress -InputObject `
-        ([object[]] @($strMergeCommit))
+    $strMergePayload = ConvertTo-Json -Depth 4 -Compress -InputObject `
+        ([object[]] @((ConvertTo-CreatedPushCommitEvidenceObject `
+                    -Id $strMergeCommit -Distinct $true)))
     $objMergeContext = Get-CreatedRefBoundaryContext `
         -RepositoryRootPath $strTopologyRoot `
         -DestinationRef 'refs/heads/new-merge' `
         -HeadRevision $strMergeCommit -EventHeadRevision $strMergeCommit `
-        -EventHeadDistinct 'true' -PushCommitCount '1' `
-        -PushDistinctCommitCount '1' -PushCommitEvidenceJson $strMergePayload `
+        -EventHeadDistinct 'true' -PushCommitEvidenceJson $strMergePayload `
         -OtherRefEvidenceJson $strMergeEvidence
     $arrMergePaths = @(Read-GitPublishedEndpointChangedPath `
             -RepositoryRootPath $strTopologyRoot `
@@ -341,14 +400,14 @@ try {
         throw 'The merge created-ref fixture lost a parent boundary.'
     }
 
-    $strRootPayload = ConvertTo-Json -Compress -InputObject `
-        ([object[]] @($strRootCommit))
+    $strRootPayload = ConvertTo-Json -Depth 4 -Compress -InputObject `
+        ([object[]] @((ConvertTo-CreatedPushCommitEvidenceObject `
+                    -Id $strRootCommit -Distinct $true)))
     $objGenuineRootContext = Get-CreatedRefBoundaryContext `
         -RepositoryRootPath $strTopologyRoot `
         -DestinationRef 'refs/heads/new-root' `
         -HeadRevision $strRootCommit -EventHeadRevision $strRootCommit `
-        -EventHeadDistinct 'true' -PushCommitCount '1' `
-        -PushDistinctCommitCount '1' -PushCommitEvidenceJson $strRootPayload `
+        -EventHeadDistinct 'true' -PushCommitEvidenceJson $strRootPayload `
         -OtherRefEvidenceJson '[]'
     $arrGenuineRootPaths = @(Read-GitPublishedEndpointChangedPath `
             -RepositoryRootPath $strTopologyRoot `
@@ -363,6 +422,8 @@ try {
         throw 'The genuine-root created-ref fixture did not use the final tree.'
     }
 
+    $strTwoOnlyPayload = ConvertTo-Json -Depth 4 -Compress -InputObject `
+        ([object[]] @($objTwoPayloadCommit))
     foreach ($objRejectedFixture in @(
             [pscustomobject]@{
                 Name = 'event head mismatch'
@@ -370,21 +431,17 @@ try {
                 Arguments = @{
                     HeadRevision = $strOneCommit
                     EventHeadRevision = $strRootCommit
-                    PushCommitCount = '1'
-                    PushDistinctCommitCount = '1'
                     PushCommitEvidenceJson = $strOnePayload
                     OtherRefEvidenceJson = $strRootEvidence
                 }
             },
             [pscustomobject]@{
-                Name = 'truncated payload'
-                Expected = 'commit array is truncated'
+                Name = 'graph mismatch'
+                Expected = 'distinct commit set contradicts'
                 Arguments = @{
                     HeadRevision = $strTwoCommit
                     EventHeadRevision = $strTwoCommit
-                    PushCommitCount = '2'
-                    PushDistinctCommitCount = '2'
-                    PushCommitEvidenceJson = $strOnePayload
+                    PushCommitEvidenceJson = $strTwoOnlyPayload
                     OtherRefEvidenceJson = $strRootEvidence
                 }
             },
@@ -394,8 +451,6 @@ try {
                 Arguments = @{
                     HeadRevision = $strOneCommit
                     EventHeadRevision = $strOneCommit
-                    PushCommitCount = '1'
-                    PushDistinctCommitCount = '1'
                     PushCommitEvidenceJson = $strOnePayload
                     OtherRefEvidenceJson = $strRootEvidence
                 }
@@ -417,8 +472,6 @@ try {
                 -HeadRevision $objArguments.HeadRevision `
                 -EventHeadRevision $objArguments.EventHeadRevision `
                 -EventHeadDistinct 'true' `
-                -PushCommitCount $objArguments.PushCommitCount `
-                -PushDistinctCommitCount $objArguments.PushDistinctCommitCount `
                 -PushCommitEvidenceJson $objArguments.PushCommitEvidenceJson `
                 -OtherRefEvidenceJson $objArguments.OtherRefEvidenceJson
             throw "Rejected created-ref fixture passed: $($objRejectedFixture.Name)"
@@ -437,6 +490,144 @@ try {
                 )) {
                 throw "Created-ref rejection '$($objRejectedFixture.Name)' returned: $strRejectedMessage"
             }
+        }
+    }
+
+    $objBoundaryCommand = Get-Command Get-CreatedRefBoundaryContext
+    if ($objBoundaryCommand.Parameters.ContainsKey('PushCommitCount') -or
+        $objBoundaryCommand.Parameters.ContainsKey('PushDistinctCommitCount')) {
+        throw 'Created-ref validation still requires undocumented push count fields.'
+    }
+
+    $objInvalidIdCommit = ConvertTo-CreatedPushCommitEvidenceObject `
+        -Id ('g' * 40) -Distinct $true
+    $objNotDistinctHeadCommit = ConvertTo-CreatedPushCommitEvidenceObject `
+        -Id $strOneCommit -Distinct $false
+    $arrEvidenceParserRejections = @(
+        [pscustomobject]@{
+            Name = 'malformed JSON'
+            Json = '{'
+            Head = $strOneCommit
+            Distinct = 'true'
+            Expected = 'malformed'
+        },
+        [pscustomobject]@{
+            Name = 'malformed commit object'
+            Json = '[{}]'
+            Head = $strOneCommit
+            Distinct = 'true'
+            Expected = 'invalid object shape'
+        },
+        [pscustomobject]@{
+            Name = 'invalid commit ID'
+            Json = ConvertTo-Json -Depth 4 -Compress -InputObject `
+                ([object[]] @($objInvalidIdCommit))
+            Head = $strOneCommit
+            Distinct = 'true'
+            Expected = 'invalid identity or scalar'
+        },
+        [pscustomobject]@{
+            Name = 'duplicate commit ID'
+            Json = ConvertTo-Json -Depth 4 -Compress -InputObject `
+                ([object[]] @($objOnePayloadCommit, $objOnePayloadCommit))
+            Head = $strOneCommit
+            Distinct = 'true'
+            Expected = 'invalid identity or scalar'
+        },
+        [pscustomobject]@{
+            Name = 'head mismatch'
+            Json = $strOnePayload
+            Head = $strTwoCommit
+            Distinct = 'true'
+            Expected = 'does not end at the event head'
+        },
+        [pscustomobject]@{
+            Name = 'head distinct mismatch'
+            Json = ConvertTo-Json -Depth 4 -Compress -InputObject `
+                ([object[]] @($objNotDistinctHeadCommit))
+            Head = $strOneCommit
+            Distinct = 'true'
+            Expected = 'does not end at the event head'
+        },
+        [pscustomobject]@{
+            Name = 'oversized evidence'
+            Json = '[' + (' ' * $intPushCommitEvidenceMaximumBytes) + ']'
+            Head = $strOneCommit
+            Distinct = 'true'
+            Expected = 'exceeds'
+        }
+    )
+    foreach ($objParserRejection in $arrEvidenceParserRejections) {
+        try {
+            $null = @(
+                Read-CreatedPushCommitEvidence `
+                    -PushCommitEvidenceJson $objParserRejection.Json `
+                    -EventHeadRevision $objParserRejection.Head `
+                    -EventHeadDistinct $objParserRejection.Distinct
+            )
+            throw "Rejected evidence parser fixture passed: $($objParserRejection.Name)"
+        }
+        catch {
+            $strRejectedMessage = $_.Exception.Message
+            if ($strRejectedMessage.StartsWith(
+                    'Rejected evidence parser fixture passed:',
+                    [StringComparison]::Ordinal
+                )) {
+                throw
+            }
+            if (-not $strRejectedMessage.Contains(
+                    $objParserRejection.Expected,
+                    [StringComparison]::OrdinalIgnoreCase
+                )) {
+                throw "Evidence parser rejection '$($objParserRejection.Name)' returned: $strRejectedMessage"
+            }
+        }
+    }
+
+    $arrCapCommitEvidence = [object[]] @(
+        for ($intCommitIndex = 1;
+            $intCommitIndex -le $intMaximumPayloadCommitCount;
+            $intCommitIndex++) {
+            ConvertTo-CreatedPushCommitEvidenceObject `
+                -Id ('{0:x40}' -f $intCommitIndex) -Distinct $false
+        }
+    )
+    $arrBelowCapCommitEvidence = [object[]] @(
+        $arrCapCommitEvidence[0..($intMaximumPayloadCommitCount - 2)]
+    )
+    $strBelowCapCommitEvidence = ConvertTo-Json -Depth 4 -Compress `
+        -InputObject $arrBelowCapCommitEvidence
+    $arrBelowCapNormalized = @(
+        Read-CreatedPushCommitEvidence `
+            -PushCommitEvidenceJson $strBelowCapCommitEvidence `
+            -EventHeadRevision $arrBelowCapCommitEvidence[-1].id `
+            -EventHeadDistinct 'false'
+    )
+    if ($arrBelowCapNormalized.Count -ne
+        ($intMaximumPayloadCommitCount - 1)) {
+        throw 'The 2047-object created-push evidence fixture was not preserved.'
+    }
+    $strAtCapCommitEvidence = ConvertTo-Json -Depth 4 -Compress `
+        -InputObject $arrCapCommitEvidence
+    try {
+        $null = @(
+            Read-CreatedPushCommitEvidence `
+                -PushCommitEvidenceJson $strAtCapCommitEvidence `
+                -EventHeadRevision $arrCapCommitEvidence[-1].id `
+                -EventHeadDistinct 'false'
+        )
+        throw 'The 2048-object created-push evidence fixture passed.'
+    }
+    catch {
+        if ($_.Exception.Message -ceq
+            'The 2048-object created-push evidence fixture passed.') {
+            throw
+        }
+        if (-not $_.Exception.Message.Contains(
+                '2048-object truncation cap',
+                [StringComparison]::Ordinal
+            )) {
+            throw "The 2048-object fixture returned: $($_.Exception.Message)"
         }
     }
 }

--- a/.github/workflows/Test-AgentInstructions.SelfTest.ps1
+++ b/.github/workflows/Test-AgentInstructions.SelfTest.ps1
@@ -1,18 +1,18 @@
 # .SYNOPSIS
-# Runs the extracted agent-instruction validator self-tests.
+# Runs the extracted published-endpoint metadata self-tests.
 #
 # .DESCRIPTION
-# Validates explicit revision-parent behavior and day-precision metadata
-# freshness with functions loaded by Test-AgentInstructions.ps1.
+# Validates final-state metadata arithmetic and authenticated endpoint handling
+# with functions loaded by Test-AgentInstructions.ps1.
 #
 # .PARAMETER RepositoryRootPath
 # The absolute path of the repository that supplies Git and document fixtures.
 #
 # .PARAMETER Revision
-# The exact Git commit to use for revision-parent tests.
+# The exact Git commit used as an authenticated endpoint fixture.
 #
 # .PARAMETER MaximumBytes
-# The maximum permitted byte count for governed document reads.
+# The maximum permitted byte count for bounded Git path reads.
 #
 # .PARAMETER MaximumMetadataUtcDate
 # The latest trusted UTC calendar date permitted in metadata fixtures.
@@ -29,21 +29,16 @@
 # None. The script throws when a self-test fails.
 #
 # .NOTES
-# Version: 1.0.20260830.0
+# Version: 1.2.20260831.0
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([void])]
 param(
-    [Parameter(Mandatory)]
-    [string] $RepositoryRootPath,
-
-    [Parameter(Mandatory)]
-    [string] $Revision,
-
+    [Parameter(Mandatory)][string] $RepositoryRootPath,
+    [Parameter(Mandatory)][string] $Revision,
     [Parameter(Mandatory)]
     [ValidateRange(1, 2147483646)]
     [int] $MaximumBytes,
-
     [Parameter(Mandatory)]
     [ValidatePattern('^\d{4}-\d{2}-\d{2}$')]
     [string] $MaximumMetadataUtcDate
@@ -54,203 +49,403 @@ if ($arrDeclaredOutputTypes.Count -ne 1 -or
     $arrDeclaredOutputTypes[0] -cne 'System.Void') {
     throw 'The extracted self-test must declare one void output contract.'
 }
-
 $script:strMaximumMetadataUtcDate = $MaximumMetadataUtcDate
-$objParentContext = Get-GovernedDocumentParentContext `
-    -RepositoryRootPath $RepositoryRootPath `
-    -RepositoryRelativePath 'AGENTS.md' `
-    -MaximumBytes $MaximumBytes `
-    -Revision $Revision
-if ($null -eq $objParentContext.ParentRevision) {
-    if ($null -ne $objParentContext.ParentContent -or
-        $objParentContext.ExpectedUtcDate -cne '' -or
-        $objParentContext.IsWorktreeTransition) {
-        throw 'The explicit root revision context is invalid.'
+
+$strBaseline = @(
+    '# Endpoint fixture'
+    '**Version:** 1.0.20260830.0'
+    '## Metadata'
+    '- **Status:** Active'
+    '- **Owner:** Repository Maintainers'
+    '- **Last Updated:** 2026-08-30'
+    '- **Scope:** Extracted final-state regression.'
+    '## Content'
+    'Published baseline.'
+) -join "`n"
+$strFinal = @(
+    '# Endpoint fixture'
+    '**Version:** 1.0.20260831.0'
+    '## Metadata'
+    '- **Status:** Accepted'
+    '- **Owner:** Repository Maintainers'
+    '- **Last Updated:** 2026-08-31'
+    '- **Scope:** Extracted final-state regression.'
+    '## Content'
+    'Corrected published final.'
+) -join "`n"
+if (@(Get-PublishedEndpointMetadataFailure -Name 'fixture.md' `
+        -CurrentContent $strFinal -ParentContent $strBaseline `
+        -ExpectedUtcDate '2026-08-31' `
+        -IsNewDocumentTransition $false).Count -ne 0) {
+    throw 'The extracted published-final regression was rejected.'
+}
+
+$strHigherTerminalRevision = $strFinal.Replace(
+    '**Version:** 1.0.20260831.0',
+    '**Version:** 1.0.20260831.3'
+)
+if (@(Get-PublishedEndpointMetadataFailure `
+    -Name 'fixture.md' -CurrentContent $strHigherTerminalRevision `
+    -ParentContent $strBaseline -ExpectedUtcDate '2026-08-31' `
+    -IsNewDocumentTransition $false).Count -ne 0) {
+    throw 'The extracted higher terminal revision was rejected.'
+}
+
+$strSameTupleRollback = $strBaseline.Replace(
+    '**Version:** 1.0.20260830.0',
+    '**Version:** 1.0.20260830.4'
+)
+$arrRollbackFailures = @(Get-PublishedEndpointMetadataFailure `
+    -Name 'fixture.md' -CurrentContent $strBaseline `
+    -ParentContent $strSameTupleRollback -ExpectedUtcDate '2026-08-30' `
+    -IsNewDocumentTransition $false)
+if ($arrRollbackFailures -cnotcontains
+    'fixture.md Version revision must not decrease from 4 to 0.') {
+    throw 'The extracted same-tuple revision rollback did not fail closed.'
+}
+
+$strDateRollback = $strFinal.Replace(
+    '**Version:** 1.0.20260831.0',
+    '**Version:** 2.0.20260829.0'
+).Replace('- **Last Updated:** 2026-08-31',
+    '- **Last Updated:** 2026-08-29')
+if (-not (@(Get-PublishedEndpointMetadataFailure `
+        -Name 'fixture.md' -CurrentContent $strDateRollback `
+        -ParentContent $strBaseline -ExpectedUtcDate '2026-08-29' `
+        -IsNewDocumentTransition $false) -match
+        'Version date must not move backward')) {
+    throw 'The extracted independent date rollback did not fail closed.'
+}
+
+$strTupleRollback = $strFinal.Replace(
+    '**Version:** 1.0.20260831.0',
+    '**Version:** 0.9.20260831.0'
+)
+if (-not (@(Get-PublishedEndpointMetadataFailure `
+        -Name 'fixture.md' -CurrentContent $strTupleRollback `
+        -ParentContent $strBaseline -ExpectedUtcDate '2026-08-31' `
+        -IsNewDocumentTransition $false) -match
+        'Version major and minor tuple must not move backward')) {
+    throw 'The extracted independent major/minor rollback did not fail closed.'
+}
+
+$strUnversionedBaseline = @(
+    '# Unversioned endpoint fixture'
+    '## Metadata'
+    '- **Status:** Active'
+    '- **Owner:** Repository Maintainers'
+    '- **Last Updated:** 2026-08-30'
+    '- **Scope:** Extracted unversioned final-state regression.'
+    '## Content'
+    'Published baseline.'
+) -join "`n"
+$strUnversionedFinal = $strUnversionedBaseline.Replace(
+    '- **Last Updated:** 2026-08-30',
+    '- **Last Updated:** 2026-08-31'
+).Replace('Published baseline.', 'Published final.')
+if (@(Get-PublishedEndpointLastUpdatedFailure -Name 'fixture.md' `
+        -CurrentContent $strUnversionedFinal `
+        -BaseContent $strUnversionedBaseline `
+        -TrustedEventUtcDate '2026-08-31' `
+        -RequireCurrentMaximumDateForRenderedChange $false).Count -ne 0) {
+    throw 'The extracted unversioned published-final regression was rejected.'
+}
+$arrStaleFailures = @(Get-PublishedEndpointLastUpdatedFailure `
+    -Name 'fixture.md' `
+    -CurrentContent ($strUnversionedBaseline + "`nRendered final change.") `
+    -BaseContent $strUnversionedBaseline `
+    -TrustedEventUtcDate '2026-08-31')
+if (-not ($arrStaleFailures -match 'Last Updated must be 2026-08-31')) {
+    throw 'The extracted stale unversioned final did not fail closed.'
+}
+
+Assert-PublishedEndpointContext -RepositoryRootPath $RepositoryRootPath `
+    -EventName 'push' -PullRequestAction '' `
+    -BaselineRevision $Revision -FinalRevision $Revision `
+    -BaselineAbsent $false -PullRequestBaseChanged ''
+if (@(Read-GitPublishedEndpointChangedPath `
+        -RepositoryRootPath $RepositoryRootPath `
+        -BaselineRevision $Revision -FinalRevision $Revision `
+        -BaselineAbsent $false -MaximumBytes $MaximumBytes).Count -ne 0) {
+    throw 'Identical extracted endpoint trees reported changed paths.'
+}
+
+$strTempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+$strTopologyRoot = [IO.Path]::Combine(
+    $strTempRoot,
+    'agent-instruction-created-ref-' + [Guid]::NewGuid().ToString('N')
+)
+[void] [IO.Directory]::CreateDirectory($strTopologyRoot)
+try {
+    $objUtf8 = [Text.UTF8Encoding]::new($false)
+    & git -C $strTopologyRoot init --quiet
+    & git -C $strTopologyRoot config user.name 'Created-ref self-test'
+    & git -C $strTopologyRoot config user.email 'created-ref@example.invalid'
+    [IO.File]::WriteAllText(
+        (Join-Path $strTopologyRoot 'root.txt'),
+        "root`n",
+        $objUtf8
+    )
+    & git -C $strTopologyRoot add -- root.txt
+    & git -C $strTopologyRoot commit --quiet -m root
+    $strRootCommit = ([string] (& git -C $strTopologyRoot rev-parse HEAD)).Trim()
+
+    & git -C $strTopologyRoot update-ref `
+        refs/remotes/event/created-other-0000 $strRootCommit
+    $arrRootEvidence = [object[]] @(
+        [pscustomobject]@{
+            ref = 'refs/heads/existing'
+            object = $strRootCommit
+            commit = $strRootCommit
+            local_ref = 'refs/remotes/event/created-other-0000'
+        }
+    )
+    $strRootEvidence = ConvertTo-Json -Compress -InputObject $arrRootEvidence
+    $objZeroContext = Get-CreatedRefBoundaryContext `
+        -RepositoryRootPath $strTopologyRoot `
+        -DestinationRef 'refs/heads/new-zero' `
+        -HeadRevision $strRootCommit -EventHeadRevision $strRootCommit `
+        -EventHeadDistinct 'false' -PushCommitCount '0' `
+        -PushDistinctCommitCount '0' -PushCommitEvidenceJson '[]' `
+        -OtherRefEvidenceJson $strRootEvidence
+    if (@($objZeroContext.IntroducedCommitRevisions).Count -ne 0 -or
+        @($objZeroContext.BoundaryRevisions).Count -ne 0 -or
+        @(Read-GitPublishedEndpointChangedPath `
+            -RepositoryRootPath $strTopologyRoot `
+            -BaselineRevision ('0' * 40) -FinalRevision $strRootCommit `
+            -BaselineAbsent $true -NewRefBoundaryRevision @() `
+            -NewRefIntroducedCommitRevision @() `
+            -MaximumBytes $MaximumBytes).Count -ne 0) {
+        throw 'The zero-introduced created-ref fixture widened its baseline.'
     }
-}
-elseif ($objParentContext.ParentRevision -cne "$Revision`^1" -or
-    [string]::IsNullOrEmpty($objParentContext.ParentContent)) {
-    throw 'The explicit child revision context is invalid.'
-}
 
-$strRootRevision = [string] (
-    & git -C $RepositoryRootPath rev-list --max-parents=0 -n 1 $Revision
-)
-if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrEmpty($strRootRevision.Trim())) {
-    throw 'Could not resolve a zero-parent revision.'
-}
-$objRootParentContext = Get-GovernedDocumentParentContext `
-    -RepositoryRootPath $RepositoryRootPath `
-    -RepositoryRelativePath 'AGENTS.md' `
-    -MaximumBytes $MaximumBytes `
-    -Revision $strRootRevision.Trim()
-if ($null -ne $objRootParentContext.ParentRevision -or
-    $null -ne $objRootParentContext.ParentContent -or
-    $objRootParentContext.ExpectedUtcDate -cne '' -or
-    $objRootParentContext.IsWorktreeTransition) {
-    throw 'The zero-parent revision context is invalid.'
-}
-
-$strGuidePath = '.github/workflows/scripts-README.md'
-$strGuideContent = Get-Content -LiteralPath (
-    Join-Path $RepositoryRootPath $strGuidePath
-) -Raw
-$objGuideMetadata = Get-DocumentMetadataContext `
-    -Content $strGuideContent -RequiresVersion $false
-if ($null -ne $objGuideMetadata.Failure) {
-    throw 'The unversioned date fixture metadata is invalid.'
-}
-$strRepositoryDate = $objGuideMetadata.UpdatedDate
-$strRepositoryDateLine = "- **Last Updated:** $strRepositoryDate"
-if ([regex]::Matches(
-        $strGuideContent,
-        '(?m)^' + [regex]::Escape($strRepositoryDateLine) + '$'
-    ).Count -ne 1) {
-    throw 'The unversioned date fixture has no unique metadata date.'
-}
-$strGuideContent = $strGuideContent.Replace(
-    $strRepositoryDateLine,
-    "- **Last Updated:** $MaximumMetadataUtcDate"
-)
-$objGuideMetadata = Get-DocumentMetadataContext `
-    -Content $strGuideContent -RequiresVersion $false
-if ($null -ne $objGuideMetadata.Failure -or
-    $objGuideMetadata.UpdatedDate -cne $MaximumMetadataUtcDate) {
-    throw 'The synthetic unversioned date fixture is invalid.'
-}
-$strMaximumDate = $MaximumMetadataUtcDate
-$strPreviousDate = ([datetime]::ParseExact(
-        $strMaximumDate,
-        'yyyy-MM-dd',
-        [Globalization.CultureInfo]::InvariantCulture
-    )).AddDays(-1).ToString('yyyy-MM-dd')
-$strFutureDate = ([datetime]::ParseExact(
-        $strMaximumDate,
-        'yyyy-MM-dd',
-        [Globalization.CultureInfo]::InvariantCulture
-    )).AddDays(1).ToString('yyyy-MM-dd')
-$strRenderedGuide = $strGuideContent + "`nRepeated same-day change.`n"
-if (@(Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $strGuidePath -CurrentContent $strRenderedGuide `
-            -BaseContent $strGuideContent -TrustedEventUtcDate '' `
-            -RequireCurrentMaximumDateForRenderedChange $true).Count -ne 0) {
-    throw 'A valid repeated same-day unversioned change was rejected.'
-}
-
-$strPreviousGuide = $strGuideContent.Replace(
-    "- **Last Updated:** $strMaximumDate",
-    "- **Last Updated:** $strPreviousDate"
-)
-$strFutureGuide = $strGuideContent.Replace(
-    "- **Last Updated:** $strMaximumDate",
-    "- **Last Updated:** $strFutureDate"
-)
-$strMissingDateGuide = $strGuideContent.Replace(
-    "- **Last Updated:** $strMaximumDate`r`n",
-    ''
-).Replace(
-    "- **Last Updated:** $strMaximumDate`n",
-    ''
-)
-$strHistoricalAdoption = $strPreviousGuide + "`nHistorical adoption.`n"
-if (@(Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $strGuidePath -CurrentContent $strHistoricalAdoption `
-            -BaseContent $null -TrustedEventUtcDate '').Count -ne 0) {
-    throw 'A valid parentless historical adoption was rejected.'
-}
-if (@(Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $strGuidePath -CurrentContent $strRenderedGuide `
-            -BaseContent $strPreviousGuide -TrustedEventUtcDate '').Count -ne 0) {
-    throw 'A valid historical date advance was rejected.'
-}
-$arrHistoricalStaleFailures = @(Get-LastUpdatedMetadataFreshnessFailure `
-        -Name $strGuidePath `
-        -CurrentContent ($strPreviousGuide + "`nHistorical stale change.`n") `
-        -BaseContent $strPreviousGuide -TrustedEventUtcDate '')
-if (-not ($arrHistoricalStaleFailures -match 'must advance from')) {
-    throw 'A historical same-date change did not require advancement.'
-}
-$strHistoricalSameDayChange = $strPreviousGuide +
-    "`nAuthenticated same-day historical change.`n"
-if (@(Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $strGuidePath -CurrentContent $strHistoricalSameDayChange `
-            -BaseContent $strPreviousGuide -TrustedEventUtcDate '' `
-            -ModifyingCommitUtcDate $strPreviousDate `
-            -AllowSameDateForExactRestoration $true).Count -ne 0) {
-    throw 'A commit-date-matched exact restoration was rejected.'
-}
-$arrHistoricalLaterCommitFailures = @(Get-LastUpdatedMetadataFreshnessFailure `
-        -Name $strGuidePath -CurrentContent $strHistoricalSameDayChange `
-        -BaseContent $strPreviousGuide -TrustedEventUtcDate '' `
-        -ModifyingCommitUtcDate $strMaximumDate `
-        -AllowSameDateForExactRestoration $true)
-if (-not ($arrHistoricalLaterCommitFailures -match 'must advance from')) {
-    throw 'A stale date was accepted for a later modifying commit.'
-}
-$strEventMatchedAdvance = $strGuideContent +
-    "`nHistorical event-matched advancement.`n"
-if (@(Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $strGuidePath -CurrentContent $strEventMatchedAdvance `
-            -BaseContent $strPreviousGuide `
-            -TrustedEventUtcDate $strMaximumDate).Count -ne 0) {
-    throw 'A valid event-matched historical advancement was rejected.'
-}
-$arrEventMatchedStaleFailures = @(Get-LastUpdatedMetadataFreshnessFailure `
-        -Name $strGuidePath `
-        -CurrentContent ($strPreviousGuide + "`nEvent-matched stale change.`n") `
-        -BaseContent $strPreviousGuide `
-        -TrustedEventUtcDate $strPreviousDate)
-if (-not ($arrEventMatchedStaleFailures -match 'must advance from')) {
-    throw 'An event-matched historical same-date change did not require advancement.'
-}
-$arrDateNegativeCases = @(
-    [pscustomobject]@{
-        Name = 'stale no-event date'
-        Current = $strPreviousGuide + "`nStale change.`n"
-        Base = $strPreviousGuide
-        Event = ''
-        Failure = "must be $strMaximumDate"
-    },
-    [pscustomobject]@{
-        Name = 'future date'
-        Current = $strFutureGuide
-        Base = $strGuideContent
-        Event = ''
-        Failure = 'later than trusted UTC'
-    },
-    [pscustomobject]@{
-        Name = 'backward date'
-        Current = $strPreviousGuide
-        Base = $strGuideContent
-        Event = ''
-        Failure = 'must not move backward'
-    },
-    [pscustomobject]@{
-        Name = 'missing Last Updated'
-        Current = $strMissingDateGuide
-        Base = $strGuideContent
-        Event = ''
-        Failure = 'must contain one exact top-level Last Updated list item'
-    },
-    [pscustomobject]@{
-        Name = 'trusted-event mismatch'
-        Current = $strRenderedGuide
-        Base = $strGuideContent
-        Event = $strPreviousDate
-        Failure = "must be $strPreviousDate"
+    [IO.File]::WriteAllText(
+        (Join-Path $strTopologyRoot 'one.txt'),
+        "one`n",
+        $objUtf8
+    )
+    & git -C $strTopologyRoot add -- one.txt
+    & git -C $strTopologyRoot commit --quiet -m one
+    $strOneCommit = ([string] (& git -C $strTopologyRoot rev-parse HEAD)).Trim()
+    $strOnePayload = ConvertTo-Json -Compress -InputObject `
+        ([object[]] @($strOneCommit))
+    $objOneContext = Get-CreatedRefBoundaryContext `
+        -RepositoryRootPath $strTopologyRoot `
+        -DestinationRef 'refs/heads/new-one' `
+        -HeadRevision $strOneCommit -EventHeadRevision $strOneCommit `
+        -EventHeadDistinct 'true' -PushCommitCount '1' `
+        -PushDistinctCommitCount '1' -PushCommitEvidenceJson $strOnePayload `
+        -OtherRefEvidenceJson $strRootEvidence
+    $arrOnePaths = @(Read-GitPublishedEndpointChangedPath `
+            -RepositoryRootPath $strTopologyRoot `
+            -BaselineRevision ('0' * 40) -FinalRevision $strOneCommit `
+            -BaselineAbsent $true `
+            -NewRefBoundaryRevision $objOneContext.BoundaryRevisions `
+            -NewRefIntroducedCommitRevision `
+                $objOneContext.IntroducedCommitRevisions `
+            -MaximumBytes $MaximumBytes)
+    if (@($objOneContext.IntroducedCommitRevisions).Count -ne 1 -or
+        @($objOneContext.BoundaryRevisions).Count -ne 1 -or
+        $objOneContext.BoundaryRevisions[0] -cne $strRootCommit -or
+        $arrOnePaths.Count -ne 1 -or $arrOnePaths[0] -cne 'one.txt') {
+        throw 'The one-introduced created-ref fixture found an incorrect boundary.'
     }
-)
-foreach ($objDateNegativeCase in $arrDateNegativeCases) {
-    $strDateFailures = @(Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $strGuidePath `
-            -CurrentContent $objDateNegativeCase.Current `
-            -BaseContent $objDateNegativeCase.Base `
-            -TrustedEventUtcDate $objDateNegativeCase.Event `
-            -RequireCurrentMaximumDateForRenderedChange $true) -join '; '
-    if (-not $strDateFailures.Contains(
-            $objDateNegativeCase.Failure,
-            [StringComparison]::Ordinal
+
+    [IO.File]::WriteAllText(
+        (Join-Path $strTopologyRoot 'two.txt'),
+        "two`n",
+        $objUtf8
+    )
+    & git -C $strTopologyRoot add -- two.txt
+    & git -C $strTopologyRoot commit --quiet -m two
+    $strTwoCommit = ([string] (& git -C $strTopologyRoot rev-parse HEAD)).Trim()
+    $strManyPayload = ConvertTo-Json -Compress -InputObject `
+        ([object[]] @($strOneCommit, $strTwoCommit))
+    $objManyContext = Get-CreatedRefBoundaryContext `
+        -RepositoryRootPath $strTopologyRoot `
+        -DestinationRef 'refs/heads/new-many' `
+        -HeadRevision $strTwoCommit -EventHeadRevision $strTwoCommit `
+        -EventHeadDistinct 'true' -PushCommitCount '2' `
+        -PushDistinctCommitCount '2' -PushCommitEvidenceJson $strManyPayload `
+        -OtherRefEvidenceJson $strRootEvidence
+    $arrManyPaths = @(Read-GitPublishedEndpointChangedPath `
+            -RepositoryRootPath $strTopologyRoot `
+            -BaselineRevision ('0' * 40) -FinalRevision $strTwoCommit `
+            -BaselineAbsent $true `
+            -NewRefBoundaryRevision $objManyContext.BoundaryRevisions `
+            -NewRefIntroducedCommitRevision `
+                $objManyContext.IntroducedCommitRevisions `
+            -MaximumBytes $MaximumBytes)
+    if (@($objManyContext.IntroducedCommitRevisions).Count -ne 2 -or
+        @($objManyContext.BoundaryRevisions).Count -ne 1 -or
+        [string]::Join("`n", $arrManyPaths) -cne "one.txt`ntwo.txt") {
+        throw 'The many-introduced created-ref fixture lost changed paths.'
+    }
+
+    & git -C $strTopologyRoot checkout --quiet -b left $strRootCommit
+    [IO.File]::WriteAllText(
+        (Join-Path $strTopologyRoot 'left.txt'), "left`n", $objUtf8
+    )
+    & git -C $strTopologyRoot add -- left.txt
+    & git -C $strTopologyRoot commit --quiet -m left
+    $strLeftCommit = ([string] (& git -C $strTopologyRoot rev-parse HEAD)).Trim()
+    & git -C $strTopologyRoot checkout --quiet -b right $strRootCommit
+    [IO.File]::WriteAllText(
+        (Join-Path $strTopologyRoot 'right.txt'), "right`n", $objUtf8
+    )
+    & git -C $strTopologyRoot add -- right.txt
+    & git -C $strTopologyRoot commit --quiet -m right
+    $strRightCommit = ([string] (& git -C $strTopologyRoot rev-parse HEAD)).Trim()
+    & git -C $strTopologyRoot checkout --quiet left
+    & git -C $strTopologyRoot merge --quiet --no-ff right -m merge
+    $strMergeCommit = ([string] (& git -C $strTopologyRoot rev-parse HEAD)).Trim()
+    & git -C $strTopologyRoot update-ref `
+        refs/remotes/event/created-other-0000 $strLeftCommit
+    & git -C $strTopologyRoot update-ref `
+        refs/remotes/event/created-other-0001 $strRightCommit
+    $arrMergeEvidence = [object[]] @(
+        [pscustomobject]@{
+            ref = 'refs/heads/left'
+            object = $strLeftCommit
+            commit = $strLeftCommit
+            local_ref = 'refs/remotes/event/created-other-0000'
+        },
+        [pscustomobject]@{
+            ref = 'refs/heads/right'
+            object = $strRightCommit
+            commit = $strRightCommit
+            local_ref = 'refs/remotes/event/created-other-0001'
+        }
+    )
+    $strMergeEvidence = ConvertTo-Json -Compress -InputObject $arrMergeEvidence
+    $strMergePayload = ConvertTo-Json -Compress -InputObject `
+        ([object[]] @($strMergeCommit))
+    $objMergeContext = Get-CreatedRefBoundaryContext `
+        -RepositoryRootPath $strTopologyRoot `
+        -DestinationRef 'refs/heads/new-merge' `
+        -HeadRevision $strMergeCommit -EventHeadRevision $strMergeCommit `
+        -EventHeadDistinct 'true' -PushCommitCount '1' `
+        -PushDistinctCommitCount '1' -PushCommitEvidenceJson $strMergePayload `
+        -OtherRefEvidenceJson $strMergeEvidence
+    $arrMergePaths = @(Read-GitPublishedEndpointChangedPath `
+            -RepositoryRootPath $strTopologyRoot `
+            -BaselineRevision ('0' * 40) -FinalRevision $strMergeCommit `
+            -BaselineAbsent $true `
+            -NewRefBoundaryRevision $objMergeContext.BoundaryRevisions `
+            -NewRefIntroducedCommitRevision `
+                $objMergeContext.IntroducedCommitRevisions `
+            -MaximumBytes $MaximumBytes)
+    if (@($objMergeContext.IntroducedCommitRevisions).Count -ne 1 -or
+        @($objMergeContext.BoundaryRevisions).Count -ne 2 -or
+        [string]::Join("`n", $arrMergePaths) -cne "left.txt`nright.txt") {
+        throw 'The merge created-ref fixture lost a parent boundary.'
+    }
+
+    $strRootPayload = ConvertTo-Json -Compress -InputObject `
+        ([object[]] @($strRootCommit))
+    $objGenuineRootContext = Get-CreatedRefBoundaryContext `
+        -RepositoryRootPath $strTopologyRoot `
+        -DestinationRef 'refs/heads/new-root' `
+        -HeadRevision $strRootCommit -EventHeadRevision $strRootCommit `
+        -EventHeadDistinct 'true' -PushCommitCount '1' `
+        -PushDistinctCommitCount '1' -PushCommitEvidenceJson $strRootPayload `
+        -OtherRefEvidenceJson '[]'
+    $arrGenuineRootPaths = @(Read-GitPublishedEndpointChangedPath `
+            -RepositoryRootPath $strTopologyRoot `
+            -BaselineRevision ('0' * 40) -FinalRevision $strRootCommit `
+            -BaselineAbsent $true -NewRefBoundaryRevision @() `
+            -NewRefIntroducedCommitRevision `
+                $objGenuineRootContext.IntroducedCommitRevisions `
+            -MaximumBytes $MaximumBytes)
+    if (-not $objGenuineRootContext.IsGenuineRootIntroduction -or
+        $arrGenuineRootPaths.Count -ne 1 -or
+        $arrGenuineRootPaths[0] -cne 'root.txt') {
+        throw 'The genuine-root created-ref fixture did not use the final tree.'
+    }
+
+    foreach ($objRejectedFixture in @(
+            [pscustomobject]@{
+                Name = 'event head mismatch'
+                Expected = 'expanded event head'
+                Arguments = @{
+                    HeadRevision = $strOneCommit
+                    EventHeadRevision = $strRootCommit
+                    PushCommitCount = '1'
+                    PushDistinctCommitCount = '1'
+                    PushCommitEvidenceJson = $strOnePayload
+                    OtherRefEvidenceJson = $strRootEvidence
+                }
+            },
+            [pscustomobject]@{
+                Name = 'truncated payload'
+                Expected = 'commit array is truncated'
+                Arguments = @{
+                    HeadRevision = $strTwoCommit
+                    EventHeadRevision = $strTwoCommit
+                    PushCommitCount = '2'
+                    PushDistinctCommitCount = '2'
+                    PushCommitEvidenceJson = $strOnePayload
+                    OtherRefEvidenceJson = $strRootEvidence
+                }
+            },
+            [pscustomobject]@{
+                Name = 'other-ref drift'
+                Expected = 'other-ref object changed'
+                Arguments = @{
+                    HeadRevision = $strOneCommit
+                    EventHeadRevision = $strOneCommit
+                    PushCommitCount = '1'
+                    PushDistinctCommitCount = '1'
+                    PushCommitEvidenceJson = $strOnePayload
+                    OtherRefEvidenceJson = $strRootEvidence
+                }
+            }
         )) {
-        throw "$($objDateNegativeCase.Name) did not fail closed."
+        if ($objRejectedFixture.Name -ceq 'other-ref drift') {
+            & git -C $strTopologyRoot update-ref `
+                refs/remotes/event/created-other-0000 $strOneCommit
+        }
+        else {
+            & git -C $strTopologyRoot update-ref `
+                refs/remotes/event/created-other-0000 $strRootCommit
+        }
+        try {
+            $objArguments = $objRejectedFixture.Arguments
+            $null = Get-CreatedRefBoundaryContext `
+                -RepositoryRootPath $strTopologyRoot `
+                -DestinationRef 'refs/heads/new-rejected' `
+                -HeadRevision $objArguments.HeadRevision `
+                -EventHeadRevision $objArguments.EventHeadRevision `
+                -EventHeadDistinct 'true' `
+                -PushCommitCount $objArguments.PushCommitCount `
+                -PushDistinctCommitCount $objArguments.PushDistinctCommitCount `
+                -PushCommitEvidenceJson $objArguments.PushCommitEvidenceJson `
+                -OtherRefEvidenceJson $objArguments.OtherRefEvidenceJson
+            throw "Rejected created-ref fixture passed: $($objRejectedFixture.Name)"
+        }
+        catch {
+            $strRejectedMessage = $_.Exception.Message
+            if ($strRejectedMessage.StartsWith(
+                    'Rejected created-ref fixture passed:',
+                    [StringComparison]::Ordinal
+                )) {
+                throw
+            }
+            if (-not $strRejectedMessage.Contains(
+                    $objRejectedFixture.Expected,
+                    [StringComparison]::OrdinalIgnoreCase
+                )) {
+                throw "Created-ref rejection '$($objRejectedFixture.Name)' returned: $strRejectedMessage"
+            }
+        }
+    }
+}
+finally {
+    if ([IO.Directory]::Exists($strTopologyRoot) -and
+        $strTopologyRoot.StartsWith(
+            $strTempRoot,
+            [StringComparison]::OrdinalIgnoreCase
+        )) {
+        Remove-Item -LiteralPath $strTopologyRoot -Recurse -Force
     }
 }

--- a/.github/workflows/Test-AgentInstructions.SelfTest.ps1
+++ b/.github/workflows/Test-AgentInstructions.SelfTest.ps1
@@ -29,7 +29,7 @@
 # None. The script throws when a self-test fails.
 #
 # .NOTES
-# Version: 1.2.20260902.1
+# Version: 1.2.20260902.2
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([void])]
@@ -410,6 +410,60 @@ try {
         throw 'The many-introduced created-ref fixture lost changed paths.'
     }
 
+    $strTransientDecisionDirectory = Join-Path $strTopologyRoot 'docs/decisions'
+    [void] [IO.Directory]::CreateDirectory($strTransientDecisionDirectory)
+    $strTransientDecisionPath = Join-Path `
+        $strTransientDecisionDirectory '0002-temp.md'
+    [IO.File]::WriteAllText(
+        $strTransientDecisionPath,
+        "# Decision 0002: Transient fixture`n",
+        $objUtf8
+    )
+    & git -C $strTopologyRoot add -- docs/decisions/0002-temp.md
+    & git -C $strTopologyRoot commit --quiet -m transient-create
+    $strTransientCreateCommit = ([string] (
+            & git -C $strTopologyRoot rev-parse HEAD
+        )).Trim()
+    & git -C $strTopologyRoot rm --quiet -- docs/decisions/0002-temp.md
+    & git -C $strTopologyRoot commit --quiet -m transient-delete
+    $strTransientDeleteCommit = ([string] (
+            & git -C $strTopologyRoot rev-parse HEAD
+        )).Trim()
+    $strTransientPayload = ConvertTo-Json -Depth 4 -Compress -InputObject `
+        ([object[]] @(
+                $objOnePayloadCommit,
+                $objTwoPayloadCommit,
+                (ConvertTo-CreatedPushCommitEvidenceObject `
+                    -Id $strTransientCreateCommit -Distinct $true),
+                (ConvertTo-CreatedPushCommitEvidenceObject `
+                    -Id $strTransientDeleteCommit -Distinct $true)
+            ))
+    $objTransientContext = Get-CreatedRefBoundaryContext `
+        -RepositoryRootPath $strTopologyRoot `
+        -DestinationRef 'refs/heads/new-transient' `
+        -HeadRevision $strTransientDeleteCommit `
+        -EventHeadRevision $strTransientDeleteCommit `
+        -EventHeadDistinct 'true' `
+        -PushCommitEvidenceJson $strTransientPayload `
+        -OtherRefEvidenceJson $strRootEvidence
+    $arrTransientPaths = @(Read-GitPublishedEndpointChangedPath `
+            -RepositoryRootPath $strTopologyRoot `
+            -BaselineRevision ('0' * 40) `
+            -FinalRevision $strTransientDeleteCommit `
+            -BaselineAbsent $true `
+            -NewRefBoundaryRevision $objTransientContext.BoundaryRevisions `
+            -NewRefIntroducedCommitRevision `
+                $objTransientContext.IntroducedCommitRevisions `
+            -MaximumBytes $MaximumBytes)
+    if (@($objTransientContext.IntroducedCommitRevisions).Count -ne 4 -or
+        @($objTransientContext.BoundaryRevisions).Count -ne 1 -or
+        (Get-CreatedRefMetadataBaselineRevision `
+            -Context $objTransientContext `
+            -HeadRevision $strTransientDeleteCommit) -cne $strRootCommit -or
+        [string]::Join("`n", $arrTransientPaths) -cne "one.txt`ntwo.txt") {
+        throw 'A transient created-ref path escaped the published endpoint diff.'
+    }
+
     & git -C $strTopologyRoot checkout --quiet -b left $strRootCommit
     [IO.File]::WriteAllText(
         (Join-Path $strTopologyRoot 'left.txt'), "left`n", $objUtf8
@@ -455,18 +509,28 @@ try {
         -HeadRevision $strMergeCommit -EventHeadRevision $strMergeCommit `
         -EventHeadDistinct 'true' -PushCommitEvidenceJson $strMergePayload `
         -OtherRefEvidenceJson $strMergeEvidence
-    $arrMergePaths = @(Read-GitPublishedEndpointChangedPath `
-            -RepositoryRootPath $strTopologyRoot `
-            -BaselineRevision ('0' * 40) -FinalRevision $strMergeCommit `
-            -BaselineAbsent $true `
-            -NewRefBoundaryRevision $objMergeContext.BoundaryRevisions `
-            -NewRefIntroducedCommitRevision `
-                $objMergeContext.IntroducedCommitRevisions `
-            -MaximumBytes $MaximumBytes)
     if (@($objMergeContext.IntroducedCommitRevisions).Count -ne 1 -or
-        @($objMergeContext.BoundaryRevisions).Count -ne 2 -or
-        [string]::Join("`n", $arrMergePaths) -cne "left.txt`nright.txt") {
-        throw 'The merge created-ref fixture lost a parent boundary.'
+        @($objMergeContext.BoundaryRevisions).Count -ne 2) {
+        throw 'The merge created-ref fixture lost a graph boundary.'
+    }
+    try {
+        [void] @(Read-GitPublishedEndpointChangedPath `
+                -RepositoryRootPath $strTopologyRoot `
+                -BaselineRevision ('0' * 40) -FinalRevision $strMergeCommit `
+                -BaselineAbsent $true `
+                -NewRefBoundaryRevision $objMergeContext.BoundaryRevisions `
+                -NewRefIntroducedCommitRevision `
+                    $objMergeContext.IntroducedCommitRevisions `
+                -MaximumBytes $MaximumBytes)
+        throw 'A multi-boundary created-ref path range was accepted.'
+    }
+    catch {
+        if (-not $_.Exception.Message.Contains(
+                'must have one boundary',
+                [StringComparison]::Ordinal
+            )) {
+            throw
+        }
     }
     try {
         [void] (Get-CreatedRefMetadataBaselineRevision `

--- a/.github/workflows/Test-AgentInstructions.SelfTest.ps1
+++ b/.github/workflows/Test-AgentInstructions.SelfTest.ps1
@@ -29,7 +29,7 @@
 # None. The script throws when a self-test fails.
 #
 # .NOTES
-# Version: 1.2.20260902.2
+# Version: 1.2.20260902.3
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([void])]
@@ -122,6 +122,55 @@ if (@(Get-PublishedEndpointMetadataFailure `
     throw 'The extracted higher-order revision reset did not fail closed.'
 }
 
+$strMetadataOnlyHigherRevision = $strBaseline.Replace(
+    '**Version:** 1.0.20260830.0',
+    '**Version:** 1.0.20260902.5'
+).Replace(
+    '- **Last Updated:** 2026-08-30',
+    '- **Last Updated:** 2026-09-02'
+)
+if (@(Get-PublishedEndpointMetadataFailure `
+    -Name 'fixture.md' -CurrentContent $strMetadataOnlyHigherRevision `
+    -ParentContent $strBaseline -ExpectedUtcDate '2026-09-02' `
+    -IsNewDocumentTransition $false) -cnotcontains
+    ('fixture.md Version revision must be exactly 0 when a published-baseline ' +
+        'major, minor, or date segment changes.')) {
+    throw 'The extracted metadata-only higher-order reset did not fail closed.'
+}
+$strMetadataOnlyHigherReset = $strMetadataOnlyHigherRevision.Replace(
+    '**Version:** 1.0.20260902.5',
+    '**Version:** 1.0.20260902.0'
+)
+if (@(Get-PublishedEndpointMetadataFailure `
+        -Name 'fixture.md' -CurrentContent $strMetadataOnlyHigherReset `
+        -ParentContent $strBaseline -ExpectedUtcDate '2026-09-02' `
+        -IsNewDocumentTransition $false).Count -ne 0) {
+    throw 'The extracted metadata-only higher-order reset was rejected.'
+}
+
+$strMetadataOnlySameTupleIncrement = $strBaseline.Replace(
+    '**Version:** 1.0.20260830.0',
+    '**Version:** 1.0.20260830.1'
+)
+if (@(Get-PublishedEndpointMetadataFailure `
+        -Name 'fixture.md' -CurrentContent $strMetadataOnlySameTupleIncrement `
+        -ParentContent $strBaseline -ExpectedUtcDate '2026-08-30' `
+        -IsNewDocumentTransition $false).Count -ne 0) {
+    throw 'The extracted metadata-only same-tuple increment was rejected.'
+}
+$strMetadataOnlySameTupleSkip = $strMetadataOnlySameTupleIncrement.Replace(
+    '**Version:** 1.0.20260830.1',
+    '**Version:** 1.0.20260830.2'
+)
+if (@(Get-PublishedEndpointMetadataFailure `
+    -Name 'fixture.md' -CurrentContent $strMetadataOnlySameTupleSkip `
+    -ParentContent $strBaseline -ExpectedUtcDate '2026-08-30' `
+    -IsNewDocumentTransition $false) -cnotcontains
+    ('fixture.md Version revision must be exactly 1 after a published change ' +
+        'with an unchanged published-baseline major, minor, and date tuple.')) {
+    throw 'The extracted metadata-only same-tuple skip did not fail closed.'
+}
+
 $strSameTupleFinal = $strBaseline.Replace(
     '**Version:** 1.0.20260830.0',
     '**Version:** 1.0.20260830.1'
@@ -140,8 +189,8 @@ if (@(Get-PublishedEndpointMetadataFailure `
     -Name 'fixture.md' -CurrentContent $strSkippedSameTupleRevision `
     -ParentContent $strBaseline -ExpectedUtcDate '2026-08-30' `
     -IsNewDocumentTransition $false) -cnotcontains
-    ('fixture.md Version revision must be exactly 1 after a rendered-content ' +
-        'change with an unchanged published-baseline major, minor, and date tuple.')) {
+    ('fixture.md Version revision must be exactly 1 after a published change ' +
+        'with an unchanged published-baseline major, minor, and date tuple.')) {
     throw 'The extracted skipped same-tuple revision did not fail closed.'
 }
 

--- a/.github/workflows/Test-AgentInstructions.SelfTest.ps1
+++ b/.github/workflows/Test-AgentInstructions.SelfTest.ps1
@@ -1,18 +1,18 @@
 # .SYNOPSIS
-# Runs the extracted agent-instruction validator self-tests.
+# Runs the extracted published-endpoint metadata self-tests.
 #
 # .DESCRIPTION
-# Validates explicit revision-parent behavior and day-precision metadata
-# freshness with functions loaded by Test-AgentInstructions.ps1.
+# Validates final-state metadata arithmetic and authenticated endpoint handling
+# with functions loaded by Test-AgentInstructions.ps1.
 #
 # .PARAMETER RepositoryRootPath
 # The absolute path of the repository that supplies Git and document fixtures.
 #
 # .PARAMETER Revision
-# The exact Git commit to use for revision-parent tests.
+# The exact Git commit used as an authenticated endpoint fixture.
 #
 # .PARAMETER MaximumBytes
-# The maximum permitted byte count for governed document reads.
+# The maximum permitted byte count for bounded Git path reads.
 #
 # .PARAMETER MaximumMetadataUtcDate
 # The latest trusted UTC calendar date permitted in metadata fixtures.
@@ -29,21 +29,16 @@
 # None. The script throws when a self-test fails.
 #
 # .NOTES
-# Version: 1.0.20260830.0
+# Version: 1.1.20260831.0
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([void])]
 param(
-    [Parameter(Mandatory)]
-    [string] $RepositoryRootPath,
-
-    [Parameter(Mandatory)]
-    [string] $Revision,
-
+    [Parameter(Mandatory)][string] $RepositoryRootPath,
+    [Parameter(Mandatory)][string] $Revision,
     [Parameter(Mandatory)]
     [ValidateRange(1, 2147483646)]
     [int] $MaximumBytes,
-
     [Parameter(Mandatory)]
     [ValidatePattern('^\d{4}-\d{2}-\d{2}$')]
     [string] $MaximumMetadataUtcDate
@@ -54,203 +49,88 @@ if ($arrDeclaredOutputTypes.Count -ne 1 -or
     $arrDeclaredOutputTypes[0] -cne 'System.Void') {
     throw 'The extracted self-test must declare one void output contract.'
 }
-
 $script:strMaximumMetadataUtcDate = $MaximumMetadataUtcDate
-$objParentContext = Get-GovernedDocumentParentContext `
-    -RepositoryRootPath $RepositoryRootPath `
-    -RepositoryRelativePath 'AGENTS.md' `
-    -MaximumBytes $MaximumBytes `
-    -Revision $Revision
-if ($null -eq $objParentContext.ParentRevision) {
-    if ($null -ne $objParentContext.ParentContent -or
-        $objParentContext.ExpectedUtcDate -cne '' -or
-        $objParentContext.IsWorktreeTransition) {
-        throw 'The explicit root revision context is invalid.'
-    }
-}
-elseif ($objParentContext.ParentRevision -cne "$Revision`^1" -or
-    [string]::IsNullOrEmpty($objParentContext.ParentContent)) {
-    throw 'The explicit child revision context is invalid.'
+
+$strBaseline = @(
+    '# Endpoint fixture'
+    '**Version:** 1.0.20260830.0'
+    '## Metadata'
+    '- **Status:** Active'
+    '- **Owner:** Repository Maintainers'
+    '- **Last Updated:** 2026-08-30'
+    '- **Scope:** Extracted final-state regression.'
+    '## Content'
+    'Published baseline.'
+) -join "`n"
+$strFinal = @(
+    '# Endpoint fixture'
+    '**Version:** 1.0.20260831.0'
+    '## Metadata'
+    '- **Status:** Accepted'
+    '- **Owner:** Repository Maintainers'
+    '- **Last Updated:** 2026-08-31'
+    '- **Scope:** Extracted final-state regression.'
+    '## Content'
+    'Corrected published final.'
+) -join "`n"
+if (@(Get-PublishedEndpointMetadataFailure -Name 'fixture.md' `
+        -CurrentContent $strFinal -ParentContent $strBaseline `
+        -ExpectedUtcDate '2026-08-31' `
+        -IsNewDocumentTransition $false).Count -ne 0) {
+    throw 'The extracted published-final regression was rejected.'
 }
 
-$strRootRevision = [string] (
-    & git -C $RepositoryRootPath rev-list --max-parents=0 -n 1 $Revision
+$strInvalidFinal = $strFinal.Replace(
+    '**Version:** 1.0.20260831.0',
+    '**Version:** 1.0.20260831.3'
 )
-if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrEmpty($strRootRevision.Trim())) {
-    throw 'Could not resolve a zero-parent revision.'
-}
-$objRootParentContext = Get-GovernedDocumentParentContext `
-    -RepositoryRootPath $RepositoryRootPath `
-    -RepositoryRelativePath 'AGENTS.md' `
-    -MaximumBytes $MaximumBytes `
-    -Revision $strRootRevision.Trim()
-if ($null -ne $objRootParentContext.ParentRevision -or
-    $null -ne $objRootParentContext.ParentContent -or
-    $objRootParentContext.ExpectedUtcDate -cne '' -or
-    $objRootParentContext.IsWorktreeTransition) {
-    throw 'The zero-parent revision context is invalid.'
+$arrInvalidFinalFailures = @(Get-PublishedEndpointMetadataFailure `
+    -Name 'fixture.md' -CurrentContent $strInvalidFinal `
+    -ParentContent $strBaseline -ExpectedUtcDate '2026-08-31' `
+    -IsNewDocumentTransition $false)
+if ($arrInvalidFinalFailures -cnotcontains
+    ('fixture.md Version revision must be exactly 0 when the major, minor, ' +
+        'or date tuple differs from the published baseline.')) {
+    throw 'The extracted invalid published-final regression did not fail closed.'
 }
 
-$strGuidePath = '.github/workflows/scripts-README.md'
-$strGuideContent = Get-Content -LiteralPath (
-    Join-Path $RepositoryRootPath $strGuidePath
-) -Raw
-$objGuideMetadata = Get-DocumentMetadataContext `
-    -Content $strGuideContent -RequiresVersion $false
-if ($null -ne $objGuideMetadata.Failure) {
-    throw 'The unversioned date fixture metadata is invalid.'
+$strUnversionedBaseline = @(
+    '# Unversioned endpoint fixture'
+    '## Metadata'
+    '- **Status:** Active'
+    '- **Owner:** Repository Maintainers'
+    '- **Last Updated:** 2026-08-30'
+    '- **Scope:** Extracted unversioned final-state regression.'
+    '## Content'
+    'Published baseline.'
+) -join "`n"
+$strUnversionedFinal = $strUnversionedBaseline.Replace(
+    '- **Last Updated:** 2026-08-30',
+    '- **Last Updated:** 2026-08-31'
+).Replace('Published baseline.', 'Published final.')
+if (@(Get-PublishedEndpointLastUpdatedFailure -Name 'fixture.md' `
+        -CurrentContent $strUnversionedFinal `
+        -BaseContent $strUnversionedBaseline `
+        -TrustedEventUtcDate '2026-08-31' `
+        -RequireCurrentMaximumDateForRenderedChange $false).Count -ne 0) {
+    throw 'The extracted unversioned published-final regression was rejected.'
 }
-$strRepositoryDate = $objGuideMetadata.UpdatedDate
-$strRepositoryDateLine = "- **Last Updated:** $strRepositoryDate"
-if ([regex]::Matches(
-        $strGuideContent,
-        '(?m)^' + [regex]::Escape($strRepositoryDateLine) + '$'
-    ).Count -ne 1) {
-    throw 'The unversioned date fixture has no unique metadata date.'
-}
-$strGuideContent = $strGuideContent.Replace(
-    $strRepositoryDateLine,
-    "- **Last Updated:** $MaximumMetadataUtcDate"
-)
-$objGuideMetadata = Get-DocumentMetadataContext `
-    -Content $strGuideContent -RequiresVersion $false
-if ($null -ne $objGuideMetadata.Failure -or
-    $objGuideMetadata.UpdatedDate -cne $MaximumMetadataUtcDate) {
-    throw 'The synthetic unversioned date fixture is invalid.'
-}
-$strMaximumDate = $MaximumMetadataUtcDate
-$strPreviousDate = ([datetime]::ParseExact(
-        $strMaximumDate,
-        'yyyy-MM-dd',
-        [Globalization.CultureInfo]::InvariantCulture
-    )).AddDays(-1).ToString('yyyy-MM-dd')
-$strFutureDate = ([datetime]::ParseExact(
-        $strMaximumDate,
-        'yyyy-MM-dd',
-        [Globalization.CultureInfo]::InvariantCulture
-    )).AddDays(1).ToString('yyyy-MM-dd')
-$strRenderedGuide = $strGuideContent + "`nRepeated same-day change.`n"
-if (@(Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $strGuidePath -CurrentContent $strRenderedGuide `
-            -BaseContent $strGuideContent -TrustedEventUtcDate '' `
-            -RequireCurrentMaximumDateForRenderedChange $true).Count -ne 0) {
-    throw 'A valid repeated same-day unversioned change was rejected.'
+$arrStaleFailures = @(Get-PublishedEndpointLastUpdatedFailure `
+    -Name 'fixture.md' `
+    -CurrentContent ($strUnversionedBaseline + "`nRendered final change.") `
+    -BaseContent $strUnversionedBaseline `
+    -TrustedEventUtcDate '2026-08-31')
+if (-not ($arrStaleFailures -match 'Last Updated must be 2026-08-31')) {
+    throw 'The extracted stale unversioned final did not fail closed.'
 }
 
-$strPreviousGuide = $strGuideContent.Replace(
-    "- **Last Updated:** $strMaximumDate",
-    "- **Last Updated:** $strPreviousDate"
-)
-$strFutureGuide = $strGuideContent.Replace(
-    "- **Last Updated:** $strMaximumDate",
-    "- **Last Updated:** $strFutureDate"
-)
-$strMissingDateGuide = $strGuideContent.Replace(
-    "- **Last Updated:** $strMaximumDate`r`n",
-    ''
-).Replace(
-    "- **Last Updated:** $strMaximumDate`n",
-    ''
-)
-$strHistoricalAdoption = $strPreviousGuide + "`nHistorical adoption.`n"
-if (@(Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $strGuidePath -CurrentContent $strHistoricalAdoption `
-            -BaseContent $null -TrustedEventUtcDate '').Count -ne 0) {
-    throw 'A valid parentless historical adoption was rejected.'
-}
-if (@(Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $strGuidePath -CurrentContent $strRenderedGuide `
-            -BaseContent $strPreviousGuide -TrustedEventUtcDate '').Count -ne 0) {
-    throw 'A valid historical date advance was rejected.'
-}
-$arrHistoricalStaleFailures = @(Get-LastUpdatedMetadataFreshnessFailure `
-        -Name $strGuidePath `
-        -CurrentContent ($strPreviousGuide + "`nHistorical stale change.`n") `
-        -BaseContent $strPreviousGuide -TrustedEventUtcDate '')
-if (-not ($arrHistoricalStaleFailures -match 'must advance from')) {
-    throw 'A historical same-date change did not require advancement.'
-}
-$strHistoricalSameDayChange = $strPreviousGuide +
-    "`nAuthenticated same-day historical change.`n"
-if (@(Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $strGuidePath -CurrentContent $strHistoricalSameDayChange `
-            -BaseContent $strPreviousGuide -TrustedEventUtcDate '' `
-            -ModifyingCommitUtcDate $strPreviousDate `
-            -AllowSameDateForExactRestoration $true).Count -ne 0) {
-    throw 'A commit-date-matched exact restoration was rejected.'
-}
-$arrHistoricalLaterCommitFailures = @(Get-LastUpdatedMetadataFreshnessFailure `
-        -Name $strGuidePath -CurrentContent $strHistoricalSameDayChange `
-        -BaseContent $strPreviousGuide -TrustedEventUtcDate '' `
-        -ModifyingCommitUtcDate $strMaximumDate `
-        -AllowSameDateForExactRestoration $true)
-if (-not ($arrHistoricalLaterCommitFailures -match 'must advance from')) {
-    throw 'A stale date was accepted for a later modifying commit.'
-}
-$strEventMatchedAdvance = $strGuideContent +
-    "`nHistorical event-matched advancement.`n"
-if (@(Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $strGuidePath -CurrentContent $strEventMatchedAdvance `
-            -BaseContent $strPreviousGuide `
-            -TrustedEventUtcDate $strMaximumDate).Count -ne 0) {
-    throw 'A valid event-matched historical advancement was rejected.'
-}
-$arrEventMatchedStaleFailures = @(Get-LastUpdatedMetadataFreshnessFailure `
-        -Name $strGuidePath `
-        -CurrentContent ($strPreviousGuide + "`nEvent-matched stale change.`n") `
-        -BaseContent $strPreviousGuide `
-        -TrustedEventUtcDate $strPreviousDate)
-if (-not ($arrEventMatchedStaleFailures -match 'must advance from')) {
-    throw 'An event-matched historical same-date change did not require advancement.'
-}
-$arrDateNegativeCases = @(
-    [pscustomobject]@{
-        Name = 'stale no-event date'
-        Current = $strPreviousGuide + "`nStale change.`n"
-        Base = $strPreviousGuide
-        Event = ''
-        Failure = "must be $strMaximumDate"
-    },
-    [pscustomobject]@{
-        Name = 'future date'
-        Current = $strFutureGuide
-        Base = $strGuideContent
-        Event = ''
-        Failure = 'later than trusted UTC'
-    },
-    [pscustomobject]@{
-        Name = 'backward date'
-        Current = $strPreviousGuide
-        Base = $strGuideContent
-        Event = ''
-        Failure = 'must not move backward'
-    },
-    [pscustomobject]@{
-        Name = 'missing Last Updated'
-        Current = $strMissingDateGuide
-        Base = $strGuideContent
-        Event = ''
-        Failure = 'must contain one exact top-level Last Updated list item'
-    },
-    [pscustomobject]@{
-        Name = 'trusted-event mismatch'
-        Current = $strRenderedGuide
-        Base = $strGuideContent
-        Event = $strPreviousDate
-        Failure = "must be $strPreviousDate"
-    }
-)
-foreach ($objDateNegativeCase in $arrDateNegativeCases) {
-    $strDateFailures = @(Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $strGuidePath `
-            -CurrentContent $objDateNegativeCase.Current `
-            -BaseContent $objDateNegativeCase.Base `
-            -TrustedEventUtcDate $objDateNegativeCase.Event `
-            -RequireCurrentMaximumDateForRenderedChange $true) -join '; '
-    if (-not $strDateFailures.Contains(
-            $objDateNegativeCase.Failure,
-            [StringComparison]::Ordinal
-        )) {
-        throw "$($objDateNegativeCase.Name) did not fail closed."
-    }
+Assert-PublishedEndpointContext -RepositoryRootPath $RepositoryRootPath `
+    -EventName 'push' -PullRequestAction '' `
+    -BaselineRevision $Revision -FinalRevision $Revision `
+    -BaselineAbsent $false -PullRequestBaseChanged ''
+if (@(Read-GitPublishedEndpointChangedPath `
+        -RepositoryRootPath $RepositoryRootPath `
+        -BaselineRevision $Revision -FinalRevision $Revision `
+        -BaselineAbsent $false -MaximumBytes $MaximumBytes).Count -ne 0) {
+    throw 'Identical extracted endpoint trees reported changed paths.'
 }

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -6659,51 +6659,173 @@ if (-not [string]::IsNullOrEmpty($InputRevision)) {
 }
 
 if ($SelfTest) {
-    $strAuthorizationFixtureBase = [string] (
-        & git -C $strRepositoryRootPath rev-list --max-parents=0 HEAD |
-            Select-Object -First 1
-    )
-    $strAuthorizationFixtureHead = [string] (
-        & git -C $strRepositoryRootPath rev-parse --verify 'HEAD^{commit}'
-    )
-    if ($LASTEXITCODE -ne 0 -or
-        $strAuthorizationFixtureBase.Trim() -notmatch '^[0-9a-fA-F]{40}$' -or
-        $strAuthorizationFixtureHead.Trim() -notmatch '^[0-9a-fA-F]{40}$') {
-        throw 'Could not resolve the production-authorization fixtures.'
-    }
     $boolOriginalExactAuthorization =
         $script:boolTrustedMaintenanceAuthorizationValidated
+    $strAuthorizationFixtureSystemTempRoot =
+        [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+    $strAuthorizationFixtureRoot = [IO.Path]::Combine(
+        $strAuthorizationFixtureSystemTempRoot,
+        'agent-instruction-trust-root-' + [Guid]::NewGuid().ToString('N')
+    )
+    $strAuthorizationFixtureRepository =
+        [IO.Path]::Combine($strAuthorizationFixtureRoot, 'source')
+    $strAuthorizationFixtureDepthOneClone =
+        [IO.Path]::Combine($strAuthorizationFixtureRoot, 'depth-one')
+    $strAuthorizationFixtureTrustPath =
+        '.github/workflows/Test-AgentInstructions.ps1'
+    $strAuthorizationFixtureObjectIdPattern =
+        '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
+    [void][IO.Directory]::CreateDirectory($strAuthorizationFixtureRepository)
     try {
+        $objAuthorizationFixtureUtf8 = [Text.UTF8Encoding]::new($false)
+        $strAuthorizationFixtureTrustFile = [IO.Path]::Combine(
+            $strAuthorizationFixtureRepository,
+            $strAuthorizationFixtureTrustPath.Replace(
+                '/',
+                [IO.Path]::DirectorySeparatorChar
+            )
+        )
+        [void][IO.Directory]::CreateDirectory(
+            [IO.Path]::GetDirectoryName($strAuthorizationFixtureTrustFile)
+        )
+        [IO.File]::WriteAllText(
+            $strAuthorizationFixtureTrustFile,
+            "baseline`n",
+            $objAuthorizationFixtureUtf8
+        )
+        & git -C $strAuthorizationFixtureRepository init --quiet `
+            --initial-branch=main
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not initialize the trust-root authorization fixture.'
+        }
+        & git -C $strAuthorizationFixtureRepository add -- `
+            $strAuthorizationFixtureTrustPath
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not stage the trust-root authorization baseline.'
+        }
+        $strAuthorizationFixtureDisabledHooks =
+            [IO.Path]::Combine($strAuthorizationFixtureRoot, 'disabled-hooks')
+        & git -C $strAuthorizationFixtureRepository `
+            -c 'user.name=Agent instruction self-test' `
+            -c 'user.email=agent-instruction-self-test@example.invalid' `
+            -c 'commit.gpgSign=false' `
+            -c "core.hooksPath=$strAuthorizationFixtureDisabledHooks" `
+            commit --quiet --no-gpg-sign -m 'trust-root baseline'
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not commit the trust-root authorization baseline.'
+        }
+        $strAuthorizationFixtureBase = [string] (
+            & git -C $strAuthorizationFixtureRepository rev-parse --verify `
+                'HEAD^{commit}'
+        )
+        if ($LASTEXITCODE -ne 0 -or
+            $strAuthorizationFixtureBase.Trim() -notmatch
+                $strAuthorizationFixtureObjectIdPattern) {
+            throw 'Could not resolve the trust-root authorization baseline.'
+        }
+
+        [IO.File]::WriteAllText(
+            $strAuthorizationFixtureTrustFile,
+            "mutated`n",
+            $objAuthorizationFixtureUtf8
+        )
+        & git -C $strAuthorizationFixtureRepository add -- `
+            $strAuthorizationFixtureTrustPath
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not stage the trust-root authorization mutation.'
+        }
+        & git -C $strAuthorizationFixtureRepository `
+            -c 'user.name=Agent instruction self-test' `
+            -c 'user.email=agent-instruction-self-test@example.invalid' `
+            -c 'commit.gpgSign=false' `
+            -c "core.hooksPath=$strAuthorizationFixtureDisabledHooks" `
+            commit --quiet --no-gpg-sign -m 'trust-root mutation'
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not commit the trust-root authorization mutation.'
+        }
+        $strAuthorizationFixtureHead = [string] (
+            & git -C $strAuthorizationFixtureRepository rev-parse --verify `
+                'HEAD^{commit}'
+        )
+        if ($LASTEXITCODE -ne 0 -or
+            $strAuthorizationFixtureHead.Trim() -notmatch
+                $strAuthorizationFixtureObjectIdPattern -or
+            $strAuthorizationFixtureHead.Trim() -ceq
+                $strAuthorizationFixtureBase.Trim()) {
+            throw 'Could not resolve the trust-root authorization mutation.'
+        }
+
+        $strAuthorizationFixtureUri =
+            ([Uri] $strAuthorizationFixtureRepository).AbsoluteUri
+        & git clone --quiet --depth 1 --no-local --no-hardlinks -- `
+            $strAuthorizationFixtureUri $strAuthorizationFixtureDepthOneClone
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not create the depth-one trust-root fixture clone.'
+        }
+        $strAuthorizationFixtureShallowState = [string] (
+            & git -C $strAuthorizationFixtureDepthOneClone rev-parse `
+                --is-shallow-repository
+        )
+        $strAuthorizationFixtureApparentRoot = [string] (
+            & git -C $strAuthorizationFixtureDepthOneClone rev-list `
+                --max-parents=0 HEAD | Select-Object -First 1
+        )
+        if ($LASTEXITCODE -ne 0 -or
+            $strAuthorizationFixtureShallowState.Trim() -cne 'true' -or
+            $strAuthorizationFixtureApparentRoot.Trim() -cne
+                $strAuthorizationFixtureHead.Trim() -or
+            $strAuthorizationFixtureApparentRoot.Trim() -ceq
+                $strAuthorizationFixtureBase.Trim()) {
+            throw 'The depth-one clone did not reproduce the apparent-root condition.'
+        }
+
         $script:boolTrustedMaintenanceAuthorizationValidated = $true
-        $arrAuthorizedProductionFailures = @(
+        $arrAuthorizedFixtureFailures = @(
             Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strRepositoryRootPath `
+                -RepositoryRootPath $strAuthorizationFixtureRepository `
                 -BaseRevision $strAuthorizationFixtureBase.Trim() `
                 -HeadRevision $strAuthorizationFixtureHead.Trim() `
-                -RepositoryRelativePath $script:arrTrustRootPaths `
+                -RepositoryRelativePath $strAuthorizationFixtureTrustPath
+        )
+        if ($arrAuthorizedFixtureFailures.Count -ne 1 -or
+            -not $arrAuthorizedFixtureFailures[0].Contains(
+                "changes trusted validation path $strAuthorizationFixtureTrustPath.",
+                [StringComparison]::Ordinal
+            )) {
+            throw 'The hermetic trust-root mutation fixture was not diagnosed.'
+        }
+
+        $arrAuthorizedProductionFailures = @(
+            Get-TrustRootRangeMutationFailure `
+                -RepositoryRootPath $strAuthorizationFixtureRepository `
+                -BaseRevision $strAuthorizationFixtureBase.Trim() `
+                -HeadRevision $strAuthorizationFixtureHead.Trim() `
+                -RepositoryRelativePath $strAuthorizationFixtureTrustPath `
                 -ExactAuthorizedMaintenanceProductionCall
         )
         if ($arrAuthorizedProductionFailures.Count -ne 0) {
             throw 'Exact authorized production maintenance did not bypass one call.'
         }
-        $arrAuthorizedFixtureFailures = @(
+
+        $arrNoMutationFixtureFailures = @(
             Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -BaseRevision $strAuthorizationFixtureBase.Trim() `
+                -RepositoryRootPath $strAuthorizationFixtureRepository `
+                -BaseRevision $strAuthorizationFixtureHead.Trim() `
                 -HeadRevision $strAuthorizationFixtureHead.Trim() `
-                -RepositoryRelativePath $script:arrTrustRootPaths
+                -RepositoryRelativePath $strAuthorizationFixtureTrustPath
         )
-        if ($arrAuthorizedFixtureFailures.Count -eq 0) {
-            throw 'An authorized self-test fixture bypassed trust-root mutation checks.'
+        if ($arrNoMutationFixtureFailures.Count -ne 0) {
+            throw 'The no-mutation trust-root fixture returned a false positive.'
         }
+
         $script:boolTrustedMaintenanceAuthorizationValidated = $false
         $boolUnauthorizedProductionRejected = $false
         try {
             [void] @(Get-TrustRootRangeMutationFailure `
-                    -RepositoryRootPath $strRepositoryRootPath `
+                    -RepositoryRootPath $strAuthorizationFixtureRepository `
                     -BaseRevision $strAuthorizationFixtureBase.Trim() `
                     -HeadRevision $strAuthorizationFixtureHead.Trim() `
-                    -RepositoryRelativePath $script:arrTrustRootPaths `
+                    -RepositoryRelativePath $strAuthorizationFixtureTrustPath `
                     -ExactAuthorizedMaintenanceProductionCall)
         }
         catch {
@@ -6719,6 +6841,13 @@ if ($SelfTest) {
     finally {
         $script:boolTrustedMaintenanceAuthorizationValidated =
             $boolOriginalExactAuthorization
+        if ([IO.Directory]::Exists($strAuthorizationFixtureRoot) -and
+            $strAuthorizationFixtureRoot.StartsWith(
+                $strAuthorizationFixtureSystemTempRoot,
+                [StringComparison]::OrdinalIgnoreCase
+            )) {
+            Remove-Item -LiteralPath $strAuthorizationFixtureRoot -Recurse -Force
+        }
     }
 }
 

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -3685,87 +3685,143 @@ function Read-CreatedPushCommitEvidence {
         $intPushCommitEvidenceMaximumBytes) {
         throw "The created-push commit evidence exceeds $intPushCommitEvidenceMaximumBytes bytes."
     }
+    $objJsonOptions = [Text.Json.JsonDocumentOptions]::new()
+    $objJsonOptions.AllowTrailingCommas = $false
+    $objJsonOptions.CommentHandling = [Text.Json.JsonCommentHandling]::Disallow
+    $objJsonOptions.MaxDepth = 8
     try {
-        $objCommitEvidence = ConvertFrom-Json `
-            -InputObject $PushCommitEvidenceJson -NoEnumerate
-        if ($objCommitEvidence -isnot [System.Array]) {
-            throw 'Commit evidence is not an array.'
-        }
-        $arrCommitEvidence = @($objCommitEvidence)
+        $objCommitEvidenceDocument = [Text.Json.JsonDocument]::Parse(
+            $PushCommitEvidenceJson,
+            $objJsonOptions
+        )
     }
     catch {
         throw 'The created-push commit evidence is malformed.'
     }
-    if ($arrCommitEvidence.Count -ge $intMaximumPayloadCommitCount) {
-        throw (
-            'The created-push commit evidence reaches the documented ' +
-            "$intMaximumPayloadCommitCount-object truncation cap."
-        )
-    }
-
-    $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
-    $strZeroObjectIdPattern = '^(?:0{40}|0{64})$'
-    $arrRequiredCommitProperties = @(
-        'author', 'committer', 'distinct', 'id', 'message', 'timestamp',
-        'tree_id', 'url'
-    )
-    $arrExpectedIdentityProperties = @('email', 'name', 'username')
-    $setCommitIds = [Collections.Generic.HashSet[string]]::new(
-        [StringComparer]::OrdinalIgnoreCase
-    )
-    $listNormalized = [Collections.Generic.List[pscustomobject]]::new()
-    foreach ($objCommit in $arrCommitEvidence) {
-        if ($null -eq $objCommit -or $objCommit -isnot [pscustomobject]) {
-            throw 'The created-push commit evidence has an invalid object shape.'
+    try {
+        $objCommitEvidenceRoot = $objCommitEvidenceDocument.RootElement
+        if ($objCommitEvidenceRoot.ValueKind -ne
+            [Text.Json.JsonValueKind]::Array) {
+            throw 'The created-push commit evidence is not an array.'
         }
-        $arrCommitPropertyNames = @(
-            $objCommit.PSObject.Properties | ForEach-Object Name
+        $intCommitEvidenceCount = $objCommitEvidenceRoot.GetArrayLength()
+        if ($intCommitEvidenceCount -ge $intMaximumPayloadCommitCount) {
+            throw (
+                'The created-push commit evidence reaches the documented ' +
+                "$intMaximumPayloadCommitCount-object truncation cap."
+            )
+        }
+
+        $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
+        $strZeroObjectIdPattern = '^(?:0{40}|0{64})$'
+        $arrRequiredCommitProperties = @(
+            'author', 'committer', 'distinct', 'id', 'message', 'timestamp',
+            'tree_id', 'url'
         )
-        foreach ($strRequiredCommitProperty in $arrRequiredCommitProperties) {
-            if ($arrCommitPropertyNames -cnotcontains $strRequiredCommitProperty) {
+        $arrExpectedIdentityProperties = @('email', 'name', 'username')
+        $setCommitIds = [Collections.Generic.HashSet[string]]::new(
+            [StringComparer]::OrdinalIgnoreCase
+        )
+        $listNormalized = [Collections.Generic.List[pscustomobject]]::new()
+        foreach ($objCommitElement in $objCommitEvidenceRoot.EnumerateArray()) {
+            if ($objCommitElement.ValueKind -ne
+                [Text.Json.JsonValueKind]::Object) {
                 throw 'The created-push commit evidence has an invalid object shape.'
             }
-        }
-        if ($objCommit.id -isnot [string] -or
-            $objCommit.id -notmatch $strObjectIdPattern -or
-            $objCommit.id -match $strZeroObjectIdPattern -or
-            -not $setCommitIds.Add($objCommit.id) -or
-            $objCommit.tree_id -isnot [string] -or
-            $objCommit.tree_id -notmatch $strObjectIdPattern -or
-            $objCommit.tree_id -match $strZeroObjectIdPattern -or
-            $objCommit.distinct -isnot [bool] -or
-            $objCommit.message -isnot [string] -or
-            $objCommit.timestamp -isnot [string] -or
-            $objCommit.url -isnot [string]) {
-            throw 'The created-push commit evidence has an invalid identity or scalar.'
-        }
-        foreach ($strIdentityName in @('author', 'committer')) {
-            $objIdentity = $objCommit.$strIdentityName
-            if ($null -eq $objIdentity -or $objIdentity -isnot [pscustomobject]) {
-                throw 'The created-push commit evidence has an invalid author or committer.'
+            $mapCommitProperties =
+                [Collections.Generic.Dictionary[string, Text.Json.JsonElement]]::new(
+                    [StringComparer]::Ordinal
+                )
+            foreach ($objCommitProperty in $objCommitElement.EnumerateObject()) {
+                if (-not $mapCommitProperties.TryAdd(
+                        $objCommitProperty.Name,
+                        $objCommitProperty.Value
+                    )) {
+                    throw 'The created-push commit evidence has a duplicate property.'
+                }
             }
-            $arrIdentityPropertyNames = @(
-                $objIdentity.PSObject.Properties | ForEach-Object Name
-            )
-            foreach ($strExpectedIdentityProperty in $arrExpectedIdentityProperties) {
-                if ($arrIdentityPropertyNames -cnotcontains $strExpectedIdentityProperty) {
+            foreach ($strRequiredCommitProperty in $arrRequiredCommitProperties) {
+                if (-not $mapCommitProperties.ContainsKey(
+                        $strRequiredCommitProperty
+                    )) {
+                    throw 'The created-push commit evidence has an invalid object shape.'
+                }
+            }
+            if ($mapCommitProperties['id'].ValueKind -ne
+                [Text.Json.JsonValueKind]::String -or
+                $mapCommitProperties['tree_id'].ValueKind -ne
+                [Text.Json.JsonValueKind]::String -or
+                $mapCommitProperties['distinct'].ValueKind -notin @(
+                    [Text.Json.JsonValueKind]::True,
+                    [Text.Json.JsonValueKind]::False
+                ) -or
+                $mapCommitProperties['message'].ValueKind -ne
+                [Text.Json.JsonValueKind]::String -or
+                $mapCommitProperties['timestamp'].ValueKind -ne
+                [Text.Json.JsonValueKind]::String -or
+                $mapCommitProperties['url'].ValueKind -ne
+                [Text.Json.JsonValueKind]::String) {
+                throw 'The created-push commit evidence has an invalid identity or scalar.'
+            }
+            $strCommitId = $mapCommitProperties['id'].GetString()
+            $strCommitTreeId = $mapCommitProperties['tree_id'].GetString()
+            if ($strCommitId -notmatch $strObjectIdPattern -or
+                $strCommitId -match $strZeroObjectIdPattern -or
+                -not $setCommitIds.Add($strCommitId) -or
+                $strCommitTreeId -notmatch $strObjectIdPattern -or
+                $strCommitTreeId -match $strZeroObjectIdPattern) {
+                throw 'The created-push commit evidence has an invalid identity or scalar.'
+            }
+            foreach ($strIdentityName in @('author', 'committer')) {
+                $objIdentityElement = $mapCommitProperties[$strIdentityName]
+                if ($objIdentityElement.ValueKind -ne
+                    [Text.Json.JsonValueKind]::Object) {
+                    throw 'The created-push commit evidence has an invalid author or committer.'
+                }
+                $mapIdentityProperties =
+                    [Collections.Generic.Dictionary[string, Text.Json.JsonElement]]::new(
+                        [StringComparer]::Ordinal
+                    )
+                foreach ($objIdentityProperty in
+                    $objIdentityElement.EnumerateObject()) {
+                    if (-not $mapIdentityProperties.TryAdd(
+                            $objIdentityProperty.Name,
+                            $objIdentityProperty.Value
+                        )) {
+                        throw 'The created-push commit evidence has a duplicate property.'
+                    }
+                }
+                foreach ($strExpectedIdentityProperty in
+                    $arrExpectedIdentityProperties) {
+                    if (-not $mapIdentityProperties.ContainsKey(
+                            $strExpectedIdentityProperty
+                        )) {
+                        throw 'The created-push commit evidence has an invalid author or committer.'
+                    }
+                }
+                if ($mapIdentityProperties['name'].ValueKind -ne
+                    [Text.Json.JsonValueKind]::String -or
+                    $mapIdentityProperties['email'].ValueKind -ne
+                    [Text.Json.JsonValueKind]::String -or
+                    $mapIdentityProperties['username'].ValueKind -notin @(
+                        [Text.Json.JsonValueKind]::String,
+                        [Text.Json.JsonValueKind]::Null
+                    )) {
                     throw 'The created-push commit evidence has an invalid author or committer.'
                 }
             }
-            if ($objIdentity.name -isnot [string] -or
-                $objIdentity.email -isnot [string] -or
-                ($null -ne $objIdentity.username -and
-                    $objIdentity.username -isnot [string])) {
-                throw 'The created-push commit evidence has an invalid author or committer.'
-            }
+            $listNormalized.Add([pscustomobject]@{
+                    Id = $strCommitId
+                    Distinct = $mapCommitProperties['distinct'].ValueKind -eq
+                    [Text.Json.JsonValueKind]::True
+                })
         }
-        $listNormalized.Add([pscustomobject]@{
-                Id = $objCommit.id
-                Distinct = $objCommit.distinct
-            })
+        $arrNormalized = @($listNormalized.ToArray())
+    }
+    finally {
+        $objCommitEvidenceDocument.Dispose()
     }
 
-    $arrNormalized = @($listNormalized.ToArray())
     if ($arrNormalized.Count -eq 0) {
         if ($EventHeadDistinct -ceq 'true') {
             throw 'The created-push commit evidence omits the distinct event head.'

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -2,7 +2,7 @@
 # Validates governed agent instructions and optional authenticated Git ranges.
 # .NOTES
 # Positional parameters are not supported.
-# Version: 1.7.20260902.3
+# Version: 1.7.20260902.4
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([string])]
@@ -5478,6 +5478,31 @@ function Get-PublishedEndpointMetadataFailure {
         return
     }
 
+    $boolRevisionChanged = $intCurrentRevision -ne $intParentRevision
+    if ($boolSameVersionTuple -and
+        ($boolRenderedContentChanged -or $boolRevisionChanged)) {
+        if ($intParentRevision -eq [int64]::MaxValue) {
+            Write-Output (
+                "The published baseline $Name Version revision cannot be incremented safely."
+            )
+            return
+        }
+        $intExpectedRevision = $intParentRevision + 1
+        if ($intCurrentRevision -ne $intExpectedRevision) {
+            Write-Output (
+                "$Name Version revision must be exactly $intExpectedRevision after a " +
+                'published change with an unchanged published-baseline major, minor, ' +
+                'and date tuple.'
+            )
+        }
+    }
+    elseif (-not $boolSameVersionTuple -and $intCurrentRevision -ne 0) {
+        Write-Output (
+            "$Name Version revision must be exactly 0 when a published-baseline " +
+            'major, minor, or date segment changes.'
+        )
+    }
+
     if (-not $boolRenderedContentChanged) {
         return
     }
@@ -5496,28 +5521,6 @@ function Get-PublishedEndpointMetadataFailure {
         }
     }
 
-    if ($boolSameVersionTuple) {
-        if ($intParentRevision -eq [int64]::MaxValue) {
-            Write-Output (
-                "The published baseline $Name Version revision cannot be incremented safely."
-            )
-            return
-        }
-        $intExpectedRevision = $intParentRevision + 1
-        if ($intCurrentRevision -ne $intExpectedRevision) {
-            Write-Output (
-                "$Name Version revision must be exactly $intExpectedRevision after a " +
-                'rendered-content change with an unchanged published-baseline major, ' +
-                'minor, and date tuple.'
-            )
-        }
-    }
-    elseif ($intCurrentRevision -ne 0) {
-        Write-Output (
-            "$Name Version revision must be exactly 0 when a published-baseline " +
-            'major, minor, or date segment changes.'
-        )
-    }
 }
 
 function Get-TrustRootRangeMutationFailure {
@@ -7381,9 +7384,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strValidatorSource,
-            '(?m)^# Version: 1\.7\.20260902\.3$'
+            '(?m)^# Version: 1\.7\.20260902\.4$'
         ).Count -ne 1) {
-        throw 'The validator script version is not 1.7.20260902.3.'
+        throw 'The validator script version is not 1.7.20260902.4.'
     }
     $boolSavedWindowsPython = $script:useWindowsPythonLauncher
     $arrSavedPythonNames = $script:pythonPathNames
@@ -7797,9 +7800,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strExtractedSelfTestSource,
-            '(?m)^# Version: 1\.2\.20260902\.2$'
+            '(?m)^# Version: 1\.2\.20260902\.3$'
         ).Count -ne 1) {
-        throw 'The extracted self-test lacks version 1.2.20260902.2.'
+        throw 'The extracted self-test lacks version 1.2.20260902.3.'
     }
     $strExtractedSelfTestRevision = if (
         [string]::IsNullOrEmpty($strValidatedInputRevision)
@@ -8802,7 +8805,7 @@ if ($SelfTest) {
         -ParentAgentsContent $strAgentsContent `
         -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value `
         -Failure ("AGENTS.md Version revision must be exactly " +
-            "$intNextAgentsRevision after a rendered-content change with an " +
+            "$intNextAgentsRevision after a published change with an " +
             'unchanged published-baseline major, minor, and date tuple.')
 
     $strHigherRevisionParent = $strAgentsContent.Replace(
@@ -8842,7 +8845,7 @@ if ($SelfTest) {
         -ParentAgentsContent $strAgentsContent `
         -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value `
         -Failure ("AGENTS.md Version revision must be exactly " +
-            "$intNextAgentsRevision after a rendered-content change with an " +
+            "$intNextAgentsRevision after a published change with an " +
             'unchanged published-baseline major, minor, and date tuple.')
 
     $objIsoEvent = ConvertFrom-TrustedEventTimestamp -Timestamp `
@@ -9008,7 +9011,7 @@ if ($SelfTest) {
             -ParentContent $strEndpointBaseline -ExpectedUtcDate '2026-08-30' `
             -IsNewDocumentTransition $false) -cnotcontains
         ('endpoint-fixture.md Version revision must be exactly 1 after a ' +
-            'rendered-content change with an unchanged published-baseline major, ' +
+            'published change with an unchanged published-baseline major, ' +
             'minor, and date tuple.')) {
         throw 'A skipped same-tuple published final revision did not fail closed.'
     }
@@ -9455,7 +9458,7 @@ if ($SelfTest) {
                 'const evidence = process.env.PUSH_COMMIT_EVIDENCE;',
                 'Buffer.byteLength(evidence, "utf8") > 1048576',
                 'commits = JSON.parse(evidence);',
-                '!Array.isArray(commits) || commits.length > 2048',
+                '!Array.isArray(commits) || commits.length >= 2048',
                 '!/^[0-9a-f]{40}$/.test(entry.id)',
                 'seenCommitIds.has(entry.id)',
                 'if (ids.length > 0 &&',
@@ -9463,7 +9466,7 @@ if ($SelfTest) {
                 '(ids.length > 0 ? "\n" : ""), "utf8");',
                 'mapfile -t push_commit_ids <"${push_commit_ids_file}"',
                 'fetch_depth=$((push_commit_count + 1))',
-                'test "${fetch_depth}" -le 2049',
+                'test "${fetch_depth}" -le 2048',
                 "destination_local_ref='refs/remotes/event/created-destination'",
                 '--no-write-fetch-head --no-recurse-submodules origin',
                 '"${PUSH_REF}:${destination_local_ref}"',
@@ -9743,10 +9746,18 @@ if ($SelfTest) {
             Expected = 'Workflow contract literal is missing: Buffer.byteLength'
         },
         [pscustomobject]@{
-            Name = 'missing push commit array and count bound'
+            Name = 'missing push commit array and truncation-cap bound'
             Content = $strAgentWorkflowContent.Replace(
-                '!Array.isArray(commits) || commits.length > 2048',
+                '!Array.isArray(commits) || commits.length >= 2048',
                 'false'
+            )
+            Expected = 'Workflow contract literal is missing: !Array.isArray(commits)'
+        },
+        [pscustomobject]@{
+            Name = 'weakened push commit truncation-cap comparison'
+            Content = $strAgentWorkflowContent.Replace(
+                '!Array.isArray(commits) || commits.length >= 2048',
+                '!Array.isArray(commits) || commits.length > 2048'
             )
             Expected = 'Workflow contract literal is missing: !Array.isArray(commits)'
         },
@@ -9797,6 +9808,14 @@ if ($SelfTest) {
                 'fetch_depth=2147483647'
             )
             Expected = 'Workflow contract literal is missing: fetch_depth=$((push_commit_count + 1))'
+        },
+        [pscustomobject]@{
+            Name = 'weakened destination history fetch cap'
+            Content = $strAgentWorkflowContent.Replace(
+                'test "${fetch_depth}" -le 2048',
+                'test "${fetch_depth}" -le 2049'
+            )
+            Expected = 'Workflow contract literal is missing: test "${fetch_depth}" -le 2048'
         },
         [pscustomobject]@{
             Name = 'forcing created destination fetch'

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -24,8 +24,6 @@ param(
     [Parameter()][AllowEmptyString()][string] $DestinationRef = '',
     [Parameter()][AllowEmptyString()][string] $EventHeadRevision = '',
     [Parameter()][AllowEmptyString()][string] $EventHeadDistinct = '',
-    [Parameter()][AllowEmptyString()][string] $PushCommitCount = '',
-    [Parameter()][AllowEmptyString()][string] $PushDistinctCommitCount = '',
     [Parameter()][AllowEmptyString()][string] $PushCommitEvidenceJson = '',
     [Parameter()][AllowEmptyString()][string] $OtherRefEvidenceJson = ''
 )
@@ -63,6 +61,7 @@ $intMetadataMaximumBoundaries = 64
 $intMaximumOtherRefCount = 256
 $intMaximumIntroducedCommitCount = 4096
 $intMaximumPayloadCommitCount = 2048
+$intPushCommitEvidenceMaximumBytes = 1048576
 $strPythonPrerequisite =
     'Python 3.12 is required to validate .codex/config.toml. On Windows, ' +
     'install the Python launcher for `py -3.12`; otherwise, expose ' +
@@ -3647,6 +3646,142 @@ function Get-AuthenticatedMergeBaseRevision {
     return @($arrMergeBases)
 }
 
+function Read-CreatedPushCommitEvidence {
+    # .SYNOPSIS
+    # Reads bounded complete commit objects from an authenticated push payload.
+    # .DESCRIPTION
+    # Validates inert webhook data without using it as graph authority. GitHub
+    # documents that the commits array contains at most 2048 objects. A payload
+    # at that cap can be truncated, so this helper rejects 2048 objects and
+    # accepts exact graph corroboration only below the cap.
+    # .PARAMETER PushCommitEvidenceJson
+    # The complete webhook commits array serialized as JSON.
+    # .PARAMETER EventHeadRevision
+    # The expanded head commit from the authenticated push event.
+    # .PARAMETER EventHeadDistinct
+    # The lowercase Boolean distinct value for the event head.
+    # .EXAMPLE
+    # Read-CreatedPushCommitEvidence @hashtableArguments
+    #
+    # # Returns normalized inert commit identities and distinct flags.
+    # .INPUTS
+    # None. No pipeline input.
+    # .OUTPUTS
+    # [System.Management.Automation.PSCustomObject[]] Normalized commit evidence.
+    # .NOTES
+    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
+    # Parameters, return shape, and positional contract can change without notice.
+    # Positional parameters are disabled; internal callers use named arguments.
+    # Version: 1.0.20260831.0.
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([pscustomobject[]])]
+    param(
+        [Parameter(Mandatory)][string] $PushCommitEvidenceJson,
+        [Parameter(Mandatory)][string] $EventHeadRevision,
+        [Parameter(Mandatory)][string] $EventHeadDistinct
+    )
+
+    if ([Text.Encoding]::UTF8.GetByteCount($PushCommitEvidenceJson) -gt
+        $intPushCommitEvidenceMaximumBytes) {
+        throw "The created-push commit evidence exceeds $intPushCommitEvidenceMaximumBytes bytes."
+    }
+    try {
+        $objCommitEvidence = ConvertFrom-Json `
+            -InputObject $PushCommitEvidenceJson -NoEnumerate
+        if ($objCommitEvidence -isnot [System.Array]) {
+            throw 'Commit evidence is not an array.'
+        }
+        $arrCommitEvidence = @($objCommitEvidence)
+    }
+    catch {
+        throw 'The created-push commit evidence is malformed.'
+    }
+    if ($arrCommitEvidence.Count -ge $intMaximumPayloadCommitCount) {
+        throw (
+            'The created-push commit evidence reaches the documented ' +
+            "$intMaximumPayloadCommitCount-object truncation cap."
+        )
+    }
+
+    $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
+    $strZeroObjectIdPattern = '^(?:0{40}|0{64})$'
+    $arrRequiredCommitProperties = @(
+        'author', 'committer', 'distinct', 'id', 'message', 'timestamp',
+        'tree_id', 'url'
+    )
+    $arrExpectedIdentityProperties = @('email', 'name', 'username')
+    $setCommitIds = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::OrdinalIgnoreCase
+    )
+    $listNormalized = [Collections.Generic.List[pscustomobject]]::new()
+    foreach ($objCommit in $arrCommitEvidence) {
+        if ($null -eq $objCommit -or $objCommit -isnot [pscustomobject]) {
+            throw 'The created-push commit evidence has an invalid object shape.'
+        }
+        $arrCommitPropertyNames = @(
+            $objCommit.PSObject.Properties | ForEach-Object Name
+        )
+        foreach ($strRequiredCommitProperty in $arrRequiredCommitProperties) {
+            if ($arrCommitPropertyNames -cnotcontains $strRequiredCommitProperty) {
+                throw 'The created-push commit evidence has an invalid object shape.'
+            }
+        }
+        if ($objCommit.id -isnot [string] -or
+            $objCommit.id -notmatch $strObjectIdPattern -or
+            $objCommit.id -match $strZeroObjectIdPattern -or
+            -not $setCommitIds.Add($objCommit.id) -or
+            $objCommit.tree_id -isnot [string] -or
+            $objCommit.tree_id -notmatch $strObjectIdPattern -or
+            $objCommit.tree_id -match $strZeroObjectIdPattern -or
+            $objCommit.distinct -isnot [bool] -or
+            $objCommit.message -isnot [string] -or
+            $objCommit.timestamp -isnot [string] -or
+            $objCommit.url -isnot [string]) {
+            throw 'The created-push commit evidence has an invalid identity or scalar.'
+        }
+        foreach ($strIdentityName in @('author', 'committer')) {
+            $objIdentity = $objCommit.$strIdentityName
+            if ($null -eq $objIdentity -or $objIdentity -isnot [pscustomobject]) {
+                throw 'The created-push commit evidence has an invalid author or committer.'
+            }
+            $arrIdentityPropertyNames = @(
+                $objIdentity.PSObject.Properties | ForEach-Object Name
+            )
+            foreach ($strExpectedIdentityProperty in $arrExpectedIdentityProperties) {
+                if ($arrIdentityPropertyNames -cnotcontains $strExpectedIdentityProperty) {
+                    throw 'The created-push commit evidence has an invalid author or committer.'
+                }
+            }
+            if ($objIdentity.name -isnot [string] -or
+                $objIdentity.email -isnot [string] -or
+                ($null -ne $objIdentity.username -and
+                    $objIdentity.username -isnot [string])) {
+                throw 'The created-push commit evidence has an invalid author or committer.'
+            }
+        }
+        $listNormalized.Add([pscustomobject]@{
+                Id = $objCommit.id
+                Distinct = $objCommit.distinct
+            })
+    }
+
+    $arrNormalized = @($listNormalized.ToArray())
+    if ($arrNormalized.Count -eq 0) {
+        if ($EventHeadDistinct -ceq 'true') {
+            throw 'The created-push commit evidence omits the distinct event head.'
+        }
+    }
+    elseif (-not [string]::Equals(
+            $arrNormalized[-1].Id,
+            $EventHeadRevision,
+            [StringComparison]::OrdinalIgnoreCase
+        ) -or $arrNormalized[-1].Distinct -ne
+        ($EventHeadDistinct -ceq 'true')) {
+        throw 'The created-push commit evidence does not end at the event head.'
+    }
+    return $arrNormalized
+}
+
 function Get-CreatedRefBoundaryContext {
     # .SYNOPSIS
     # Authenticates a created-ref push and derives its introduced graph boundary.
@@ -3663,12 +3798,8 @@ function Get-CreatedRefBoundaryContext {
     # The expanded head commit from the authenticated push event.
     # .PARAMETER EventHeadDistinct
     # The lowercase Boolean distinct value for the event head.
-    # .PARAMETER PushCommitCount
-    # The authenticated push size as invariant decimal text.
-    # .PARAMETER PushDistinctCommitCount
-    # The authenticated distinct push size as invariant decimal text.
     # .PARAMETER PushCommitEvidenceJson
-    # The bounded webhook commit ID array serialized as JSON.
+    # The bounded complete webhook commits array serialized as JSON.
     # .PARAMETER OtherRefEvidenceJson
     # The bounded, fetched, authenticated other-ref inventory as JSON.
     # .EXAMPLE
@@ -3692,8 +3823,6 @@ function Get-CreatedRefBoundaryContext {
         [Parameter(Mandatory)][string] $HeadRevision,
         [Parameter(Mandatory)][string] $EventHeadRevision,
         [Parameter(Mandatory)][string] $EventHeadDistinct,
-        [Parameter(Mandatory)][string] $PushCommitCount,
-        [Parameter(Mandatory)][string] $PushDistinctCommitCount,
         [Parameter(Mandatory)][string] $PushCommitEvidenceJson,
         [Parameter(Mandatory)][string] $OtherRefEvidenceJson
     )
@@ -3721,22 +3850,12 @@ function Get-CreatedRefBoundaryContext {
         throw 'The created-push head distinct field must be true or false.'
     }
 
-    $intPushCommitCount = 0
-    $intPushDistinctCommitCount = 0
-    if ($PushCommitCount -cnotmatch '^(?:0|[1-9][0-9]*)$' -or
-        -not [int]::TryParse($PushCommitCount, [ref] $intPushCommitCount)) {
-        throw 'The created-push size is invalid or exceeds a signed 32-bit integer.'
-    }
-    if ($PushDistinctCommitCount -cnotmatch '^(?:0|[1-9][0-9]*)$' -or
-        -not [int]::TryParse(
-            $PushDistinctCommitCount,
-            [ref] $intPushDistinctCommitCount
-        )) {
-        throw 'The created-push distinct size is invalid or exceeds a signed 32-bit integer.'
-    }
-    if ($intPushDistinctCommitCount -gt $intPushCommitCount) {
-        throw 'The created-push distinct size exceeds its size.'
-    }
+    $arrCommitEvidence = @(
+        Read-CreatedPushCommitEvidence `
+            -PushCommitEvidenceJson $PushCommitEvidenceJson `
+            -EventHeadRevision $EventHeadRevision `
+            -EventHeadDistinct $EventHeadDistinct
+    )
 
     try {
         $objOtherRefEvidence = ConvertFrom-Json `
@@ -3851,39 +3970,38 @@ function Get-CreatedRefBoundaryContext {
         }
     }
     $boolHeadIntroduced = $setIntroducedCommits.Contains($HeadRevision)
-    if (($EventHeadDistinct -ceq 'true') -ne $boolHeadIntroduced -or
-        $arrIntroducedCommits.Count -ne $intPushDistinctCommitCount) {
+    if (($EventHeadDistinct -ceq 'true') -ne $boolHeadIntroduced) {
         throw 'The created-push payload contradicts the authenticated introduced graph.'
     }
 
-    try {
-        $objCommitEvidence = ConvertFrom-Json `
-            -InputObject $PushCommitEvidenceJson -NoEnumerate
-        if ($objCommitEvidence -isnot [System.Array]) {
-            throw 'Commit evidence is not an array.'
-        }
-        $arrCommitEvidence = @($objCommitEvidence)
-    }
-    catch {
-        throw 'The created-push commit evidence is malformed.'
-    }
-    $intExpectedEvidenceCount = [Math]::Min(
-        $intPushCommitCount,
-        $intMaximumPayloadCommitCount
-    )
-    if ($arrCommitEvidence.Count -ne $intExpectedEvidenceCount) {
-        throw 'The created-push commit array is truncated or inconsistent.'
-    }
-    $setPayloadCommits = [Collections.Generic.HashSet[string]]::new(
+    $setPayloadDistinctCommits = [Collections.Generic.HashSet[string]]::new(
         [StringComparer]::OrdinalIgnoreCase
     )
     foreach ($objCommit in $arrCommitEvidence) {
-        $strCommit = [string] $objCommit
-        if ($strCommit -notmatch $strObjectIdPattern -or
-            $strCommit -match $strZeroObjectIdPattern -or
-            -not $setPayloadCommits.Add($strCommit) -or
-            -not $setIntroducedCommits.Contains($strCommit)) {
+        & git -C $RepositoryRootPath cat-file -e `
+            "$($objCommit.Id)`^{commit}" 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            throw 'The created-push commit evidence names an unavailable commit.'
+        }
+        & git -C $RepositoryRootPath merge-base --is-ancestor `
+            $objCommit.Id $HeadRevision 2>$null
+        if ($LASTEXITCODE -ne 0) {
             throw 'The created-push commit array contradicts the authenticated graph.'
+        }
+        $boolCommitIntroduced = $setIntroducedCommits.Contains($objCommit.Id)
+        if ($objCommit.Distinct -ne $boolCommitIntroduced) {
+            throw 'The created-push distinct flags contradict the authenticated graph.'
+        }
+        if ($objCommit.Distinct) {
+            [void] $setPayloadDistinctCommits.Add($objCommit.Id)
+        }
+    }
+    if ($setPayloadDistinctCommits.Count -ne $setIntroducedCommits.Count) {
+        throw 'The created-push distinct commit set contradicts the authenticated graph.'
+    }
+    foreach ($strIntroducedCommit in $arrIntroducedCommits) {
+        if (-not $setPayloadDistinctCommits.Contains($strIntroducedCommit)) {
+            throw 'The created-push distinct commit set contradicts the authenticated graph.'
         }
     }
 
@@ -6396,8 +6514,6 @@ if (-not $boolPublishedEndpointsRequested -and
         -not [string]::IsNullOrEmpty($DestinationRef) -or
         -not [string]::IsNullOrEmpty($EventHeadRevision) -or
         -not [string]::IsNullOrEmpty($EventHeadDistinct) -or
-        -not [string]::IsNullOrEmpty($PushCommitCount) -or
-        -not [string]::IsNullOrEmpty($PushDistinctCommitCount) -or
         -not [string]::IsNullOrEmpty($PushCommitEvidenceJson) -or
         -not [string]::IsNullOrEmpty($OtherRefEvidenceJson) -or
         $PublishedBaselineAbsent -or $PublishedFinalDeleted)) {
@@ -6425,16 +6541,12 @@ if ($PublishedBaselineAbsent) {
         -HeadRevision $PublishedFinalRevision `
         -EventHeadRevision $EventHeadRevision `
         -EventHeadDistinct $EventHeadDistinct `
-        -PushCommitCount $PushCommitCount `
-        -PushDistinctCommitCount $PushDistinctCommitCount `
         -PushCommitEvidenceJson $PushCommitEvidenceJson `
         -OtherRefEvidenceJson $OtherRefEvidenceJson
 }
 elseif (-not [string]::IsNullOrEmpty($DestinationRef) -or
     -not [string]::IsNullOrEmpty($EventHeadRevision) -or
     -not [string]::IsNullOrEmpty($EventHeadDistinct) -or
-    -not [string]::IsNullOrEmpty($PushCommitCount) -or
-    -not [string]::IsNullOrEmpty($PushDistinctCommitCount) -or
     -not [string]::IsNullOrEmpty($PushCommitEvidenceJson) -or
     -not [string]::IsNullOrEmpty($OtherRefEvidenceJson)) {
     throw 'Created-push evidence is valid only when the destination ref is new.'
@@ -6986,8 +7098,8 @@ if ($SelfTest) {
         param($objNode)
         $objNode -is [Management.Automation.Language.FunctionDefinitionAst]
     }, $true))
-    if ($arrValidatorFunctionAsts.Count -ne 56) {
-        throw 'The validator function-help inventory must contain exactly 56 functions.'
+    if ($arrValidatorFunctionAsts.Count -ne 57) {
+        throw 'The validator function-help inventory must contain exactly 57 functions.'
     }
     foreach ($objFunctionAst in $arrValidatorFunctionAsts) {
         $objHelp = $objFunctionAst.GetHelpContent()
@@ -8817,6 +8929,7 @@ if ($SelfTest) {
                 'cmp --silent "${raw_refs}" "${raw_refs_after}"',
                 'AGENT_INSTRUCTION_DESTINATION_REF:',
                 'AGENT_INSTRUCTION_PUSH_COMMIT_EVIDENCE:',
+                'toJson(github.event.commits)',
                 '-OtherRefEvidenceJson',
                 'id: trust-root-authorization',
                 '-AuthorizationApplicabilityOnly',
@@ -8856,7 +8969,12 @@ if ($SelfTest) {
         }
         foreach ($strForbiddenTransitionLiteral in @(
                 'PR_PREVIOUS_HEAD_SHA', 'refs/remotes/event/pr-previous-head',
-                'AGENT_INSTRUCTION_NEW_REF_COMMITS_JSON'
+                'AGENT_INSTRUCTION_NEW_REF_COMMITS_JSON',
+                'github.event.size', 'github.event.distinct_size',
+                'github.event.commits.*.id',
+                'AGENT_INSTRUCTION_PUSH_COMMIT_COUNT',
+                'AGENT_INSTRUCTION_PUSH_DISTINCT_COMMIT_COUNT',
+                '-PushCommitCount', '-PushDistinctCommitCount'
             )) {
             if ($Content.Contains(
                     $strForbiddenTransitionLiteral,
@@ -8984,6 +9102,22 @@ if ($SelfTest) {
                 'github.event.pull_request.created_at'
             )
             Expected = 'Workflow contract literal is missing: github.event.pull_request.updated_at'
+        },
+        [pscustomobject]@{
+            Name = 'commit evidence reduced to IDs'
+            Content = $strAgentWorkflowContent.Replace(
+                'toJson(github.event.commits)',
+                'toJson(github.event.commits.*.id)'
+            )
+            Expected = 'Workflow contract literal is missing: toJson(github.event.commits)'
+        },
+        [pscustomobject]@{
+            Name = 'undocumented push size contract'
+            Content = $strAgentWorkflowContent.Replace(
+                'toJson(github.event.commits)',
+                'toJson(github.event.size)'
+            )
+            Expected = 'Workflow contract literal is missing: toJson(github.event.commits)'
         }
     )
     foreach ($objWorkflowMutation in $arrWorkflowMutations) {

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -2,7 +2,7 @@
 # Validates governed agent instructions and optional authenticated Git ranges.
 # .NOTES
 # Positional parameters are not supported.
-# Version: 1.7.20260831.0
+# Version: 1.7.20260902.0
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([string])]
@@ -4827,6 +4827,82 @@ function Get-DocumentationClaimFailure {
     }
 }
 
+function Get-DecisionLifecyclePolicyFailure {
+    # .SYNOPSIS
+    # Finds an invalid decision-record lifecycle policy.
+    #
+    # .DESCRIPTION
+    # Requires one decision-record Status representation, the four retained
+    # lifecycle values, and an explicit prohibition on a second narrative status.
+    #
+    # .PARAMETER Content
+    # The documentation instruction content to inspect.
+    #
+    # .EXAMPLE
+    # Get-DecisionLifecyclePolicyFailure -Content $strDocs
+    #
+    # # Returns one string for each lifecycle-policy failure.
+    #
+    # .INPUTS
+    # None. You can't pipe objects to this function.
+    #
+    # .OUTPUTS
+    # [string] One record for each decision lifecycle policy failure.
+    #
+    # .NOTES
+    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
+    # Parameters, return shape, and positional contract can change without notice.
+    # Positional parameters are disabled; internal callers use named arguments.
+    # Version: 1.0.20260902.0.
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string] $Content
+    )
+
+    $arrSectionMatches = @([regex]::Matches(
+            $Content,
+            '(?ms)^## Decision Record Standards\s*\r?\n(?<Body>.*?)(?=^## |\z)'
+        ))
+    if ($arrSectionMatches.Count -ne 1) {
+        Write-Output (
+            'Documentation instructions must contain exactly one Decision Record ' +
+            'Standards section.'
+        )
+        return
+    }
+
+    $strSectionBody = $arrSectionMatches[0].Groups['Body'].Value
+    if ([regex]::Matches($strSectionBody, '\*\*Status\*\*').Count -ne 1) {
+        Write-Output (
+            'Decision records must use exactly one Tier 1 Status representation.'
+        )
+    }
+
+    $arrAllowedValuesMatches = @([regex]::Matches(
+            $strSectionBody,
+            'For decision records, its value MUST be ' +
+                '(?<Values>[A-Za-z]+(?: \| [A-Za-z]+)+)\.'
+        ))
+    $strExpectedValues = 'Proposed | Accepted | Superseded | Deprecated'
+    if ($arrAllowedValuesMatches.Count -ne 1 -or
+        $arrAllowedValuesMatches[0].Groups['Values'].Value -cne $strExpectedValues) {
+        Write-Output (
+            'Decision record Status must allow exactly ' + $strExpectedValues + '.'
+        )
+    }
+
+    if ([regex]::Matches(
+            $strSectionBody,
+            'A decision record MUST NOT add a separate narrative status field or section\.'
+        ).Count -ne 1) {
+        Write-Output (
+            'Decision records must prohibit a separate narrative status representation.'
+        )
+    }
+}
+
 function Get-DocumentMetadataContext {
     # .SYNOPSIS
     # Gets validated document-level metadata context.
@@ -5187,20 +5263,19 @@ function Get-PublishedEndpointMetadataFailure {
         if (-not $IsNewDocumentTransition) {
             return
         }
-        if (-not $RequireExpectedUtcDateForRenderedChange) {
-            return
-        }
-        if ([string]::IsNullOrEmpty($ExpectedUtcDate) -or
-            -not (Test-MetadataCalendarDatePair `
-                -VersionDate $ExpectedUtcDate.Replace('-', '') `
-                -UpdatedDate $ExpectedUtcDate)) {
-            Write-Output "The expected UTC date for $Name is unavailable or invalid."
-            return
-        }
-        if ($strCurrentUpdatedDate -cne $ExpectedUtcDate) {
-            Write-Output (
-                "$Name Last Updated must be $ExpectedUtcDate after a rendered-content change."
-            )
+        if ($RequireExpectedUtcDateForRenderedChange) {
+            if ([string]::IsNullOrEmpty($ExpectedUtcDate) -or
+                -not (Test-MetadataCalendarDatePair `
+                    -VersionDate $ExpectedUtcDate.Replace('-', '') `
+                    -UpdatedDate $ExpectedUtcDate)) {
+                Write-Output "The expected UTC date for $Name is unavailable or invalid."
+                return
+            }
+            if ($strCurrentUpdatedDate -cne $ExpectedUtcDate) {
+                Write-Output (
+                    "$Name Last Updated must be $ExpectedUtcDate after a rendered-content change."
+                )
+            }
         }
         if ($intCurrentRevision -ne 0) {
             Write-Output (
@@ -5312,14 +5387,20 @@ function Get-PublishedEndpointMetadataFailure {
             )
             return
         }
-        $intMinimumRevision = $intParentRevision + 1
-        if ($intCurrentRevision -lt $intMinimumRevision) {
+        $intExpectedRevision = $intParentRevision + 1
+        if ($intCurrentRevision -ne $intExpectedRevision) {
             Write-Output (
-                "$Name Version revision must be at least $intMinimumRevision after a " +
+                "$Name Version revision must be exactly $intExpectedRevision after a " +
                 'rendered-content change with an unchanged published-baseline major, ' +
                 'minor, and date tuple.'
             )
         }
+    }
+    elseif ($intCurrentRevision -ne 0) {
+        Write-Output (
+            "$Name Version revision must be exactly 0 when a published-baseline " +
+            'major, minor, or date segment changes.'
+        )
     }
 }
 
@@ -7010,6 +7091,8 @@ elseif (-not (Test-GitIgnorePathEffective `
 $arrRepositoryFailures += @(Get-DocumentationClaimFailure `
         -Content $strDocsInstructionsContent `
         -TrackedPaths $arrTrackedRepositoryPaths)
+$arrRepositoryFailures += @(Get-DecisionLifecyclePolicyFailure `
+        -Content $strDocsInstructionsContent)
 $arrCanonicalDecisionGuideLinks = @(
     '../../STYLE_GUIDE.md',
     '../../STYLE_GUIDE_RATIONALE.md'
@@ -7102,8 +7185,8 @@ if ($SelfTest) {
         param($objNode)
         $objNode -is [Management.Automation.Language.FunctionDefinitionAst]
     }, $true))
-    if ($arrValidatorFunctionAsts.Count -ne 55) {
-        throw 'The validator function-help inventory must contain exactly 55 functions.'
+    if ($arrValidatorFunctionAsts.Count -ne 56) {
+        throw 'The validator function-help inventory must contain exactly 56 functions.'
     }
     foreach ($objFunctionAst in $arrValidatorFunctionAsts) {
         $objHelp = $objFunctionAst.GetHelpContent()
@@ -7141,7 +7224,7 @@ if ($SelfTest) {
             }
             if ([regex]::Matches(
                     $strFunctionNotes,
-                    '(?m)^Version: 1\.0\.202608(?:30|31)\.0\.$'
+                    '(?m)^Version: 1\.0\.(?:202608(?:30|31)|20260902)\.0\.$'
                 ).Count -ne 1) {
                 $listMissingHelp.Add('landing or repair helper Version')
             }
@@ -7163,9 +7246,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strValidatorSource,
-            '(?m)^# Version: 1\.7\.20260831\.0$'
+            '(?m)^# Version: 1\.7\.20260902\.0$'
         ).Count -ne 1) {
-        throw 'The validator script version does not use build date 20260831.'
+        throw 'The validator script version does not use build date 20260902.'
     }
     $boolSavedWindowsPython = $script:useWindowsPythonLauncher
     $arrSavedPythonNames = $script:pythonPathNames
@@ -7242,26 +7325,45 @@ if ($SelfTest) {
             ($arrDocumentationClaimFailures -join '; ')
         )
     }
-    $strDocumentationOwnerEnforcerRelationship =
-        '`.github/workflows/Test-AgentInstructions.ps1` is a non-owner ' +
-        'enforcement mechanism. It checks the named owner at the exact input ' +
-        'revision and rejects stale repository-specific documentation claims.'
-    if (-not $strDocsInstructionsContent.Contains(
-            $strDocumentationOwnerEnforcerRelationship,
-            [StringComparison]::Ordinal
-        )) {
-        throw 'The documentation owner and non-owner enforcer relationship changed.'
+    $arrDecisionLifecycleFailures = @(Get-DecisionLifecyclePolicyFailure `
+            -Content $strDocsInstructionsContent)
+    if ($arrDecisionLifecycleFailures.Count -ne 0) {
+        throw (
+            'The decision lifecycle baseline failed validation: ' +
+            ($arrDecisionLifecycleFailures -join '; ')
+        )
     }
-    $strDocumentationOwnerEnforcerMutation = $strDocsInstructionsContent.Replace(
-        'is a non-owner enforcement mechanism',
-        'is an owner enforcement mechanism'
+    $strGenericDecisionStatusMutation = $strDocsInstructionsContent.Replace(
+        'Proposed | Accepted | Superseded | Deprecated',
+        'Draft | Proposed | Active | Accepted | Superseded | Deprecated'
     )
-    if ($strDocumentationOwnerEnforcerMutation -ceq $strDocsInstructionsContent -or
-        $strDocumentationOwnerEnforcerMutation.Contains(
-            $strDocumentationOwnerEnforcerRelationship,
-            [StringComparison]::Ordinal
-        )) {
-        throw 'A documentation owner and enforcer mutation was not detected.'
+    if ($strGenericDecisionStatusMutation -ceq $strDocsInstructionsContent -or
+        @(Get-DecisionLifecyclePolicyFailure `
+                -Content $strGenericDecisionStatusMutation) -cnotcontains
+            ('Decision record Status must allow exactly ' +
+                'Proposed | Accepted | Superseded | Deprecated.')) {
+        throw 'A generic decision Status set did not fail closed.'
+    }
+    $strDuplicateDecisionStatusMutation = $strDocsInstructionsContent.Replace(
+        'A decision record MUST NOT add a separate narrative status field or section.',
+        ('A second **Status** representation records decision history. ' +
+            'A decision record MUST NOT add a separate narrative status field or section.')
+    )
+    if ($strDuplicateDecisionStatusMutation -ceq $strDocsInstructionsContent -or
+        @(Get-DecisionLifecyclePolicyFailure `
+                -Content $strDuplicateDecisionStatusMutation) -cnotcontains
+            'Decision records must use exactly one Tier 1 Status representation.') {
+        throw 'A duplicate decision Status representation did not fail closed.'
+    }
+    $strNarrativeDecisionStatusMutation = $strDocsInstructionsContent.Replace(
+        'A decision record MUST NOT add a separate narrative status field or section.',
+        'A decision record MAY add a separate narrative status field or section.'
+    )
+    if ($strNarrativeDecisionStatusMutation -ceq $strDocsInstructionsContent -or
+        @(Get-DecisionLifecyclePolicyFailure `
+                -Content $strNarrativeDecisionStatusMutation) -cnotcontains
+            'Decision records must prohibit a separate narrative status representation.') {
+        throw 'A permitted narrative decision Status did not fail closed.'
     }
     foreach ($strOwnerPath in $script:arrDocumentationClaimOwnerPaths) {
         $arrMissingOwnerFailures = @(Get-DocumentationClaimFailure `
@@ -7394,7 +7496,7 @@ if ($SelfTest) {
             -ExpectedUtcDate $objDocsMetadataContext.UpdatedDate `
             -IsNewDocumentTransition $false)
     if (-not ($arrDocsStaleMetadataFailures -match [regex]::Escape(
-                '.github/instructions/docs.instructions.md Version revision must be at least'
+                '.github/instructions/docs.instructions.md Version revision must be exactly'
             ))) {
         throw 'The docs-only stale-metadata mutation did not fail closed.'
     }
@@ -7422,7 +7524,7 @@ if ($SelfTest) {
                 -ParentContent $objDocumentContext.Content `
                 -ExpectedUtcDate $objMetadataContext.UpdatedDate `
                 -IsNewDocumentTransition $false)
-        $strFailure = "$strNewlyCoveredPath Version revision must be at least"
+        $strFailure = "$strNewlyCoveredPath Version revision must be exactly"
         if (-not ($arrStaleMetadataFailures -match [regex]::Escape(
                     $strFailure
                 ))) {
@@ -7502,9 +7604,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strExtractedSelfTestSource,
-            '(?m)^# Version: 1\.2\.20260831\.0$'
+            '(?m)^# Version: 1\.2\.20260902\.0$'
         ).Count -ne 1) {
-        throw 'The extracted self-test lacks version 1.2.20260831.0.'
+        throw 'The extracted self-test lacks version 1.2.20260902.0.'
     }
     $strExtractedSelfTestRevision = if (
         [string]::IsNullOrEmpty($strValidatedInputRevision)
@@ -7758,7 +7860,7 @@ if ($SelfTest) {
             -ExpectedUtcDate $objDocsMetadataContext.UpdatedDate `
             -IsNewDocumentTransition $false)
     if (-not ($arrNestedGeminiMetadataFailures -match [regex]::Escape(
-                'tools/GEMINI.md Version revision must be at least'
+                'tools/GEMINI.md Version revision must be exactly'
             ))) {
         throw 'A cataloged nested GEMINI.md bypassed rendered metadata transition.'
     }
@@ -8506,7 +8608,7 @@ if ($SelfTest) {
         -AgentsContent $strRenderedAgentsMutation `
         -ParentAgentsContent $strAgentsContent `
         -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value `
-        -Failure ("AGENTS.md Version revision must be at least " +
+        -Failure ("AGENTS.md Version revision must be exactly " +
             "$intNextAgentsRevision after a rendered-content change with an " +
             'unchanged published-baseline major, minor, and date tuple.')
 
@@ -8542,10 +8644,13 @@ if ($SelfTest) {
         $objAgentsVersionMatch.Value,
         $strAgentsVersionStem + $intJumpedAgentsRevision
     )
-    Assert-FixtureAccepted `
+    Assert-Failure `
         -AgentsContent $strSameDayRevisionJump `
         -ParentAgentsContent $strAgentsContent `
-        -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value
+        -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value `
+        -Failure ("AGENTS.md Version revision must be exactly " +
+            "$intNextAgentsRevision after a rendered-content change with an " +
+            'unchanged published-baseline major, minor, and date tuple.')
 
     $objIsoEvent = ConvertFrom-TrustedEventTimestamp -Timestamp `
         ($objAgentsUpdatedMatch.Groups['Date'].Value + 'T00:00:00Z')
@@ -8690,8 +8795,10 @@ if ($SelfTest) {
         -Name 'endpoint-fixture.md' -CurrentContent $strHigherRevisionPublishedFinal `
         -ParentContent $strEndpointBaseline -ExpectedUtcDate '2026-08-31' `
         -IsNewDocumentTransition $false)
-    if ($arrHigherRevisionPublishedFinalFailures.Count -ne 0) {
-        throw 'A higher published final revision was rejected.'
+    if ($arrHigherRevisionPublishedFinalFailures -cnotcontains
+        ('endpoint-fixture.md Version revision must be exactly 0 when a ' +
+            'published-baseline major, minor, or date segment changes.')) {
+        throw 'A nonzero revision after a higher-order change did not fail closed.'
     }
     $strSameTupleFinal = $strEndpointBaseline.Replace(
         '**Version:** 1.0.20260830.0', '**Version:** 1.0.20260830.1'
@@ -8706,8 +8813,11 @@ if ($SelfTest) {
     if (@(Get-PublishedEndpointMetadataFailure -Name 'endpoint-fixture.md' `
             -CurrentContent $strSkippedRevisionFinal `
             -ParentContent $strEndpointBaseline -ExpectedUtcDate '2026-08-30' `
-            -IsNewDocumentTransition $false).Count -ne 0) {
-        throw 'A higher same-tuple published final revision was rejected.'
+            -IsNewDocumentTransition $false) -cnotcontains
+        ('endpoint-fixture.md Version revision must be exactly 1 after a ' +
+            'rendered-content change with an unchanged published-baseline major, ' +
+            'minor, and date tuple.')) {
+        throw 'A skipped same-tuple published final revision did not fail closed.'
     }
     foreach ($strLifecycleStatus in @(
             'Draft', 'Proposed', 'Active', 'Accepted', 'Superseded', 'Deprecated'
@@ -8716,7 +8826,7 @@ if ($SelfTest) {
             '- **Status:** Active', "- **Status:** $strLifecycleStatus")
         if ($null -ne (Get-DocumentMetadataContext `
                 -Content $strLifecycleFixture).Failure) {
-            throw "ADR lifecycle status was rejected: $strLifecycleStatus"
+            throw "A generic Tier 1 lifecycle status was rejected: $strLifecycleStatus"
         }
     }
     Assert-PublishedEndpointContext -RepositoryRootPath $strRepositoryRootPath `

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -2,7 +2,7 @@
 # Validates governed agent instructions and optional authenticated Git ranges.
 # .NOTES
 # Positional parameters are not supported.
-# Version: 1.7.20260902.1
+# Version: 1.7.20260902.2
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([string])]
@@ -4127,6 +4127,61 @@ function Get-CreatedRefBoundaryContext {
     }
 }
 
+function Get-CreatedRefMetadataBaselineRevision {
+    # .SYNOPSIS
+    # Selects the authenticated metadata baseline for one created ref.
+    # .DESCRIPTION
+    # Reuses the exact head when the ref introduces no commits, uses the sole
+    # outside-parent boundary for introduced non-root history, returns no
+    # baseline for a genuine root, and rejects ambiguous multi-boundary history.
+    # .PARAMETER Context
+    # The authenticated context returned by Get-CreatedRefBoundaryContext.
+    # .PARAMETER HeadRevision
+    # The exact created-ref final commit.
+    # .EXAMPLE
+    # Get-CreatedRefMetadataBaselineRevision @hashtableArguments
+    #
+    # # Returns the authenticated metadata baseline.
+    # .INPUTS
+    # None. No pipeline input.
+    # .OUTPUTS
+    # [string] The baseline commit, or an empty string for a genuine root.
+    # .NOTES
+    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
+    # Parameters, return shape, and positional contract can change without notice.
+    # Positional parameters are disabled; internal callers use named arguments.
+    # Version: 1.0.20260902.0.
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][pscustomobject] $Context,
+        [Parameter(Mandatory)][string] $HeadRevision
+    )
+
+    $arrIntroduced = @($Context.IntroducedCommitRevisions)
+    $arrBoundaries = @($Context.BoundaryRevisions)
+    $strEffectiveBaseline = [string] $Context.EffectiveBaselineRevision
+    if ($Context.IsGenuineRootIntroduction) {
+        if ($arrIntroduced.Count -lt 1 -or $arrBoundaries.Count -ne 0 -or
+            -not [string]::IsNullOrEmpty($strEffectiveBaseline)) {
+            throw 'The genuine-root created-ref metadata context is inconsistent.'
+        }
+        return ''
+    }
+    if ($arrIntroduced.Count -eq 0) {
+        if ($arrBoundaries.Count -ne 0 -or
+            $strEffectiveBaseline -cne $HeadRevision) {
+            throw 'The zero-introduction created-ref metadata context is inconsistent.'
+        }
+        return $HeadRevision
+    }
+    if ($arrBoundaries.Count -eq 1 -and
+        $strEffectiveBaseline -ceq $arrBoundaries[0]) {
+        return $strEffectiveBaseline
+    }
+    throw 'An introduced created ref lacks one unambiguous metadata baseline.'
+}
+
 function Test-GovernedInstructionPath {
     # .SYNOPSIS
     # Tests whether a repository-relative path is a governed instruction path.
@@ -4903,6 +4958,64 @@ function Get-DecisionLifecyclePolicyFailure {
     }
 }
 
+function Get-DecisionRecordLifecycleFailure {
+    # .SYNOPSIS
+    # Finds lifecycle representation failures in one decision record.
+    # .DESCRIPTION
+    # Requires one four-state metadata Status and no operative level-two Status
+    # section for a new or changed ADR. An unchanged published legacy ADR remains
+    # valid until its next content change, as required by the migration boundary.
+    # .PARAMETER Name
+    # The repository-relative decision-record path.
+    # .PARAMETER CurrentContent
+    # The final decision-record content.
+    # .PARAMETER BaselineContent
+    # The published baseline content, or null when no baseline document exists.
+    # .EXAMPLE
+    # Get-DecisionRecordLifecycleFailure @hashtableArguments
+    #
+    # # Returns lifecycle failures for one changed decision record.
+    # .INPUTS
+    # None. No pipeline input.
+    # .OUTPUTS
+    # [string] Zero or more lifecycle diagnostics.
+    # .NOTES
+    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
+    # Parameters, return shape, and positional contract can change without notice.
+    # Positional parameters are disabled; internal callers use named arguments.
+    # Version: 1.0.20260902.0.
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory)][string] $CurrentContent,
+        [Parameter()][AllowNull()][string] $BaselineContent
+    )
+
+    if ($null -ne $BaselineContent -and
+        $CurrentContent -ceq $BaselineContent) {
+        return
+    }
+    $objMetadata = Get-DocumentMetadataContext `
+        -Content $CurrentContent -RequiresVersion $false
+    if ($null -ne $objMetadata.Failure) {
+        return
+    }
+    $arrAllowedStatuses = @(
+        'Proposed', 'Accepted', 'Superseded', 'Deprecated'
+    )
+    if ($arrAllowedStatuses -cnotcontains $objMetadata.Status) {
+        Write-Output (
+            "$Name Status must be Proposed, Accepted, Superseded, or Deprecated."
+        )
+    }
+    $objMarkdownContext = Get-OperativeMarkdownContext -Content $CurrentContent
+    if (@($objMarkdownContext.LevelTwoHeadings |
+            Where-Object Text -CEQ 'Status').Count -ne 0) {
+        Write-Output "$Name must not contain a separate operative Status section."
+    }
+}
+
 function Get-DocumentMetadataContext {
     # .SYNOPSIS
     # Gets validated document-level metadata context.
@@ -5147,6 +5260,7 @@ function Get-DocumentMetadataContext {
 
     return [pscustomobject]@{
         Failure = $null
+        Status = $hashtableFieldMatches['Status'].Groups['Value'].Value
         Major = if ($RequiresVersion) {$objVersionMatch.Groups['Major'].Value} else {$null}
         Minor = if ($RequiresVersion) {$objVersionMatch.Groups['Minor'].Value} else {$null}
         VersionDate = if ($RequiresVersion) {$objVersionMatch.Groups['Date'].Value} else {$null}
@@ -6469,9 +6583,14 @@ if (-not $boolPublishedEndpointsRequested -and
         $PublishedBaselineAbsent -or $PublishedFinalDeleted)) {
     throw 'Metadata event fields require complete published endpoints.'
 }
+$objTrustedEventTimestamp = $null
+$strTrustedEventUtcDate = ''
 if (-not [string]::IsNullOrEmpty($TrustedEventTimestamp)) {
-    [void] (
+    $objTrustedEventTimestamp =
         ConvertFrom-TrustedEventTimestamp -Timestamp $TrustedEventTimestamp
+    $strTrustedEventUtcDate = $objTrustedEventTimestamp.ToString(
+        'yyyy-MM-dd',
+        [Globalization.CultureInfo]::InvariantCulture
     )
 }
 if ($boolPublishedEndpointsRequested) {
@@ -6484,6 +6603,7 @@ if ($boolPublishedEndpointsRequested) {
         -PullRequestBaseChanged $PullRequestBaseChanged
 }
 $objCreatedRefContext = $null
+$strCreatedRefMetadataBaselineRevision = ''
 if ($PublishedBaselineAbsent) {
     $objCreatedRefContext = Get-CreatedRefBoundaryContext `
         -RepositoryRootPath $strRepositoryRootPath `
@@ -6493,6 +6613,10 @@ if ($PublishedBaselineAbsent) {
         -EventHeadDistinct $EventHeadDistinct `
         -PushCommitEvidenceJson $PushCommitEvidenceJson `
         -OtherRefEvidenceJson $OtherRefEvidenceJson
+    $strCreatedRefMetadataBaselineRevision =
+        Get-CreatedRefMetadataBaselineRevision `
+            -Context $objCreatedRefContext `
+            -HeadRevision $PublishedFinalRevision
 }
 elseif (-not [string]::IsNullOrEmpty($DestinationRef) -or
     -not [string]::IsNullOrEmpty($EventHeadRevision) -or
@@ -6769,13 +6893,24 @@ if (-not [string]::IsNullOrEmpty($strValidatedInputRevision) -and
         [StringComparison]::OrdinalIgnoreCase
     )) {
     $arrTrustRootBaseRevisions = @($arrPublishedGraphBases)
-    $arrTrustRootFailures = @(Get-TrustRootRangeMutationFailure `
-            -ExactAuthorizedMaintenanceProductionCall `
-            -RepositoryRootPath $strRepositoryRootPath `
-            -BaseRevision $arrTrustRootBaseRevisions `
-            -HeadRevision $PublishedFinalRevision `
-            -RepositoryRelativePath $script:arrTrustRootPaths) |
-        Sort-Object -Unique
+    $arrTrustRootFailures = if (
+        $script:boolTrustedMaintenanceAuthorizationValidated
+    ) {
+        @(Get-TrustRootRangeMutationFailure `
+                -ExactAuthorizedMaintenanceProductionCall `
+                -RepositoryRootPath $strRepositoryRootPath `
+                -BaseRevision $arrTrustRootBaseRevisions `
+                -HeadRevision $PublishedFinalRevision `
+                -RepositoryRelativePath $script:arrTrustRootPaths)
+    }
+    else {
+        @(Get-TrustRootRangeMutationFailure `
+                -RepositoryRootPath $strRepositoryRootPath `
+                -BaseRevision $arrTrustRootBaseRevisions `
+                -HeadRevision $PublishedFinalRevision `
+                -RepositoryRelativePath $script:arrTrustRootPaths)
+    }
+    $arrTrustRootFailures = @($arrTrustRootFailures | Sort-Object -Unique)
     if (@($arrTrustRootFailures).Count -gt 0) {
         throw (
             'Trusted validation root changed:' + [Environment]::NewLine + '- ' +
@@ -7000,20 +7135,18 @@ $listGovernedDocumentContexts = [Collections.Generic.List[pscustomobject]]::new(
 foreach ($objDocumentSpec in $arrGovernedMetadataDocuments) {
     $objParentContext = if ($boolPublishedEndpointsRequested) {
         $strPublishedBaselineContent = $null
-        $boolGenuineRootIntroduction = $PublishedBaselineAbsent -and
-            $null -ne $objCreatedRefContext -and
-            $objCreatedRefContext.IsGenuineRootIntroduction
-        if ($PublishedBaselineAbsent -and -not $boolGenuineRootIntroduction) {
-            $strPublishedBaselineContent =
-                $hashtableGovernedInstructionContent[$objDocumentSpec.Path]
+        $strMetadataBaselineRevision = if ($PublishedBaselineAbsent) {
+            $strCreatedRefMetadataBaselineRevision
+        } else {
+            $PublishedBaselineRevision
         }
-        elseif (-not $PublishedBaselineAbsent) {
+        if (-not [string]::IsNullOrEmpty($strMetadataBaselineRevision)) {
             & git -C $strRepositoryRootPath cat-file -e `
-                "$PublishedBaselineRevision`:$($objDocumentSpec.Path)" 2>$null
+                "$strMetadataBaselineRevision`:$($objDocumentSpec.Path)" 2>$null
             if ($LASTEXITCODE -eq 0) {
                 $strPublishedBaselineContent = Read-GitRevisionText `
                     -RepositoryRootPath $strRepositoryRootPath `
-                    -Revision $PublishedBaselineRevision `
+                    -Revision $strMetadataBaselineRevision `
                     -RepositoryRelativePath $objDocumentSpec.Path `
                     -MaximumBytes $objDocumentSpec.MaximumBytes `
                     -RequireRegularFile
@@ -7021,13 +7154,9 @@ foreach ($objDocumentSpec in $arrGovernedMetadataDocuments) {
         }
         [pscustomobject]@{
             ParentContent = $strPublishedBaselineContent
-            ExpectedUtcDate = ''
-            ParentRevision = if ($PublishedBaselineAbsent) {
-                $null
-            } else {
-                $PublishedBaselineRevision
-            }
-            IsWorktreeTransition = $false
+            ExpectedUtcDate = $strTrustedEventUtcDate
+            ParentRevision = $strMetadataBaselineRevision
+            IsWorktreeTransition = $true
         }
     }
     elseif ([string]::IsNullOrEmpty($strValidatedInputRevision)) {
@@ -7106,6 +7235,10 @@ foreach ($objDecisionContext in @(
     if ($null -eq $objDecisionContext.Content) {
         continue
     }
+    $arrRepositoryFailures += @(Get-DecisionRecordLifecycleFailure `
+            -Name $objDecisionContext.Path `
+            -CurrentContent $objDecisionContext.Content `
+            -BaselineContent $objDecisionContext.ParentContent)
     $objDecisionMarkdownContext = Get-OperativeMarkdownContext `
         -Content $objDecisionContext.Content
     $arrDecisionLinks = [string[]]@(
@@ -7185,8 +7318,8 @@ if ($SelfTest) {
         param($objNode)
         $objNode -is [Management.Automation.Language.FunctionDefinitionAst]
     }, $true))
-    if ($arrValidatorFunctionAsts.Count -ne 56) {
-        throw 'The validator function-help inventory must contain exactly 56 functions.'
+    if ($arrValidatorFunctionAsts.Count -ne 58) {
+        throw 'The validator function-help inventory must contain exactly 58 functions.'
     }
     foreach ($objFunctionAst in $arrValidatorFunctionAsts) {
         $objHelp = $objFunctionAst.GetHelpContent()
@@ -7246,9 +7379,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strValidatorSource,
-            '(?m)^# Version: 1\.7\.20260902\.1$'
+            '(?m)^# Version: 1\.7\.20260902\.2$'
         ).Count -ne 1) {
-        throw 'The validator script version is not 1.7.20260902.1.'
+        throw 'The validator script version is not 1.7.20260902.2.'
     }
     $boolSavedWindowsPython = $script:useWindowsPythonLauncher
     $arrSavedPythonNames = $script:pythonPathNames
@@ -7364,6 +7497,64 @@ if ($SelfTest) {
                 -Content $strNarrativeDecisionStatusMutation) -cnotcontains
             'Decision records must prohibit a separate narrative status representation.') {
         throw 'A permitted narrative decision Status did not fail closed.'
+    }
+    $strLegacyDecisionRecord = @(
+        '# Decision 0001: Legacy fixture'
+        '## Metadata'
+        '- **Status:** Active'
+        '- **Owner:** Repository Maintainers'
+        '- **Last Updated:** 2026-08-30'
+        '- **Scope:** Tests transition-aware ADR lifecycle enforcement.'
+        '## Status'
+        'Accepted before the lifecycle migration.'
+        '## Context'
+        'Legacy context.'
+    ) -join "`n"
+    if (@(Get-DecisionRecordLifecycleFailure `
+            -Name 'docs/decisions/0001-legacy.md' `
+            -CurrentContent $strLegacyDecisionRecord `
+            -BaselineContent $strLegacyDecisionRecord).Count -ne 0) {
+        throw 'An unchanged published legacy ADR did not remain valid.'
+    }
+    $strChangedLegacyDecisionRecord = $strLegacyDecisionRecord.Replace(
+        'Legacy context.',
+        'Changed legacy context.'
+    )
+    $arrChangedLegacyDecisionFailures = @(Get-DecisionRecordLifecycleFailure `
+            -Name 'docs/decisions/0001-legacy.md' `
+            -CurrentContent $strChangedLegacyDecisionRecord `
+            -BaselineContent $strLegacyDecisionRecord)
+    foreach ($strExpectedFailure in @(
+            ('docs/decisions/0001-legacy.md Status must be Proposed, Accepted, ' +
+                'Superseded, or Deprecated.'),
+            ('docs/decisions/0001-legacy.md must not contain a separate operative ' +
+                'Status section.')
+        )) {
+        if ($arrChangedLegacyDecisionFailures -cnotcontains $strExpectedFailure) {
+            throw (
+                'A changed legacy ADR did not require lifecycle migration: ' +
+                ($arrChangedLegacyDecisionFailures -join '; ')
+            )
+        }
+    }
+    $strCompliantDecisionRecord = $strChangedLegacyDecisionRecord.Replace(
+        '- **Status:** Active',
+        '- **Status:** Accepted'
+    ).Replace(
+        "## Status`nAccepted before the lifecycle migration.`n",
+        ''
+    )
+    if (@(Get-DecisionRecordLifecycleFailure `
+            -Name 'docs/decisions/0001-legacy.md' `
+            -CurrentContent $strCompliantDecisionRecord `
+            -BaselineContent $strLegacyDecisionRecord).Count -ne 0) {
+        throw 'A changed ADR with one valid lifecycle Status did not pass.'
+    }
+    if (@(Get-DecisionRecordLifecycleFailure `
+            -Name 'docs/decisions/0003-new.md' `
+            -CurrentContent $strLegacyDecisionRecord `
+            -BaselineContent $null).Count -ne 2) {
+        throw 'A new ADR accepted the legacy two-status representation.'
     }
     foreach ($strOwnerPath in $script:arrDocumentationClaimOwnerPaths) {
         $arrMissingOwnerFailures = @(Get-DocumentationClaimFailure `
@@ -7604,9 +7795,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strExtractedSelfTestSource,
-            '(?m)^# Version: 1\.2\.20260902\.0$'
+            '(?m)^# Version: 1\.2\.20260902\.1$'
         ).Count -ne 1) {
-        throw 'The extracted self-test lacks version 1.2.20260902.0.'
+        throw 'The extracted self-test lacks version 1.2.20260902.1.'
     }
     $strExtractedSelfTestRevision = if (
         [string]::IsNullOrEmpty($strValidatedInputRevision)

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -2,7 +2,7 @@
 # Validates governed agent instructions and optional authenticated Git ranges.
 # .NOTES
 # Positional parameters are not supported.
-# Version: 1.7.20260902.4
+# Version: 1.7.20260902.5
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([string])]
@@ -7384,9 +7384,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strValidatorSource,
-            '(?m)^# Version: 1\.7\.20260902\.4$'
+            '(?m)^# Version: 1\.7\.20260902\.5$'
         ).Count -ne 1) {
-        throw 'The validator script version is not 1.7.20260902.4.'
+        throw 'The validator script version is not 1.7.20260902.5.'
     }
     $boolSavedWindowsPython = $script:useWindowsPythonLauncher
     $arrSavedPythonNames = $script:pythonPathNames
@@ -7762,6 +7762,55 @@ if ($SelfTest) {
     }
     if (Test-ProhibitedClaudeLocalPath -RepositoryRelativePath 'CLAUDE.local.md.bak') {
         throw 'A Claude local-memory near miss was prohibited.'
+    }
+    $strTrustRootAuthorizationPath =
+        '.github/workflows/Test-TrustRootAuthorization.ps1'
+    $strTrustRootAuthorizationSource = [IO.File]::ReadAllText(
+        (Join-Path $strRepositoryRootPath $strTrustRootAuthorizationPath),
+        [Text.UTF8Encoding]::new($false)
+    )
+    $arrTrustRootAuthorizationTokens = $null
+    $arrTrustRootAuthorizationParseErrors = $null
+    $objTrustRootAuthorizationAst =
+        [Management.Automation.Language.Parser]::ParseInput(
+            $strTrustRootAuthorizationSource,
+            [ref] $arrTrustRootAuthorizationTokens,
+            [ref] $arrTrustRootAuthorizationParseErrors
+        )
+    if (@($arrTrustRootAuthorizationParseErrors).Count -ne 0 -or
+        $null -eq $objTrustRootAuthorizationAst.ParamBlock) {
+        throw 'The trust-root authorization script parameter inventory is invalid.'
+    }
+    $strTrustRootAuthorizationHelpSource =
+        $strTrustRootAuthorizationSource.Substring(
+            0,
+            $objTrustRootAuthorizationAst.ParamBlock.Extent.StartOffset
+        )
+    $arrTrustRootAuthorizationParameterNames = @(
+        $objTrustRootAuthorizationAst.ParamBlock.Parameters |
+            ForEach-Object { $_.Name.VariablePath.UserPath }
+    )
+    $arrTrustRootAuthorizationHelpMatches = @(
+        [regex]::Matches(
+            $strTrustRootAuthorizationHelpSource,
+            '(?m)^# \.PARAMETER ([A-Za-z][A-Za-z0-9]*)$'
+        )
+    )
+    if ($arrTrustRootAuthorizationHelpMatches.Count -ne
+        $arrTrustRootAuthorizationParameterNames.Count) {
+        throw 'The trust-root authorization script parameter help inventory is incomplete.'
+    }
+    foreach ($strTrustRootAuthorizationParameterName in
+        $arrTrustRootAuthorizationParameterNames) {
+        if (@($arrTrustRootAuthorizationHelpMatches | Where-Object {
+                    $_.Groups[1].Value -ceq
+                        $strTrustRootAuthorizationParameterName
+                }).Count -ne 1) {
+            throw (
+                'The trust-root authorization script lacks exactly one help ' +
+                    "entry for $strTrustRootAuthorizationParameterName."
+            )
+        }
     }
     $strExtractedSelfTestPath =
         '.github/workflows/Test-AgentInstructions.SelfTest.ps1'

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -2,7 +2,7 @@
 # Validates governed agent instructions and optional authenticated Git ranges.
 # .NOTES
 # Positional parameters are not supported.
-# Version: 1.7.20260902.0
+# Version: 1.7.20260902.1
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([string])]
@@ -7246,9 +7246,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strValidatorSource,
-            '(?m)^# Version: 1\.7\.20260902\.0$'
+            '(?m)^# Version: 1\.7\.20260902\.1$'
         ).Count -ne 1) {
-        throw 'The validator script version does not use build date 20260902.'
+        throw 'The validator script version is not 1.7.20260902.1.'
     }
     $boolSavedWindowsPython = $script:useWindowsPythonLauncher
     $arrSavedPythonNames = $script:pythonPathNames

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -6762,10 +6762,28 @@ if ($SelfTest) {
             throw 'Could not resolve the trust-root authorization mutation.'
         }
 
-        $strAuthorizationFixtureUri =
-            ([Uri] $strAuthorizationFixtureRepository).AbsoluteUri
+        $strAuthorizationFixtureCloneSource =
+            [IO.Path]::GetFullPath($strAuthorizationFixtureRepository)
+        $strAuthorizationFixtureResolvedSource = [IO.Path]::GetFullPath(
+            (Get-Item -LiteralPath $strAuthorizationFixtureCloneSource `
+                    -ErrorAction Stop).FullName
+        )
+        if ([string]::IsNullOrWhiteSpace(
+                $strAuthorizationFixtureCloneSource
+            ) -or
+            -not [IO.Path]::IsPathFullyQualified(
+                $strAuthorizationFixtureCloneSource
+            ) -or
+            -not [string]::Equals(
+                $strAuthorizationFixtureCloneSource,
+                $strAuthorizationFixtureResolvedSource,
+                [StringComparison]::Ordinal
+            )) {
+            throw 'The trust-root fixture clone source path is invalid.'
+        }
         & git clone --quiet --depth 1 --no-local --no-hardlinks -- `
-            $strAuthorizationFixtureUri $strAuthorizationFixtureDepthOneClone
+            $strAuthorizationFixtureCloneSource `
+            $strAuthorizationFixtureDepthOneClone
         if ($LASTEXITCODE -ne 0) {
             throw 'Could not create the depth-one trust-root fixture clone.'
         }
@@ -9161,6 +9179,66 @@ if ($SelfTest) {
         [IO.Path]::Combine($PSScriptRoot, 'agent-instructions.yml')
     )
     $strValidatorSourceContent = [IO.File]::ReadAllText($PSCommandPath)
+    $scriptBlockGetFixtureCloneSourceFailure = {
+        param([Parameter(Mandatory)][string] $Content)
+
+        $listFailures = [Collections.Generic.List[string]]::new()
+        $strForbiddenUriConversion =
+            '([Uri] $strAuthorizationFixtureRepository).' + 'AbsoluteUri'
+        if ($Content.Contains(
+                $strForbiddenUriConversion,
+                [StringComparison]::Ordinal
+            )) {
+            $listFailures.Add(
+                'The fixture clone source must not use URI conversion.'
+            )
+        }
+        if ($Content -notmatch (
+                '(?s)\$strAuthorizationFixtureCloneSource\s*=\s*' +
+                '\[IO\.Path\]::GetFullPath\(' +
+                '\$strAuthorizationFixtureRepository\).*?' +
+                '\[IO\.Path\]::IsPathFullyQualified\(\s*' +
+                '\$strAuthorizationFixtureCloneSource\s*\).*?' +
+                '\[string\]::Equals\(\s*' +
+                '\$strAuthorizationFixtureCloneSource,\s*' +
+                '\$strAuthorizationFixtureResolvedSource,\s*' +
+                '\[StringComparison\]::Ordinal\s*\).*?' +
+                'git clone --quiet --depth 1 --no-local --no-hardlinks --' +
+                '\s*`?\s*\$strAuthorizationFixtureCloneSource\s*`?\s*' +
+                '\$strAuthorizationFixtureDepthOneClone'
+            )) {
+            $listFailures.Add(
+                'The fixture clone source path contract is incomplete.'
+            )
+        }
+        return $listFailures.ToArray()
+    }
+    $arrFixtureCloneSourceFailures = @(
+        & $scriptBlockGetFixtureCloneSourceFailure `
+            -Content $strValidatorSourceContent
+    )
+    if ($arrFixtureCloneSourceFailures.Count -ne 0) {
+        throw (
+            'Fixture clone source contract failed: ' +
+            ($arrFixtureCloneSourceFailures -join '; ')
+        )
+    }
+    $strOldFixtureUriConversion =
+        '([Uri] $strAuthorizationFixtureRepository).' + 'AbsoluteUri'
+    $strMutatedFixtureCloneSource = $strValidatorSourceContent.Replace(
+        '[IO.Path]::GetFullPath($strAuthorizationFixtureRepository)',
+        $strOldFixtureUriConversion
+    )
+    $arrMutatedFixtureCloneSourceFailures = @(
+        & $scriptBlockGetFixtureCloneSourceFailure `
+            -Content $strMutatedFixtureCloneSource
+    )
+    if ($strMutatedFixtureCloneSource -ceq $strValidatorSourceContent -or
+        $arrMutatedFixtureCloneSourceFailures.Count -lt 1 -or
+        $arrMutatedFixtureCloneSourceFailures -cnotcontains
+            'The fixture clone source must not use URI conversion.') {
+        throw 'The unsafe fixture clone source mutation was not rejected.'
+    }
     $arrLegacyCompatibilityVariableName = @(
         'script:strLegacyMetadataRangeCompatibilityMarker',
         'script:strLegacyStyleGuideRationaleCompatibilityMarker',

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -2,7 +2,7 @@
 # Validates governed agent instructions and optional authenticated Git ranges.
 # .NOTES
 # Positional parameters are not supported.
-# Version: 1.7.20260902.5
+# Version: 1.7.20260902.6
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([string])]
@@ -4890,7 +4890,8 @@ function Get-DecisionLifecyclePolicyFailure {
     #
     # .DESCRIPTION
     # Requires one decision-record Status representation, the four retained
-    # lifecycle values, and an explicit prohibition on a second narrative status.
+    # lifecycle values, an explicit prohibition on a second narrative status,
+    # and the unchanged-byte legacy migration boundary.
     #
     # .PARAMETER Content
     # The documentation instruction content to inspect.
@@ -4958,15 +4959,28 @@ function Get-DecisionLifecyclePolicyFailure {
             'Decision records must prohibit a separate narrative status representation.'
         )
     }
+
+    if ([regex]::Matches(
+            $strSectionBody,
+            ('Published legacy decision records that predate this lifecycle rule ' +
+                'MAY retain their existing status representation while their bytes ' +
+                'remain unchanged\. The next change to such a record MUST migrate it ' +
+                'to the single Tier 1 Status metadata field and MUST remove each ' +
+                'separate narrative status field or section\.')
+        ).Count -ne 1) {
+        Write-Output (
+            'Decision records must document the unchanged legacy migration boundary.'
+        )
+    }
 }
 
 function Get-DecisionRecordLifecycleFailure {
     # .SYNOPSIS
     # Finds lifecycle representation failures in one decision record.
     # .DESCRIPTION
-    # Requires one four-state metadata Status and no operative level-two Status
-    # section for a new or changed ADR. An unchanged published legacy ADR remains
-    # valid until its next content change, as required by the migration boundary.
+    # Requires one four-state metadata Status and no separate structured Status
+    # field or section for a new or changed ADR. An unchanged published legacy ADR
+    # remains valid until its next content change under the migration boundary.
     # .PARAMETER Name
     # The repository-relative decision-record path.
     # .PARAMETER CurrentContent
@@ -5012,9 +5026,33 @@ function Get-DecisionRecordLifecycleFailure {
         )
     }
     $objMarkdownContext = Get-OperativeMarkdownContext -Content $CurrentContent
+    $objMetadataHeading = @(
+        $objMarkdownContext.LevelTwoHeadings |
+            Where-Object Text -CEQ 'Metadata'
+    )[0]
+    $intMetadataSectionEnd = $objMarkdownContext.SourceLines.Count
+    foreach ($objLevelTwoHeading in $objMarkdownContext.LevelTwoHeadings) {
+        if ($objLevelTwoHeading.Start -gt $objMetadataHeading.Start) {
+            $intMetadataSectionEnd = $objLevelTwoHeading.Start
+            break
+        }
+    }
     if (@($objMarkdownContext.LevelTwoHeadings |
-            Where-Object Text -CEQ 'Status').Count -ne 0) {
+            Where-Object {
+                $_.Start -ne $objMetadataHeading.Start -and
+                $_.Text -match '(?i)\bStatus\b'
+            }).Count -ne 0) {
         Write-Output "$Name must not contain a separate operative Status section."
+    }
+    if (@($objMarkdownContext.ProseBlocks |
+            Where-Object {
+                ($_.Start -le $objMetadataHeading.Start -or
+                    $_.Start -ge $intMetadataSectionEnd) -and
+                $_.Text -match '(?i)^[^:\r\n]*\bStatus\b\s*:\s*\S'
+            }).Count -ne 0) {
+        Write-Output (
+            "$Name must not contain a separate operative Status field outside Metadata."
+        )
     }
 }
 
@@ -7384,9 +7422,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strValidatorSource,
-            '(?m)^# Version: 1\.7\.20260902\.5$'
+            '(?m)^# Version: 1\.7\.20260902\.6$'
         ).Count -ne 1) {
-        throw 'The validator script version is not 1.7.20260902.5.'
+        throw 'The validator script version is not 1.7.20260902.6.'
     }
     $boolSavedWindowsPython = $script:useWindowsPythonLauncher
     $arrSavedPythonNames = $script:pythonPathNames
@@ -7503,6 +7541,26 @@ if ($SelfTest) {
             'Decision records must prohibit a separate narrative status representation.') {
         throw 'A permitted narrative decision Status did not fail closed.'
     }
+    $strPermanentLegacyDecisionMutation = $strDocsInstructionsContent.Replace(
+        'while their bytes remain unchanged.',
+        'without a required migration boundary.'
+    )
+    if ($strPermanentLegacyDecisionMutation -ceq $strDocsInstructionsContent -or
+        @(Get-DecisionLifecyclePolicyFailure `
+                -Content $strPermanentLegacyDecisionMutation) -cnotcontains
+            'Decision records must document the unchanged legacy migration boundary.') {
+        throw 'A permanent legacy decision exception did not fail closed.'
+    }
+    $strOptionalLegacyMigrationMutation = $strDocsInstructionsContent.Replace(
+        'The next change to such a record MUST migrate it',
+        'The next change to such a record MAY migrate it'
+    )
+    if ($strOptionalLegacyMigrationMutation -ceq $strDocsInstructionsContent -or
+        @(Get-DecisionLifecyclePolicyFailure `
+                -Content $strOptionalLegacyMigrationMutation) -cnotcontains
+            'Decision records must document the unchanged legacy migration boundary.') {
+        throw 'An optional legacy decision migration did not fail closed.'
+    }
     $strLegacyDecisionRecord = @(
         '# Decision 0001: Legacy fixture'
         '## Metadata'
@@ -7554,6 +7612,40 @@ if ($SelfTest) {
             -CurrentContent $strCompliantDecisionRecord `
             -BaselineContent $strLegacyDecisionRecord).Count -ne 0) {
         throw 'A changed ADR with one valid lifecycle Status did not pass.'
+    }
+    $strDecisionStatusSectionRecord = $strCompliantDecisionRecord.Replace(
+        "## Context`n",
+        "## Decision Status`nAccepted.`n## Context`n"
+    )
+    if (@(Get-DecisionRecordLifecycleFailure `
+            -Name 'docs/decisions/0001-legacy.md' `
+            -CurrentContent $strDecisionStatusSectionRecord `
+            -BaselineContent $strLegacyDecisionRecord) -cnotcontains
+        ('docs/decisions/0001-legacy.md must not contain a separate operative ' +
+            'Status section.')) {
+        throw 'A Decision Status section escaped lifecycle validation.'
+    }
+    $strDecisionStatusFieldRecord = $strCompliantDecisionRecord.Replace(
+        "## Context`n",
+        "## Context`n- **Decision Status:** Accepted`n"
+    )
+    if (@(Get-DecisionRecordLifecycleFailure `
+            -Name 'docs/decisions/0001-legacy.md' `
+            -CurrentContent $strDecisionStatusFieldRecord `
+            -BaselineContent $strLegacyDecisionRecord) -cnotcontains
+        ('docs/decisions/0001-legacy.md must not contain a separate operative ' +
+            'Status field outside Metadata.')) {
+        throw 'A Decision Status field escaped lifecycle validation.'
+    }
+    $strDecisionStatusProseRecord = $strCompliantDecisionRecord.Replace(
+        'Changed legacy context.',
+        'The decision status remains accepted in ordinary prose.'
+    )
+    if (@(Get-DecisionRecordLifecycleFailure `
+            -Name 'docs/decisions/0001-legacy.md' `
+            -CurrentContent $strDecisionStatusProseRecord `
+            -BaselineContent $strLegacyDecisionRecord).Count -ne 0) {
+        throw 'Ordinary decision status prose was rejected as a second representation.'
     }
     if (@(Get-DecisionRecordLifecycleFailure `
             -Name 'docs/decisions/0003-new.md' `

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -972,6 +972,13 @@ function Read-GitPublishedEndpointChangedPath {
 
     $arrBoundaries = @($NewRefBoundaryRevision)
     $arrIntroducedCommits = @($NewRefIntroducedCommitRevision)
+    $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
+    foreach ($strRevision in @($arrBoundaries + $arrIntroducedCommits)) {
+        if ([string]::IsNullOrEmpty($strRevision) -or
+            $strRevision -notmatch $strObjectIdPattern) {
+            throw 'The created-ref path range contains an invalid revision.'
+        }
+    }
     $arrArguments = if ($BaselineAbsent -and $arrIntroducedCommits.Count -eq 0) {
         return [string[]] @()
     }
@@ -6887,6 +6894,16 @@ $arrTrackedRepositoryPaths = @(Read-GitTrackedPath `
 $arrPublishedBaselinePaths = @()
 $arrPublishedChangedPaths = @()
 if ($boolPublishedEndpointsRequested) {
+    [string[]] $arrPublishedNewRefBoundaryRevisions = @()
+    [string[]] $arrPublishedNewRefIntroducedCommitRevisions = @()
+    if ($null -ne $objCreatedRefContext) {
+        $arrPublishedNewRefBoundaryRevisions = [string[]] @(
+            $objCreatedRefContext.BoundaryRevisions
+        )
+        $arrPublishedNewRefIntroducedCommitRevisions = [string[]] @(
+            $objCreatedRefContext.IntroducedCommitRevisions
+        )
+    }
     if (-not $PublishedBaselineAbsent) {
         $arrPublishedBaselinePaths = @(Read-GitTrackedPath `
             -RepositoryRootPath $strRepositoryRootPath `
@@ -6898,12 +6915,9 @@ if ($boolPublishedEndpointsRequested) {
         -BaselineRevision $PublishedBaselineRevision `
         -FinalRevision $PublishedFinalRevision `
         -BaselineAbsent ([bool]$PublishedBaselineAbsent) `
-        -NewRefBoundaryRevision $(if ($null -eq $objCreatedRefContext) {
-                @()
-            } else { @($objCreatedRefContext.BoundaryRevisions) }) `
-        -NewRefIntroducedCommitRevision $(if ($null -eq $objCreatedRefContext) {
-                @()
-            } else { @($objCreatedRefContext.IntroducedCommitRevisions) }) `
+        -NewRefBoundaryRevision $arrPublishedNewRefBoundaryRevisions `
+        -NewRefIntroducedCommitRevision `
+            $arrPublishedNewRefIntroducedCommitRevisions `
         -MaximumBytes $intGitPathListMaximumBytes) | Sort-Object -Unique
 }
 $arrPublishedDecisionPaths = @(
@@ -8916,6 +8930,163 @@ if ($SelfTest) {
             -FinalRevision $strCheckedOutRevision -BaselineAbsent $false `
             -MaximumBytes $intGitPathListMaximumBytes).Count -ne 0) {
         throw 'Identical published endpoint trees reported changed paths.'
+    }
+    [string[]] $arrPublishedPathEmptyRevisions = @()
+    [string[]] $arrPublishedPathHeadRevision = @($strCheckedOutRevision)
+    $arrNoIntroducedPublishedPaths = @(Read-GitPublishedEndpointChangedPath `
+        -RepositoryRootPath $strRepositoryRootPath `
+        -BaselineRevision '' -FinalRevision $strCheckedOutRevision `
+        -BaselineAbsent $true `
+        -NewRefBoundaryRevision $arrPublishedPathEmptyRevisions `
+        -NewRefIntroducedCommitRevision $arrPublishedPathEmptyRevisions `
+        -MaximumBytes $intGitPathListMaximumBytes)
+    if ($arrNoIntroducedPublishedPaths.Count -ne 0) {
+        throw 'A created ref with no introduced commits reported changed paths.'
+    }
+    $arrRootIntroductionPublishedPaths = @(Read-GitPublishedEndpointChangedPath `
+        -RepositoryRootPath $strRepositoryRootPath `
+        -BaselineRevision '' -FinalRevision $strCheckedOutRevision `
+        -BaselineAbsent $true `
+        -NewRefBoundaryRevision $arrPublishedPathEmptyRevisions `
+        -NewRefIntroducedCommitRevision $arrPublishedPathHeadRevision `
+        -MaximumBytes $intGitPathListMaximumBytes)
+    [string[]] $arrExpectedRootIntroductionPublishedPaths = @(
+        Read-GitTrackedPath -RepositoryRootPath $strRepositoryRootPath `
+            -Revision $strCheckedOutRevision `
+            -MaximumBytes $intGitPathListMaximumBytes
+    )
+    [string[]] $arrActualRootIntroductionPublishedPaths =
+        @($arrRootIntroductionPublishedPaths)
+    [Array]::Sort(
+        $arrExpectedRootIntroductionPublishedPaths,
+        [StringComparer]::Ordinal
+    )
+    [Array]::Sort(
+        $arrActualRootIntroductionPublishedPaths,
+        [StringComparer]::Ordinal
+    )
+    $boolRootIntroductionPathSetMatches =
+        $arrActualRootIntroductionPublishedPaths.Count -eq
+            $arrExpectedRootIntroductionPublishedPaths.Count
+    for ($intPathIndex = 0;
+        $boolRootIntroductionPathSetMatches -and
+            $intPathIndex -lt $arrExpectedRootIntroductionPublishedPaths.Count;
+        $intPathIndex++) {
+        $boolRootIntroductionPathSetMatches =
+            $arrActualRootIntroductionPublishedPaths[$intPathIndex] -ceq
+                $arrExpectedRootIntroductionPublishedPaths[$intPathIndex]
+    }
+    if (-not $boolRootIntroductionPathSetMatches) {
+        throw 'A zero-boundary created ref returned an incorrect final-tree path set.'
+    }
+    $strPublishedPathParentRevision = ([string] (
+            & git -C $strRepositoryRootPath rev-parse --verify 'HEAD^1^{commit}'
+        )).Trim()
+    if ($LASTEXITCODE -ne 0 -or
+        $strPublishedPathParentRevision -notmatch
+            '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
+        throw 'Could not resolve the nonzero-boundary path fixture.'
+    }
+    $objExpectedBoundedPathStartInfo = [Diagnostics.ProcessStartInfo]::new('git')
+    $objExpectedBoundedPathStartInfo.UseShellExecute = $false
+    $objExpectedBoundedPathStartInfo.CreateNoWindow = $true
+    $objExpectedBoundedPathStartInfo.RedirectStandardOutput = $true
+    $objExpectedBoundedPathStartInfo.RedirectStandardError = $true
+    foreach ($strExpectedBoundedPathArgument in @(
+            '-C', $strRepositoryRootPath, 'diff', '--name-only', '-z',
+            '--no-renames', '--no-ext-diff', '--no-textconv',
+            $strPublishedPathParentRevision, $strCheckedOutRevision,
+            '--', ':(top)**'
+        )) {
+        $objExpectedBoundedPathStartInfo.ArgumentList.Add(
+            $strExpectedBoundedPathArgument
+        )
+    }
+    $objExpectedBoundedPathProcess = [Diagnostics.Process]::new()
+    $objExpectedBoundedPathProcess.StartInfo = $objExpectedBoundedPathStartInfo
+    $objExpectedBoundedPathResult = Read-BoundedProcessData `
+        -Process $objExpectedBoundedPathProcess `
+        -MaximumBytes $intGitPathListMaximumBytes `
+        -TimeoutMilliseconds 10000 `
+        -DisplayName 'Independent nonzero-boundary path fixture'
+    if ($objExpectedBoundedPathResult.ExitCode -ne 0) {
+        throw 'Could not derive the expected nonzero-boundary path set.'
+    }
+    [string[]] $arrExpectedBoundedIntroductionPublishedPaths = @(
+        ConvertFrom-GitPathListData -Bytes $objExpectedBoundedPathResult.Bytes
+    )
+    [string[]] $arrPublishedPathParentRevision =
+        @($strPublishedPathParentRevision)
+    $arrBoundedIntroductionPublishedPaths = @(
+        Read-GitPublishedEndpointChangedPath `
+            -RepositoryRootPath $strRepositoryRootPath `
+            -BaselineRevision '' -FinalRevision $strCheckedOutRevision `
+            -BaselineAbsent $true `
+            -NewRefBoundaryRevision $arrPublishedPathParentRevision `
+            -NewRefIntroducedCommitRevision $arrPublishedPathHeadRevision `
+            -MaximumBytes $intGitPathListMaximumBytes
+    )
+    [string[]] $arrActualBoundedIntroductionPublishedPaths =
+        @($arrBoundedIntroductionPublishedPaths)
+    [Array]::Sort(
+        $arrExpectedBoundedIntroductionPublishedPaths,
+        [StringComparer]::Ordinal
+    )
+    [Array]::Sort(
+        $arrActualBoundedIntroductionPublishedPaths,
+        [StringComparer]::Ordinal
+    )
+    $boolBoundedIntroductionPathSetMatches =
+        $arrActualBoundedIntroductionPublishedPaths.Count -eq
+            $arrExpectedBoundedIntroductionPublishedPaths.Count
+    for ($intPathIndex = 0;
+        $boolBoundedIntroductionPathSetMatches -and
+            $intPathIndex -lt $arrExpectedBoundedIntroductionPublishedPaths.Count;
+        $intPathIndex++) {
+        $boolBoundedIntroductionPathSetMatches =
+            $arrActualBoundedIntroductionPublishedPaths[$intPathIndex] -ceq
+                $arrExpectedBoundedIntroductionPublishedPaths[$intPathIndex]
+    }
+    if (-not $boolBoundedIntroductionPathSetMatches) {
+        throw 'A nonzero-boundary created ref returned an incorrect changed-path set.'
+    }
+    foreach ($objMalformedPublishedPathRange in @(
+            [pscustomobject]@{
+                Name = 'null boundary'
+                Boundary = [string[]]::new(1)
+                Introduced = $arrPublishedPathHeadRevision
+            },
+            [pscustomobject]@{
+                Name = 'empty boundary'
+                Boundary = [string[]] @('')
+                Introduced = $arrPublishedPathHeadRevision
+            },
+            [pscustomobject]@{
+                Name = 'invalid introduced revision'
+                Boundary = $arrPublishedPathEmptyRevisions
+                Introduced = [string[]] @('not-an-object-id')
+            }
+        )) {
+        try {
+            [void] @(Read-GitPublishedEndpointChangedPath `
+                    -RepositoryRootPath $strRepositoryRootPath `
+                    -BaselineRevision '' -FinalRevision $strCheckedOutRevision `
+                    -BaselineAbsent $true `
+                    -NewRefBoundaryRevision `
+                        $objMalformedPublishedPathRange.Boundary `
+                    -NewRefIntroducedCommitRevision `
+                        $objMalformedPublishedPathRange.Introduced `
+                    -MaximumBytes $intGitPathListMaximumBytes)
+            throw "A $($objMalformedPublishedPathRange.Name) was accepted."
+        }
+        catch {
+            if (-not $_.Exception.Message.Contains(
+                    'created-ref path range contains an invalid revision',
+                    [StringComparison]::Ordinal
+                )) {
+                throw
+            }
+        }
     }
     $strNewRefTestHead = $strCheckedOutRevision
     $strNewRefZeroRevision = '0' * $strNewRefTestHead.Length

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -2,31 +2,54 @@
 # Validates governed agent instructions and optional authenticated Git ranges.
 # .NOTES
 # Positional parameters are not supported.
-# Version: 1.7.20260830.7
+# Version: 1.7.20260831.0
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([string])]
 param(
     [Parameter()][switch] $SelfTest,
+    [Parameter()][AllowEmptyString()][string] $AuthorizationBaseRevision = '',
+    [Parameter()][AllowEmptyString()][string] $AuthorizationHeadRevision = '',
+    [Parameter()][switch] $TrustedMaintenanceAuthorizationValidated,
     [Parameter()][AllowEmptyString()][string] $InputRevision = '',
-    [Parameter()][AllowEmptyString()][string] $RangeBaseRevision = '',
-    [Parameter()][AllowEmptyString()][string] $RangeHeadRevision = '',
-    [Parameter()][switch] $RangeIsNewRef,
-    [Parameter()][switch] $RangeIsDeletedRef,
+    [Parameter()][AllowEmptyString()][string] $PublishedBaselineRevision = '',
+    [Parameter()][AllowEmptyString()][string] $PublishedFinalRevision = '',
+    [Parameter()][switch] $PublishedBaselineAbsent,
+    [Parameter()][switch] $PublishedFinalDeleted,
     [Parameter()][switch] $PushApplicabilityOnly,
     [Parameter()][AllowEmptyString()][string] $TrustedEventTimestamp = '',
     [Parameter()][AllowEmptyString()][string] $EventName = '',
     [Parameter()][AllowEmptyString()][string] $PullRequestAction = '',
-    [Parameter()][AllowEmptyString()][string] $PreviousHeadRevision = '',
     [Parameter()][AllowEmptyString()][string] $PullRequestBaseChanged = '',
+    [Parameter()][AllowEmptyString()][string] $DestinationRef = '',
     [Parameter()][AllowEmptyString()][string] $EventHeadRevision = '',
     [Parameter()][AllowEmptyString()][string] $EventHeadDistinct = '',
-    [Parameter()][AllowEmptyString()][string] $NewRefCommitCount = '',
-    [Parameter()][AllowEmptyString()][string] $NewRefCommitEvidenceJson = ''
+    [Parameter()][AllowEmptyString()][string] $PushCommitCount = '',
+    [Parameter()][AllowEmptyString()][string] $PushDistinctCommitCount = '',
+    [Parameter()][AllowEmptyString()][string] $PushCommitEvidenceJson = '',
+    [Parameter()][AllowEmptyString()][string] $OtherRefEvidenceJson = ''
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+if ($TrustedMaintenanceAuthorizationValidated) {
+    if ($EventName -cne 'pull_request_target' -or
+        [string]::IsNullOrEmpty($AuthorizationBaseRevision) -or
+        [string]::IsNullOrEmpty($AuthorizationHeadRevision) -or
+        [string]::IsNullOrEmpty($InputRevision) -or
+        $InputRevision -cne $AuthorizationHeadRevision) {
+        throw 'Trusted maintenance authorization requires exact pull request endpoints.'
+    }
+}
+$script:boolTrustedMaintenanceAuthorizationValidated =
+    [bool] $TrustedMaintenanceAuthorizationValidated
+# Trusted-bootstrap compatibility data; do not use as active policy.
+$script:strLegacyMetadataRangeCompatibilityMarker =
+    'metadata-range-transition-policy-v1'
+$script:strLegacyStyleGuideRationaleCompatibilityMarker =
+    'style-guide-rationale-metadata-policy-v1'
+$script:strLegacyOperationalLintGuideCompatibilityMarker =
+    'operational-lint-guide-metadata-policy-v1'
 $intAgentsMaximumInputBytes = 32768
 $intClaudeMaximumInputBytes = 131072
 $intCodexConfigMaximumInputBytes = 65536
@@ -35,15 +58,11 @@ $intDocsInstructionsMaximumInputBytes = 131072
 $intInstructionDocumentMaximumInputBytes = 131072
 $intStyleGuideRationaleMaximumInputBytes = 196608
 $intValidatorMaximumInputBytes = 573440
-$intHistoricalPolicyMarkerMaximumBytes = 573440
 $intGitPathListMaximumBytes = 1048576
-$intMetadataMaximumParents = 64
-$intNewRefMaximumCommitEvidence = 2048
-$strMetadataRangePolicyMarker = 'metadata-range-transition-policy-v1'
-$strLintGuideMetadataPolicyMarker =
-    'operational-lint-guide-metadata-policy-v1'
-$strStyleGuideRationaleMetadataPolicyMarker =
-    'style-guide-rationale-metadata-policy-v1'
+$intMetadataMaximumBoundaries = 64
+$intMaximumOtherRefCount = 256
+$intMaximumIntroducedCommitCount = 4096
+$intMaximumPayloadCommitCount = 2048
 $strPythonPrerequisite =
     'Python 3.12 is required to validate .codex/config.toml. On Windows, ' +
     'install the Python launcher for `py -3.12`; otherwise, expose ' +
@@ -64,9 +83,11 @@ $script:arrOperationalLintGuidePaths = @(
 )
 $script:arrTrustRootPaths = @(
     $script:arrCheckoutAttributePaths
+    '.github/workflows/Test-TrustRootAuthorization.ps1',
     '.github/workflows/Test-AgentInstructions.SelfTest.ps1',
     '.github/workflows/Test-AgentInstructions.ps1',
     '.github/workflows/Test-AgentInstructionParserManifest.mjs',
+    '.github/workflows/trust-root-authorization.json',
     '.github/workflows/agent-instructions.yml'
 )
 $script:arrGovernedInstructionRootPaths = @(
@@ -81,8 +102,10 @@ $script:arrPushGovernedExactPaths = @(
     $script:arrOperationalLintGuidePaths
     '.codex/config.toml',
     '.github/workflows/Test-AgentInstructionParserManifest.mjs',
+    '.github/workflows/Test-TrustRootAuthorization.ps1',
     '.github/workflows/Test-AgentInstructions.SelfTest.ps1',
     '.github/workflows/Test-AgentInstructions.ps1',
+    '.github/workflows/trust-root-authorization.json',
     '.github/workflows/agent-instructions.yml',
     '.gitignore',
     '.npmrc',
@@ -214,8 +237,7 @@ $script:arrProhibitedDocumentationClaimLiterals = @(
     'comment block at the top of `CONTRIBUTING.md`'
 )
 $script:arrDocumentationClaimOwnerPaths = @(
-    '.github/instructions/docs.instructions.md',
-    '.github/workflows/Test-AgentInstructions.ps1'
+    '.github/instructions/docs.instructions.md'
 )
 $script:strClaudeImportFailure =
     'CLAUDE.md must not contain active @path imports.'
@@ -891,47 +913,46 @@ function Read-GitTrackedPath {
     return ConvertFrom-GitPathListData -Bytes $objProcessResult.Bytes
 }
 
-function Read-GitRangeTouchedPath {
+function Read-GitPublishedEndpointChangedPath {
     # .SYNOPSIS
-    # Reads bounded path-touch history from a Git revision range.
+    # Reads bounded paths changed between the published baseline and final state.
     #
     # .DESCRIPTION
-    # Reads every path touched by the authenticated commit history in a revision range.
+    # Uses authenticated endpoint trees. A created ref uses its graph-derived
+    # introduced set and outside-parent boundaries. Only a genuine root uses
+    # the complete final tree.
     #
     # .PARAMETER RepositoryRootPath
     # The absolute path of the trusted Git repository.
     #
-    # .PARAMETER BaseRevision
-    # The authenticated base Git object IDs to exclude from the topic range.
+    # .PARAMETER BaselineRevision
+    # The authenticated published baseline commit, or the zero object ID.
     #
-    # .PARAMETER HeadRevision
-    # The authenticated head Git object ID.
+    # .PARAMETER FinalRevision
+    # The authenticated published final commit.
     #
-    # .PARAMETER IsNewRefRange
-    # Indicates whether the range represents a newly created ref.
+    # .PARAMETER BaselineAbsent
+    # Indicates that the publication created a ref with no baseline tree.
     #
     # .PARAMETER NewRefBoundaryRevision
-    # The authenticated boundary revision for a new ref.
+    # The bounded outside-parent boundary for a created ref.
     #
-    # .PARAMETER NewRefHasIntroducedCommit
-    # Indicates whether the new ref introduces a commit outside the boundary.
-    #
-    # .PARAMETER RepositoryRelativePathspec
-    # The exact repository-relative Git pathspec to inspect.
+    # .PARAMETER NewRefIntroducedCommitRevision
+    # The bounded introduced commit set for a created ref.
     #
     # .PARAMETER MaximumBytes
-    # The maximum permitted output size in bytes.
+    # The maximum permitted Git path-list output size.
     #
     # .EXAMPLE
-    # Read-GitRangeTouchedPath @hashtableArguments
+    # Read-GitPublishedEndpointChangedPath @hashtableArguments
     #
-    # # Runs with validated named arguments.
+    # # Returns the paths whose final state differs from the baseline.
     #
     # .INPUTS
     # None. No pipeline input.
     #
     # .OUTPUTS
-    # [System.String] Zero or more validated values or diagnostics described in the function description.
+    # [string] Zero or more changed repository-relative paths.
     #
     # .NOTES
     # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
@@ -941,118 +962,55 @@ function Read-GitRangeTouchedPath {
     [CmdletBinding(PositionalBinding = $false)]
     [OutputType([string])]
     param(
-        [Parameter(Mandatory)]
-        [string] $RepositoryRootPath,
-
-        [Parameter(Mandatory)]
-        [AllowEmptyCollection()]
-        [AllowEmptyString()]
-        [string[]] $BaseRevision,
-
-        [Parameter(Mandatory)]
-        [string] $HeadRevision,
-
-        [Parameter(Mandatory)]
-        [bool] $IsNewRefRange,
-
-        [Parameter()]
-        [AllowEmptyCollection()]
-        [string[]] $NewRefBoundaryRevision = @(),
-
-        [Parameter()]
-        [bool] $NewRefHasIntroducedCommit = $false,
-
-        [Parameter(Mandatory)]
-        [string] $RepositoryRelativePathspec,
-
-        [Parameter(Mandatory)]
-        [ValidateRange(1, 2147483646)]
-        [int] $MaximumBytes
+        [Parameter(Mandatory)][string] $RepositoryRootPath,
+        [Parameter(Mandatory)][AllowEmptyString()][string] $BaselineRevision,
+        [Parameter(Mandatory)][string] $FinalRevision,
+        [Parameter(Mandatory)][bool] $BaselineAbsent,
+        [Parameter()][AllowEmptyCollection()][string[]] $NewRefBoundaryRevision = @(),
+        [Parameter()][AllowEmptyCollection()][string[]] $NewRefIntroducedCommitRevision = @(),
+        [Parameter(Mandatory)][ValidateRange(1, 2147483646)][int] $MaximumBytes
     )
 
-    $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
-    $strZeroObjectIdPattern = '^(?:0{40}|0{64})$'
-    if ($HeadRevision -notmatch $strObjectIdPattern -or
-        $HeadRevision -match $strZeroObjectIdPattern) {
-        throw 'The touched-path range head is invalid.'
+    $arrBoundaries = @($NewRefBoundaryRevision)
+    $arrIntroducedCommits = @($NewRefIntroducedCommitRevision)
+    $arrArguments = if ($BaselineAbsent -and $arrIntroducedCommits.Count -eq 0) {
+        return [string[]] @()
     }
-    if ($RepositoryRelativePathspec.StartsWith('-', [StringComparison]::Ordinal) -or
-        [IO.Path]::IsPathRooted($RepositoryRelativePathspec) -or
-        $RepositoryRelativePathspec -match '(^|/)\.\.?(/|$)' -or
-        $RepositoryRelativePathspec.Contains('\', [StringComparison]::Ordinal)) {
-        throw 'The touched-path range pathspec is invalid.'
+    elseif ($BaselineAbsent -and $arrBoundaries.Count -eq 0) {
+        @('-C', $RepositoryRootPath, 'ls-tree', '-r', '-z', '--name-only',
+            $FinalRevision)
     }
-
-    $arrBaseRevisions = @($BaseRevision)
-    $arrRevisionArguments = @()
-    if ($IsNewRefRange) {
-        if ($arrBaseRevisions.Count -ne 1 -or
-            $arrBaseRevisions[0] -notmatch $strZeroObjectIdPattern) {
-            throw 'A new-ref touched-path range requires an all-zero base.'
-        }
-        if (-not $NewRefHasIntroducedCommit) {
-            if ($NewRefBoundaryRevision.Count -ne 0) {
-                throw 'A new-ref range without introduced commits must not have boundaries.'
-            }
-            return [string[]] @()
-        }
-        $arrRevisionArguments += $HeadRevision
-        if ($NewRefBoundaryRevision.Count -gt 0) {
-            $arrRevisionArguments += '--not'
-            foreach ($strBoundaryRevision in $NewRefBoundaryRevision) {
-                if ($strBoundaryRevision -notmatch $strObjectIdPattern -or
-                    $strBoundaryRevision -match $strZeroObjectIdPattern) {
-                    throw 'The new-ref touched-path boundary is invalid.'
-                }
-                $arrRevisionArguments += $strBoundaryRevision
-            }
-        }
+    elseif ($BaselineAbsent) {
+        @(
+            '-C', $RepositoryRootPath, 'log', '--format=', '--name-only', '-z',
+            '-m', '--no-renames', '--no-ext-diff', '--no-textconv',
+            $FinalRevision, '--not'
+        ) + $arrBoundaries + @('--', ':(top)**')
     }
     else {
-        if ($arrBaseRevisions.Count -lt 1 -or $arrBaseRevisions.Count -gt 64 -or
-            @($arrBaseRevisions | Sort-Object -Unique).Count -ne
-                $arrBaseRevisions.Count) {
-            throw 'An existing touched-path range requires 1 through 64 unique bases.'
-        }
-        foreach ($strBaseRevision in $arrBaseRevisions) {
-            if ($strBaseRevision -notmatch $strObjectIdPattern -or
-                $strBaseRevision -match $strZeroObjectIdPattern) {
-                throw 'An existing touched-path range contains an invalid base.'
-            }
-        }
-        $arrRevisionArguments += @($HeadRevision, '--not') + $arrBaseRevisions
+        @('-C', $RepositoryRootPath, 'diff', '--name-only', '-z',
+            '--no-renames', '--no-ext-diff', '--no-textconv',
+            $BaselineRevision, $FinalRevision, '--', ':(top)**')
     }
-
     $objStartInfo = [Diagnostics.ProcessStartInfo]::new('git')
     $objStartInfo.UseShellExecute = $false
     $objStartInfo.CreateNoWindow = $true
     $objStartInfo.RedirectStandardOutput = $true
     $objStartInfo.RedirectStandardError = $true
-    foreach ($strArgument in @(
-            '-C', $RepositoryRootPath, 'log', '--format=', '--name-only', '-z',
-            '-m', '--no-renames', '--no-ext-diff', '--no-textconv'
-        ) + $arrRevisionArguments + @('--', $RepositoryRelativePathspec)) {
+    foreach ($strArgument in $arrArguments) {
         $objStartInfo.ArgumentList.Add($strArgument)
     }
-    $objGitProcess = [Diagnostics.Process]::new()
-    $objGitProcess.StartInfo = $objStartInfo
-    $objProcessResult = Read-BoundedProcessData `
-        -Process $objGitProcess `
-        -MaximumBytes $MaximumBytes `
-        -TimeoutMilliseconds 10000 `
-        -DisplayName 'Git authenticated range touched-path enumeration'
-    if ($objProcessResult.ExitCode -ne 0) {
-        throw 'Could not enumerate paths touched by the authenticated range.'
+    $objProcess = [Diagnostics.Process]::new()
+    $objProcess.StartInfo = $objStartInfo
+    $objResult = Read-BoundedProcessData -Process $objProcess `
+        -MaximumBytes $MaximumBytes -TimeoutMilliseconds 10000 `
+        -DisplayName 'Git published-endpoint path enumeration'
+    if ($objResult.ExitCode -ne 0) {
+        throw 'Could not enumerate paths changed between published endpoints.'
     }
-
-    $setTouchedPaths = [Collections.Generic.HashSet[string]]::new(
-        [StringComparer]::Ordinal
-    )
-    foreach ($strTouchedPath in @(ConvertFrom-GitPathListData `
-                -Bytes $objProcessResult.Bytes -AllowDuplicatePath)) {
-        [void]$setTouchedPaths.Add($strTouchedPath)
-    }
-    return @($setTouchedPaths | Sort-Object)
+    $arrPaths = @(ConvertFrom-GitPathListData -Bytes $objResult.Bytes `
+            -AllowDuplicatePath:$BaselineAbsent)
+    return @($arrPaths | Sort-Object -Unique)
 }
 
 function Read-RepositoryInputData {
@@ -1357,78 +1315,13 @@ function Read-GitRevisionText {
         -DisplayName "$Revision`:$RepositoryRelativePath"
 }
 
-function Test-HistoricalPolicyMarker {
+function Get-PublishedBaselineDocumentContext {
     # .SYNOPSIS
-    # Tests whether a revision file contains an ordinal literal.
+    # Gets the local HEAD baseline for one governed worktree document.
     #
     # .DESCRIPTION
-    # Reads one historical policy file and tests for an exact ordinal marker.
-    #
-    # .PARAMETER RepositoryRootPath
-    # The absolute path of the trusted Git repository.
-    #
-    # .PARAMETER Revision
-    # The exact Git revision to inspect.
-    #
-    # .PARAMETER RepositoryRelativePath
-    # The canonical repository-relative path to inspect.
-    #
-    # .PARAMETER Literal
-    # The exact ordinal marker to find.
-    #
-    # .EXAMPLE
-    # Test-HistoricalPolicyMarker @hashtableArguments
-    #
-    # # Runs with validated named arguments.
-    #
-    # .INPUTS
-    # None. No pipeline input.
-    #
-    # .OUTPUTS
-    # [System.Boolean] True when the condition in the synopsis is satisfied; otherwise false.
-    #
-    # .NOTES
-    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
-    # Parameters, return shape, and positional contract can change without notice.
-    # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
-    [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([bool])]
-    param(
-        [Parameter(Mandatory)]
-        [string] $RepositoryRootPath,
-
-        [Parameter(Mandatory)]
-        [string] $Revision,
-
-        [Parameter(Mandatory)]
-        [string] $RepositoryRelativePath,
-
-        [Parameter(Mandatory)]
-        [string] $Literal
-    )
-
-    & git -C $RepositoryRootPath cat-file -e `
-        "$Revision`:$RepositoryRelativePath" 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        return $false
-    }
-
-    $strRevisionContent = Read-GitRevisionText `
-        -RepositoryRootPath $RepositoryRootPath `
-        -Revision $Revision `
-        -RepositoryRelativePath $RepositoryRelativePath `
-        -MaximumBytes $intHistoricalPolicyMarkerMaximumBytes `
-        -RequireRegularFile
-    return $strRevisionContent.Contains($Literal, [StringComparison]::Ordinal)
-}
-
-function Get-GovernedDocumentParentContext {
-    # .SYNOPSIS
-    # Gets the worktree or first-parent comparison for one governed document.
-    #
-    # .DESCRIPTION
-    # Resolves the current governed document and its comparison parent from the worktree or an exact revision.
+    # Reads the published local baseline from HEAD and reports whether the
+    # worktree content differs from it.
     #
     # .PARAMETER RepositoryRootPath
     # The absolute path of the trusted Git repository.
@@ -1439,11 +1332,8 @@ function Get-GovernedDocumentParentContext {
     # .PARAMETER MaximumBytes
     # The maximum permitted output size in bytes.
     #
-    # .PARAMETER Revision
-    # The exact Git revision to inspect.
-    #
     # .EXAMPLE
-    # Get-GovernedDocumentParentContext @hashtableArguments
+    # Get-PublishedBaselineDocumentContext @hashtableArguments
     #
     # # Runs with validated named arguments.
     #
@@ -1469,52 +1359,8 @@ function Get-GovernedDocumentParentContext {
 
         [Parameter(Mandatory)]
         [ValidateRange(1, 2147483646)]
-        [int] $MaximumBytes,
-
-        [Parameter()]
-        [AllowEmptyString()]
-        [string] $Revision = ''
+        [int] $MaximumBytes
     )
-
-    if (-not [string]::IsNullOrEmpty($Revision)) {
-        if ($Revision -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-            throw "The governed-document input revision is invalid: $Revision"
-        }
-        $arrCommitAndParents = @(([string](& git -C $RepositoryRootPath rev-list --parents `
-                    -n 1 $Revision)).Trim() -split '\s+')
-        if ($LASTEXITCODE -ne 0 -or $arrCommitAndParents[0] -ine $Revision) {
-            throw "Could not read parents of input commit $Revision."
-        }
-        if ($arrCommitAndParents.Count -eq 1) {
-            return [pscustomobject]@{ParentContent = $null; ExpectedUtcDate = ''
-                ParentRevision = $null; IsWorktreeTransition = $false}
-        }
-        $strParentRevision = "$Revision`^1"
-        & git -C $RepositoryRootPath cat-file -e `
-            "$strParentRevision`^{commit}" 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            throw "The governed-document input commit has no first parent: $Revision"
-        }
-        & git -C $RepositoryRootPath cat-file -e `
-            "$strParentRevision`:$RepositoryRelativePath" 2>$null
-        $strParentContent = if ($LASTEXITCODE -eq 0) {
-            Read-GitRevisionText `
-                -RepositoryRootPath $RepositoryRootPath `
-                -Revision $strParentRevision `
-                -RepositoryRelativePath $RepositoryRelativePath `
-                -MaximumBytes $MaximumBytes `
-                -RequireRegularFile
-        }
-        else {
-            $null
-        }
-        return [pscustomobject]@{
-            ParentContent = $strParentContent
-            ExpectedUtcDate = ''
-            ParentRevision = $strParentRevision
-            IsWorktreeTransition = $false
-        }
-    }
 
     & git -C $RepositoryRootPath diff --quiet HEAD -- $RepositoryRelativePath
     $intDiffExitCode = $LASTEXITCODE
@@ -1522,14 +1368,10 @@ function Get-GovernedDocumentParentContext {
         throw "Could not compare $RepositoryRelativePath with HEAD."
     }
 
-    if ($intDiffExitCode -eq 1) {
-        $strParentRevision = 'HEAD'
-        $strExpectedUtcDate = [DateTimeOffset]::UtcNow.ToString('yyyy-MM-dd')
-    }
-    else {
-        $strParentRevision = 'HEAD^'
-        $strExpectedUtcDate = ''
-    }
+    $strParentRevision = 'HEAD'
+    $strExpectedUtcDate = if ($intDiffExitCode -eq 1) {
+        [DateTimeOffset]::UtcNow.ToString('yyyy-MM-dd')
+    } else { '' }
 
     & git -C $RepositoryRootPath cat-file -e `
         "$strParentRevision`:$RepositoryRelativePath" 2>$null
@@ -3324,7 +3166,7 @@ function Get-CurrentInputMetadataFreshnessFailure {
     }
 }
 
-function Get-LastUpdatedMetadataFreshnessFailure {
+function Get-PublishedEndpointLastUpdatedFailure {
     # .SYNOPSIS
     # Validates metadata and freshness without a Version field.
     #
@@ -3353,7 +3195,7 @@ function Get-LastUpdatedMetadataFreshnessFailure {
     # Requires changed rendered content to use the latest allowed current date.
     #
     # .EXAMPLE
-    # Get-LastUpdatedMetadataFreshnessFailure @hashtableArguments
+    # Get-PublishedEndpointLastUpdatedFailure @hashtableArguments
     #
     # # Runs with validated named arguments.
     #
@@ -3470,106 +3312,6 @@ function Get-LastUpdatedMetadataFreshnessFailure {
             'after a historical rendered-content change.'
         )
     }
-}
-
-function Test-TopicOwnedGitPathDeltaEqual {
-    # .SYNOPSIS
-    # Compares one authenticated path delta across two topic-head ranges.
-    #
-    # .DESCRIPTION
-    # Compares one path delta across previous and current topic-head ranges.
-    #
-    # .PARAMETER RepositoryRootPath
-    # The absolute path of the trusted Git repository.
-    #
-    # .PARAMETER PreviousBaseRevision
-    # The previous authenticated base Git object ID.
-    #
-    # .PARAMETER PreviousHeadRevision
-    # The previous authenticated head Git object ID.
-    #
-    # .PARAMETER CurrentBaseRevision
-    # The current authenticated base Git object ID.
-    #
-    # .PARAMETER CurrentHeadRevision
-    # The current authenticated head Git object ID.
-    #
-    # .PARAMETER RepositoryRelativePath
-    # The canonical repository-relative path to inspect.
-    #
-    # .EXAMPLE
-    # Test-TopicOwnedGitPathDeltaEqual @hashtableArguments
-    #
-    # # Runs with validated named arguments.
-    #
-    # .INPUTS
-    # None. No pipeline input.
-    #
-    # .OUTPUTS
-    # [System.Boolean] True when the condition in the synopsis is satisfied; otherwise false.
-    #
-    # .NOTES
-    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
-    # Parameters, return shape, and positional contract can change without notice.
-    # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
-    [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([bool])]
-    param(
-        [Parameter(Mandatory)][string] $RepositoryRootPath,
-        [Parameter(Mandatory)][string] $PreviousBaseRevision,
-        [Parameter(Mandatory)][string] $PreviousHeadRevision,
-        [Parameter(Mandatory)][string] $CurrentBaseRevision,
-        [Parameter(Mandatory)][string] $CurrentHeadRevision,
-        [Parameter(Mandatory)][string] $RepositoryRelativePath
-    )
-
-    $arrPreviousDelta = @(& git -C $RepositoryRootPath diff --unified=0 --no-renames `
-            --no-ext-diff --no-textconv $PreviousBaseRevision `
-            $PreviousHeadRevision -- $RepositoryRelativePath)
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Could not read the authenticated previous topic-owned path delta.'
-    }
-    $arrCurrentDelta = @(& git -C $RepositoryRootPath diff --unified=0 --no-renames `
-            --no-ext-diff --no-textconv $CurrentBaseRevision `
-            $CurrentHeadRevision -- $RepositoryRelativePath)
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Could not read the authenticated current topic-owned path delta.'
-    }
-    $scriptBlockGetPatchIdentity = {
-        param(
-            [string[]] $DeltaLines,
-            [string] $RangeDescription
-        )
-
-        if ($DeltaLines.Count -eq 0) {
-            return ''
-        }
-        $arrPatchIdentityOutput = @(
-            $DeltaLines | & git -C $RepositoryRootPath patch-id --verbatim
-        )
-        if ($LASTEXITCODE -ne 0) {
-            throw "Could not fingerprint the authenticated $RangeDescription delta."
-        }
-        $arrPatchIdentityOutput = @(
-            $arrPatchIdentityOutput | Where-Object {
-                -not [string]::IsNullOrWhiteSpace([string]$_)
-            }
-        )
-        if ($arrPatchIdentityOutput.Count -ne 1 -or
-            ([string]$arrPatchIdentityOutput[0]).Trim() -cnotmatch
-                '^(?<PatchId>[0-9a-f]{40}|[0-9a-f]{64})\s+[0-9a-f]+$') {
-            throw "The authenticated $RangeDescription delta has no unique patch identity."
-        }
-        return $Matches['PatchId']
-    }
-    $strPreviousPatchIdentity = & $scriptBlockGetPatchIdentity `
-        -DeltaLines $arrPreviousDelta -RangeDescription 'previous topic-owned path'
-    $strCurrentPatchIdentity = & $scriptBlockGetPatchIdentity `
-        -DeltaLines $arrCurrentDelta -RangeDescription 'current topic-owned path'
-    return (
-        $strPreviousPatchIdentity -ceq $strCurrentPatchIdentity
-    )
 }
 
 function Get-MarkdownParserBootstrapFailure {
@@ -3734,12 +3476,13 @@ function Test-ProhibitedClaudeLocalPath {
     return $RepositoryRelativePath -imatch '^(?:[^/]+/)*CLAUDE\.local\.md$'
 }
 
-function Get-MetadataEventRevisionContext {
+function Assert-PublishedEndpointContext {
     # .SYNOPSIS
-    # Resolves history and current-event comparison bases from trusted payload data.
+    # Authenticates the published baseline and final Git endpoints.
     #
     # .DESCRIPTION
-    # Authenticates event revisions and derives the exact historical and current comparison ranges used for metadata freshness validation.
+    # Validates event-specific flags, exact object IDs, object availability, and
+    # pull-request base-change evidence without inspecting topic commit history.
     #
     # .PARAMETER RepositoryRootPath
     # The absolute path of the trusted Git repository.
@@ -3748,45 +3491,30 @@ function Get-MetadataEventRevisionContext {
     # The authenticated GitHub event name.
     #
     # .PARAMETER PullRequestAction
-    # The authenticated pull-request action.
+    # The authenticated pull-request action, or empty for push.
     #
-    # .PARAMETER BaseRevision
-    # The authenticated base Git object ID.
+    # .PARAMETER BaselineRevision
+    # The authenticated published baseline commit, or zero for ref creation.
     #
-    # .PARAMETER HeadRevision
-    # The authenticated head Git object ID.
+    # .PARAMETER FinalRevision
+    # The authenticated published final commit.
     #
-    # .PARAMETER IsNewRefRange
-    # Indicates whether the range represents a newly created ref.
-    #
-    # .PARAMETER PreviousHeadRevision
-    # The previous authenticated head Git object ID.
+    # .PARAMETER BaselineAbsent
+    # Indicates that the publication created a ref with no baseline tree.
     #
     # .PARAMETER PullRequestBaseChanged
-    # Indicates whether the pull-request base changed in this event.
-    #
-    # .PARAMETER EventHeadRevision
-    # The head revision authenticated by the event payload.
-    #
-    # .PARAMETER EventHeadDistinct
-    # Indicates whether the event head differs from the current head.
-    #
-    # .PARAMETER NewRefCommitCount
-    # The authenticated number of introduced commits for a new ref.
-    #
-    # .PARAMETER NewRefCommitEvidenceJson
-    # The authenticated JSON evidence for introduced new-ref commits.
+    # Exact authenticated evidence for an edited pull-request base change.
     #
     # .EXAMPLE
-    # Get-MetadataEventRevisionContext @hashtableArguments
+    # Assert-PublishedEndpointContext @hashtableArguments
     #
-    # # Runs with validated named arguments.
+    # # Throws unless the endpoint pair and event fields are authenticated.
     #
     # .INPUTS
     # None. No pipeline input.
     #
     # .OUTPUTS
-    # [System.Management.Automation.PSCustomObject] One validated context object described in the function description.
+    # None. The function throws on invalid endpoint context.
     #
     # .NOTES
     # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
@@ -3794,395 +3522,427 @@ function Get-MetadataEventRevisionContext {
     # Positional parameters are disabled; internal callers use named arguments.
     # Version: 1.0.20260830.0.
     [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([pscustomobject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory)][string] $RepositoryRootPath,
         [Parameter(Mandatory)][string] $EventName,
         [Parameter(Mandatory)][AllowEmptyString()][string] $PullRequestAction,
-        [Parameter(Mandatory)][string] $BaseRevision,
-        [Parameter(Mandatory)][string] $HeadRevision,
-        [Parameter(Mandatory)][bool] $IsNewRefRange,
-        [Parameter(Mandatory)][AllowEmptyString()][string] $PreviousHeadRevision,
-        [Parameter()][AllowEmptyString()][string] $PullRequestBaseChanged = '',
-        [Parameter(Mandatory)][AllowEmptyString()][string] $EventHeadRevision,
-        [Parameter(Mandatory)][AllowEmptyString()][string] $EventHeadDistinct,
-        [Parameter()][AllowEmptyString()][string] $NewRefCommitCount = '',
-        [Parameter()][AllowEmptyString()][string] $NewRefCommitEvidenceJson = ''
+        [Parameter(Mandatory)][AllowEmptyString()][string] $BaselineRevision,
+        [Parameter(Mandatory)][string] $FinalRevision,
+        [Parameter(Mandatory)][bool] $BaselineAbsent,
+        [Parameter(Mandatory)][AllowEmptyString()][string] $PullRequestBaseChanged
     )
 
     $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
     $strZeroObjectIdPattern = '^(?:0{40}|0{64})$'
-    if ($HeadRevision -notmatch $strObjectIdPattern -or
-        $HeadRevision -match $strZeroObjectIdPattern) {
-        throw 'The metadata event head is invalid.'
+    if ($EventName -cnotin @('push', 'pull_request_target')) {
+        throw "Unsupported metadata publication event: $EventName"
     }
-    & git -C $RepositoryRootPath cat-file -e "$HeadRevision`^{commit}" 2>$null
+    if ($FinalRevision -notmatch $strObjectIdPattern -or
+        $FinalRevision -match $strZeroObjectIdPattern) {
+        throw 'The published final revision must be a nonzero Git object ID.'
+    }
+    & git -C $RepositoryRootPath cat-file -e "$FinalRevision`^{commit}" 2>$null
     if ($LASTEXITCODE -ne 0) {
-        throw 'The metadata event head is unavailable.'
+        throw "The published final commit is unavailable: $FinalRevision"
     }
 
-    if ($EventName -ceq 'push') {
-        if (-not [string]::IsNullOrEmpty($PullRequestAction) -or
-            -not [string]::IsNullOrEmpty($PullRequestBaseChanged) -or
-            -not [string]::IsNullOrEmpty($PreviousHeadRevision)) {
-            throw 'A push metadata event must not supply pull request fields.'
+    if ($BaselineAbsent) {
+        if ($EventName -cne 'push' -or
+            $BaselineRevision -notmatch $strZeroObjectIdPattern) {
+            throw 'Only a created push may use an absent published baseline.'
         }
-        if ($EventHeadRevision -notmatch $strObjectIdPattern -or
-            $EventHeadRevision -match $strZeroObjectIdPattern) {
-            throw 'A push metadata event requires a valid expanded head revision.'
+    }
+    else {
+        if ($BaselineRevision -notmatch $strObjectIdPattern -or
+            $BaselineRevision -match $strZeroObjectIdPattern) {
+            throw 'The published baseline revision must be a nonzero Git object ID.'
         }
-        if (-not [string]::Equals(
-                $EventHeadRevision,
-                $HeadRevision,
-                [StringComparison]::OrdinalIgnoreCase
-            )) {
-            throw 'The expanded push head revision must match the event after revision.'
-        }
-        if ($EventHeadDistinct -cnotin @('true', 'false')) {
-            throw 'The expanded push head distinct value must be true or false.'
-        }
-        $boolHeadIntroducedByPush = $EventHeadDistinct -ceq 'true'
-        if ($IsNewRefRange) {
-            if ($BaseRevision -notmatch $strZeroObjectIdPattern) {
-                throw 'A new-ref push metadata event requires an all-zero base.'
-            }
-            $intNewRefCommitCount = 0
-            if ($NewRefCommitCount -cnotmatch '^(?:0|[1-9][0-9]*)$' -or
-                -not [int]::TryParse($NewRefCommitCount, [ref]$intNewRefCommitCount)) {
-                throw 'A new-ref push requires a valid authenticated commit count.'
-            }
-            if ($intNewRefCommitCount -gt $intNewRefMaximumCommitEvidence) {
-                throw (
-                    'The authenticated new-ref commit count exceeds the maximum of ' +
-                    "$intNewRefMaximumCommitEvidence."
-                )
-            }
-            try {
-                $objNewRefCommitEvidence = ConvertFrom-Json `
-                    -InputObject $NewRefCommitEvidenceJson -NoEnumerate
-                if ($objNewRefCommitEvidence -isnot [System.Array]) {
-                    throw 'The evidence value is not an array.'
-                }
-                $arrNewRefCommitEvidence = @($objNewRefCommitEvidence)
-            }
-            catch {
-                throw 'The authenticated new-ref commit evidence is malformed.'
-            }
-            if ($arrNewRefCommitEvidence.Count -gt $intNewRefCommitCount) {
-                throw 'The authenticated new-ref commit evidence exceeds its declared count.'
-            }
-            $arrSuppliedEvidence = @($arrNewRefCommitEvidence)
-            if ($arrNewRefCommitEvidence.Count -lt $intNewRefCommitCount) {
-                $arrOtherRefTips = @(@(& git -C $RepositoryRootPath for-each-ref `
-                        '--format=%(objectname)' refs 2>$null) | Where-Object {
-                    -not [string]::Equals(([string]$_).Trim(), $HeadRevision,
-                        [StringComparison]::OrdinalIgnoreCase)
-                })
-                if ($LASTEXITCODE -ne 0) {
-                    throw 'Could not identify refs for new-ref evidence recovery.'
-                }
-                $arrRevisionArguments = @('-C', $RepositoryRootPath, 'rev-list',
-                    '--topo-order', "--max-count=$intNewRefCommitCount", $HeadRevision)
-                if ($arrOtherRefTips.Count -gt 0) {
-                    $arrRevisionArguments += @('--not') + $arrOtherRefTips
-                }
-                $arrRecoveredEvidence = @(& git @arrRevisionArguments 2>$null)
-                if ($LASTEXITCODE -ne 0 -or
-                    $arrRecoveredEvidence.Count -ne $intNewRefCommitCount) {
-                    throw 'The authenticated new-ref commit evidence is incomplete.'
-                }
-                $arrNewRefCommitEvidence = $arrRecoveredEvidence
-            }
-            if (-not $boolHeadIntroducedByPush) {
-                if ($intNewRefCommitCount -ne 0) {
-                    throw 'A non-distinct new-ref push must report zero introduced commits.'
-                }
-            }
-            elseif ($intNewRefCommitCount -eq 0) {
-                throw 'Distinct new-ref push requires an introduced commit.'
-            }
-            $setEvidenceCommits = [Collections.Generic.HashSet[string]]::new(
-                [StringComparer]::OrdinalIgnoreCase
-            )
-            $dictionaryEvidenceParents =
-                [Collections.Generic.Dictionary[string, string[]]]::new(
-                    [StringComparer]::OrdinalIgnoreCase
-                )
-            foreach ($objEvidenceCommit in $arrNewRefCommitEvidence) {
-                $strEvidenceCommit = [string]$objEvidenceCommit
-                if ($strEvidenceCommit -notmatch $strObjectIdPattern -or
-                    $strEvidenceCommit -match $strZeroObjectIdPattern) {
-                    throw 'The authenticated new-ref commit evidence contains an invalid commit.'
-                }
-                if (-not $setEvidenceCommits.Add($strEvidenceCommit)) {
-                    throw 'The authenticated new-ref commit evidence contains a duplicate commit.'
-                }
-                & git -C $RepositoryRootPath cat-file -e `
-                    "$strEvidenceCommit`^{commit}" 2>$null
-                if ($LASTEXITCODE -ne 0) {
-                    throw 'The authenticated new-ref commit evidence is unavailable.'
-                }
-                $strCommitAndParents = [string](& git -C $RepositoryRootPath `
-                        rev-list --parents -n 1 $strEvidenceCommit 2>$null)
-                if ($LASTEXITCODE -ne 0) {
-                    throw 'The authenticated new-ref commit evidence is unavailable.'
-                }
-                $arrCommitAndParents = @($strCommitAndParents.Trim() -split '\s+')
-                if ($arrCommitAndParents.Count -eq 0 -or
-                    $arrCommitAndParents[0] -notmatch $strObjectIdPattern -or
-                    -not [string]::Equals(
-                        $arrCommitAndParents[0],
-                        $strEvidenceCommit,
-                        [StringComparison]::OrdinalIgnoreCase
-                    )) {
-                    throw 'Git returned a mismatched new-ref evidence identity.'
-                }
-                $intEvidenceParentCount = $arrCommitAndParents.Count - 1
-                if ($intEvidenceParentCount -gt $intMetadataMaximumParents) {
-                    throw (
-                        "Authenticated new-ref commit $strEvidenceCommit has " +
-                        "$intEvidenceParentCount parents; the maximum is " +
-                        "$intMetadataMaximumParents."
-                    )
-                }
-                $listEvidenceParents = [Collections.Generic.List[string]]::new()
-                for ($intParentIndex = 1;
-                    $intParentIndex -lt $arrCommitAndParents.Count;
-                    $intParentIndex++) {
-                    $strEvidenceParent = [string]$arrCommitAndParents[$intParentIndex]
-                    if ($strEvidenceParent -notmatch $strObjectIdPattern -or
-                        $strEvidenceParent -match $strZeroObjectIdPattern) {
-                        throw 'Git returned an invalid new-ref evidence parent.'
-                    }
-                    & git -C $RepositoryRootPath cat-file -e `
-                        "$strEvidenceParent`^{commit}" 2>$null
-                    if ($LASTEXITCODE -ne 0) {
-                        throw 'Git returned an unavailable new-ref evidence parent.'
-                    }
-                    $listEvidenceParents.Add($strEvidenceParent)
-                }
-                $dictionaryEvidenceParents.Add(
-                    $strEvidenceCommit,
-                    $listEvidenceParents.ToArray()
-                )
-            }
-            $setSuppliedEvidence = [Collections.Generic.HashSet[string]]::new(
-                [StringComparer]::OrdinalIgnoreCase)
-            foreach ($objSuppliedEvidence in $arrSuppliedEvidence) {
-                $strSuppliedEvidence = [string]$objSuppliedEvidence
-                if ($strSuppliedEvidence -notmatch $strObjectIdPattern -or
-                    $strSuppliedEvidence -match $strZeroObjectIdPattern) {
-                    throw 'The authenticated new-ref commit evidence contains an invalid commit.'
-                }
-                if (-not $setSuppliedEvidence.Add($strSuppliedEvidence)) {
-                    throw 'The authenticated new-ref commit evidence contains a duplicate commit.'
-                }
-                if (-not $setEvidenceCommits.Contains($strSuppliedEvidence)) {
-                    throw 'The authenticated new-ref commit evidence contradicts Git history.'
-                }
-            }
-            if ($boolHeadIntroducedByPush -and
-                -not $setEvidenceCommits.Contains($HeadRevision)) {
-                throw 'The authenticated new-ref commit evidence does not contain the event head.'
-            }
-            $setReachableEvidence = [Collections.Generic.HashSet[string]]::new(
-                [StringComparer]::OrdinalIgnoreCase
-            )
-            $setBoundaryParents = [Collections.Generic.HashSet[string]]::new(
-                [StringComparer]::OrdinalIgnoreCase
-            )
-            if ($boolHeadIntroducedByPush) {
-                $stackEvidenceCommits = [Collections.Generic.Stack[string]]::new()
-                $stackEvidenceCommits.Push($HeadRevision)
-                while ($stackEvidenceCommits.Count -gt 0) {
-                    $strReachableCommit = $stackEvidenceCommits.Pop()
-                    if (-not $setReachableEvidence.Add($strReachableCommit)) {
-                        continue
-                    }
-                    foreach ($strReachableParent in
-                        $dictionaryEvidenceParents[$strReachableCommit]) {
-                        if ($setEvidenceCommits.Contains($strReachableParent)) {
-                            $stackEvidenceCommits.Push($strReachableParent)
-                        }
-                        else {
-                            [void]$setBoundaryParents.Add($strReachableParent)
-                        }
-                    }
-                }
-                if ($setReachableEvidence.Count -ne $setEvidenceCommits.Count) {
-                    throw 'The authenticated new-ref commit evidence contains a disconnected commit.'
-                }
-            }
-            $arrFreshnessBases = @($setBoundaryParents | Sort-Object)
-            return [pscustomobject]@{
-                HistoryBaseRevision = $BaseRevision
-                HistoryBaseRevisions = @($BaseRevision)
-                FreshnessBaseRevision = if ($arrFreshnessBases.Count -eq 1) {
-                    $arrFreshnessBases[0]
-                } else { '' }
-                FreshnessBaseRevisions = $arrFreshnessBases
-                EvaluateFreshness = $boolHeadIntroducedByPush
-                PreviousTopicBaseRevision = ''
-                PreviousTopicHeadRevision = ''
-                CurrentTopicBaseRevision = ''
-                CurrentTopicHeadRevision = ''
-                NewRefBoundaryRevisions = $arrFreshnessBases
-                NewRefIntroducedCommitRevisions = @(
-                    $setEvidenceCommits | Sort-Object
-                )
-            }
-        }
-        if (-not [string]::IsNullOrEmpty($NewRefCommitCount) -or
-            -not [string]::IsNullOrEmpty($NewRefCommitEvidenceJson)) {
-            throw 'An existing-ref push must not supply new-ref commit evidence.'
-        }
-        if ($BaseRevision -notmatch $strObjectIdPattern -or
-            $BaseRevision -match $strZeroObjectIdPattern) {
-            throw 'An existing-ref push metadata event requires a valid base.'
-        }
-        & git -C $RepositoryRootPath cat-file -e `
-            "$BaseRevision`^{commit}" 2>$null
+        & git -C $RepositoryRootPath cat-file -e "$BaselineRevision`^{commit}" 2>$null
         if ($LASTEXITCODE -ne 0) {
-            throw 'The existing-ref push base is unavailable.'
-        }
-        return [pscustomobject]@{
-            HistoryBaseRevision = $BaseRevision
-            HistoryBaseRevisions = @($BaseRevision)
-            FreshnessBaseRevision = if ($boolHeadIntroducedByPush) {
-                $BaseRevision
-            }
-            else {
-                ''
-            }
-            FreshnessBaseRevisions = if ($boolHeadIntroducedByPush) {
-                @($BaseRevision)
-            } else { @() }
-            EvaluateFreshness = $boolHeadIntroducedByPush
-            PreviousTopicBaseRevision = ''
-            PreviousTopicHeadRevision = ''
-            CurrentTopicBaseRevision = ''
-            CurrentTopicHeadRevision = ''
+            throw "The published baseline commit is unavailable: $BaselineRevision"
         }
     }
 
-    if ($EventName -cne 'pull_request_target') {
-        throw "Unsupported metadata event name: $EventName"
-    }
-    if ($IsNewRefRange -or
-        -not [string]::IsNullOrEmpty($EventHeadRevision) -or
-        -not [string]::IsNullOrEmpty($EventHeadDistinct) -or
-        -not [string]::IsNullOrEmpty($NewRefCommitCount) -or
-        -not [string]::IsNullOrEmpty($NewRefCommitEvidenceJson)) {
-        throw 'A pull request metadata event must not use push-only fields.'
-    }
-    if ($PullRequestAction -cnotin @('opened', 'reopened', 'synchronize', 'edited')) {
-        throw "Unsupported pull request metadata action: $PullRequestAction"
-    }
-    if ($PullRequestAction -ceq 'edited') {
-        if ($PullRequestBaseChanged -cne 'true') {
-            throw 'An edited pull request event requires trusted base-change proof.'
+    if ($EventName -ceq 'pull_request_target') {
+        if ($BaselineAbsent -or
+            $PullRequestAction -cnotin @('opened', 'reopened', 'synchronize', 'edited')) {
+            throw 'Pull request publication endpoints are incomplete.'
+        }
+        if ($PullRequestAction -ceq 'edited') {
+            if ($PullRequestBaseChanged -cne 'true') {
+                throw 'An edited pull request requires an authenticated base change.'
+            }
+        }
+        elseif (-not [string]::IsNullOrEmpty($PullRequestBaseChanged)) {
+            throw 'Pull request base-change evidence is only valid for edited events.'
         }
     }
-    elseif (-not [string]::IsNullOrEmpty($PullRequestBaseChanged)) {
-        throw 'Only an edited pull request event may supply base-change proof.'
+    elseif (-not [string]::IsNullOrEmpty($PullRequestAction) -or
+        -not [string]::IsNullOrEmpty($PullRequestBaseChanged)) {
+        throw 'Push publication endpoints received pull request fields.'
     }
-    if ($BaseRevision -notmatch $strObjectIdPattern -or
-        $BaseRevision -match $strZeroObjectIdPattern) {
-        throw 'A pull request metadata event requires a valid base tip.'
-    }
-    & git -C $RepositoryRootPath cat-file -e "$BaseRevision`^{commit}" 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        throw 'The pull request base tip is unavailable.'
-    }
+}
+
+function Get-AuthenticatedMergeBaseRevision {
+    # .SYNOPSIS
+    # Gets every authenticated merge base for two commits.
+    # .DESCRIPTION
+    # Returns 1 through 64 exact commit IDs and fails closed for indeterminate graphs.
+    # .PARAMETER RepositoryRootPath
+    # The absolute path of the trusted Git repository.
+    # .PARAMETER LeftRevision
+    # The first authenticated commit endpoint.
+    # .PARAMETER RightRevision
+    # The second authenticated commit endpoint.
+    # .EXAMPLE
+    # Get-AuthenticatedMergeBaseRevision @hashtableArguments
+    #
+    # # Returns the bounded merge-base set.
+    # .INPUTS
+    # None. No pipeline input.
+    # .OUTPUTS
+    # [string] One or more authenticated merge-base commit IDs.
+    # .NOTES
+    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
+    # Parameters, return shape, and positional contract can change without notice.
+    # Positional parameters are disabled; internal callers use named arguments.
+    # Version: 1.0.20260831.0.
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string] $RepositoryRootPath,
+        [Parameter(Mandatory)][string] $LeftRevision,
+        [Parameter(Mandatory)][string] $RightRevision
+    )
+
+    $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
     $arrMergeBases = @(
         & git -C $RepositoryRootPath merge-base --all `
-            $BaseRevision $HeadRevision 2>$null |
-            ForEach-Object { ([string]$_).Trim() } |
+            $LeftRevision $RightRevision 2>$null |
+            ForEach-Object { ([string] $_).Trim() } |
             Sort-Object -Unique
     )
     if ($LASTEXITCODE -ne 0 -or $arrMergeBases.Count -lt 1 -or
-        $arrMergeBases.Count -gt $intMetadataMaximumParents -or
-        @($arrMergeBases | Where-Object {
-                $_ -notmatch $strObjectIdPattern -or $_ -match $strZeroObjectIdPattern
-            }).Count -ne 0) {
-        throw 'The pull request metadata range must have 1 through 64 available merge bases.'
+        $arrMergeBases.Count -gt $intMetadataMaximumBoundaries) {
+        throw 'The authenticated graph must have 1 through 64 merge bases.'
     }
     foreach ($strMergeBase in $arrMergeBases) {
-        & git -C $RepositoryRootPath cat-file -e "$strMergeBase`^{commit}" 2>$null
+        if ($strMergeBase -notmatch $strObjectIdPattern) {
+            throw 'Git returned an invalid merge-base identity.'
+        }
+        & git -C $RepositoryRootPath cat-file -e `
+            "$strMergeBase`^{commit}" 2>$null
         if ($LASTEXITCODE -ne 0) {
-            throw 'The pull request metadata range contains an unavailable merge base.'
+            throw 'Git returned an unavailable merge-base commit.'
+        }
+        foreach ($strEndpoint in @($LeftRevision, $RightRevision)) {
+            & git -C $RepositoryRootPath merge-base --is-ancestor `
+                $strMergeBase $strEndpoint 2>$null
+            if ($LASTEXITCODE -ne 0) {
+                throw 'Git returned a merge base that is not reachable from both endpoints.'
+            }
         }
     }
-    $strHistoryBase = if ($arrMergeBases.Count -eq 1) {
-        $arrMergeBases[0]
-    } else { '' }
+    return @($arrMergeBases)
+}
 
-    if ($PullRequestAction -cne 'synchronize') {
-        if (-not [string]::IsNullOrEmpty($PreviousHeadRevision)) {
-            throw 'A nonsynchronize pull request must not supply a previous head.'
-        }
-        return [pscustomobject]@{
-            HistoryBaseRevision = $strHistoryBase
-            HistoryBaseRevisions = $arrMergeBases
-            FreshnessBaseRevision = $strHistoryBase
-            FreshnessBaseRevisions = $arrMergeBases
-            EvaluateFreshness = $true
-            PreviousTopicBaseRevision = ''
-            PreviousTopicHeadRevision = ''
-            CurrentTopicBaseRevision = ''
-            CurrentTopicHeadRevision = ''
-        }
+function Get-CreatedRefBoundaryContext {
+    # .SYNOPSIS
+    # Authenticates a created-ref push and derives its introduced graph boundary.
+    # .DESCRIPTION
+    # Uses only explicitly fetched other repository refs as graph authority. The
+    # webhook commit array corroborates the graph and never narrows it.
+    # .PARAMETER RepositoryRootPath
+    # The absolute path of the trusted Git repository.
+    # .PARAMETER DestinationRef
+    # The exact new branch ref from the authenticated push event.
+    # .PARAMETER HeadRevision
+    # The exact published final commit.
+    # .PARAMETER EventHeadRevision
+    # The expanded head commit from the authenticated push event.
+    # .PARAMETER EventHeadDistinct
+    # The lowercase Boolean distinct value for the event head.
+    # .PARAMETER PushCommitCount
+    # The authenticated push size as invariant decimal text.
+    # .PARAMETER PushDistinctCommitCount
+    # The authenticated distinct push size as invariant decimal text.
+    # .PARAMETER PushCommitEvidenceJson
+    # The bounded webhook commit ID array serialized as JSON.
+    # .PARAMETER OtherRefEvidenceJson
+    # The bounded, fetched, authenticated other-ref inventory as JSON.
+    # .EXAMPLE
+    # Get-CreatedRefBoundaryContext @hashtableArguments
+    #
+    # # Returns bounded introduced commits and outside-parent boundaries.
+    # .INPUTS
+    # None. No pipeline input.
+    # .OUTPUTS
+    # [System.Management.Automation.PSCustomObject] One authenticated context.
+    # .NOTES
+    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
+    # Parameters, return shape, and positional contract can change without notice.
+    # Positional parameters are disabled; internal callers use named arguments.
+    # Version: 1.0.20260831.0.
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][string] $RepositoryRootPath,
+        [Parameter(Mandatory)][string] $DestinationRef,
+        [Parameter(Mandatory)][string] $HeadRevision,
+        [Parameter(Mandatory)][string] $EventHeadRevision,
+        [Parameter(Mandatory)][string] $EventHeadDistinct,
+        [Parameter(Mandatory)][string] $PushCommitCount,
+        [Parameter(Mandatory)][string] $PushDistinctCommitCount,
+        [Parameter(Mandatory)][string] $PushCommitEvidenceJson,
+        [Parameter(Mandatory)][string] $OtherRefEvidenceJson
+    )
+
+    $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
+    $strZeroObjectIdPattern = '^(?:0{40}|0{64})$'
+    if ($DestinationRef -cnotmatch '^refs/heads/.+' -or
+        $DestinationRef.IndexOfAny([char[]] @("`0", "`r", "`n", "`t", ' ')) -ge 0) {
+        throw 'A created push requires the exact destination branch ref.'
     }
-    if ($PreviousHeadRevision -notmatch $strObjectIdPattern -or
-        $PreviousHeadRevision -match $strZeroObjectIdPattern -or
-        [string]::Equals(
-            $PreviousHeadRevision,
+    & git check-ref-format $DestinationRef 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw 'The created-push destination ref is invalid.'
+    }
+    if ($EventHeadRevision -notmatch $strObjectIdPattern -or
+        $EventHeadRevision -match $strZeroObjectIdPattern -or
+        -not [string]::Equals(
+            $EventHeadRevision,
             $HeadRevision,
             [StringComparison]::OrdinalIgnoreCase
         )) {
-        throw 'A synchronize event requires a distinct valid previous topic head.'
+        throw 'The expanded event head must equal the exact created-push after commit.'
     }
-    & git -C $RepositoryRootPath cat-file -e `
-        "$PreviousHeadRevision`^{commit}" 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        throw 'The synchronize previous topic head is unavailable.'
+    if ($EventHeadDistinct -cnotin @('true', 'false')) {
+        throw 'The created-push head distinct field must be true or false.'
     }
-    $arrPreviousMergeBases = @(
-        & git -C $RepositoryRootPath merge-base --all `
-            $BaseRevision $PreviousHeadRevision 2>$null |
-            ForEach-Object { ([string]$_).Trim() } |
-            Sort-Object -Unique
+
+    $intPushCommitCount = 0
+    $intPushDistinctCommitCount = 0
+    if ($PushCommitCount -cnotmatch '^(?:0|[1-9][0-9]*)$' -or
+        -not [int]::TryParse($PushCommitCount, [ref] $intPushCommitCount)) {
+        throw 'The created-push size is invalid or exceeds a signed 32-bit integer.'
+    }
+    if ($PushDistinctCommitCount -cnotmatch '^(?:0|[1-9][0-9]*)$' -or
+        -not [int]::TryParse(
+            $PushDistinctCommitCount,
+            [ref] $intPushDistinctCommitCount
+        )) {
+        throw 'The created-push distinct size is invalid or exceeds a signed 32-bit integer.'
+    }
+    if ($intPushDistinctCommitCount -gt $intPushCommitCount) {
+        throw 'The created-push distinct size exceeds its size.'
+    }
+
+    try {
+        $objOtherRefEvidence = ConvertFrom-Json `
+            -InputObject $OtherRefEvidenceJson -NoEnumerate
+        if ($objOtherRefEvidence -isnot [System.Array]) {
+            throw 'Other-ref evidence is not an array.'
+        }
+        $arrOtherRefEvidence = @($objOtherRefEvidence)
+    }
+    catch {
+        throw 'The authenticated other-ref evidence is malformed.'
+    }
+    if ($arrOtherRefEvidence.Count -gt $intMaximumOtherRefCount) {
+        throw "The authenticated other-ref count exceeds $intMaximumOtherRefCount."
+    }
+    $setOtherRefNames = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::Ordinal
     )
-    if ($LASTEXITCODE -ne 0 -or $arrPreviousMergeBases.Count -lt 1 -or
-        $arrPreviousMergeBases.Count -gt $intMetadataMaximumParents -or
-        @($arrPreviousMergeBases | Where-Object {
-                $_ -notmatch $strObjectIdPattern -or $_ -match $strZeroObjectIdPattern
-            }).Count -ne 0) {
-        throw 'The synchronize previous topic range must have 1 through 64 available merge bases.'
+    $setOtherTipCommits = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::OrdinalIgnoreCase
+    )
+    $strPreviousRef = ''
+    for ($intRefIndex = 0;
+        $intRefIndex -lt $arrOtherRefEvidence.Count;
+        $intRefIndex++) {
+        $objRefEvidence = $arrOtherRefEvidence[$intRefIndex]
+        $arrPropertyNames = @($objRefEvidence.PSObject.Properties.Name)
+        if ($arrPropertyNames.Count -ne 4 -or
+            $arrPropertyNames -cnotcontains 'ref' -or
+            $arrPropertyNames -cnotcontains 'object' -or
+            $arrPropertyNames -cnotcontains 'commit' -or
+            $arrPropertyNames -cnotcontains 'local_ref') {
+            throw 'The authenticated other-ref evidence has an invalid shape.'
+        }
+        $strRefName = [string] $objRefEvidence.ref
+        $strObjectId = [string] $objRefEvidence.object
+        $strCommitId = [string] $objRefEvidence.commit
+        $strLocalRef = [string] $objRefEvidence.local_ref
+        $strExpectedLocalRef =
+            'refs/remotes/event/created-other-{0:D4}' -f $intRefIndex
+        if ($strRefName -cnotmatch '^refs/(?:heads|tags)/.+' -or
+            $strRefName -ceq $DestinationRef -or
+            $strRefName -cmatch '^refs/pull/' -or
+            $strRefName.IndexOfAny([char[]] @("`0", "`r", "`n", "`t", ' ')) -ge 0) {
+            throw 'The authenticated other-ref evidence contains an unsafe or destination ref.'
+        }
+        & git check-ref-format $strRefName 2>$null
+        if ($LASTEXITCODE -ne 0 -or
+            (-not [string]::IsNullOrEmpty($strPreviousRef) -and
+                [string]::CompareOrdinal($strPreviousRef, $strRefName) -ge 0) -or
+            -not $setOtherRefNames.Add($strRefName)) {
+            throw 'The authenticated other-ref names must be valid, unique, and sorted.'
+        }
+        $strPreviousRef = $strRefName
+        if ($strObjectId -notmatch $strObjectIdPattern -or
+            $strObjectId -match $strZeroObjectIdPattern -or
+            $strCommitId -notmatch $strObjectIdPattern -or
+            $strCommitId -match $strZeroObjectIdPattern -or
+            $strLocalRef -cne $strExpectedLocalRef) {
+            throw 'The authenticated other-ref evidence contains an invalid identity.'
+        }
+        $strResolvedObject = [string] (& git -C $RepositoryRootPath `
+                rev-parse --verify "$strLocalRef`^{object}" 2>$null)
+        if ($LASTEXITCODE -ne 0 -or
+            -not [string]::Equals(
+                $strResolvedObject.Trim(),
+                $strObjectId,
+                [StringComparison]::OrdinalIgnoreCase
+            )) {
+            throw 'An authenticated other-ref object changed after enumeration.'
+        }
+        $strResolvedCommit = [string] (& git -C $RepositoryRootPath `
+                rev-parse --verify "$strLocalRef`^{commit}" 2>$null)
+        if ($LASTEXITCODE -ne 0 -or
+            -not [string]::Equals(
+                $strResolvedCommit.Trim(),
+                $strCommitId,
+                [StringComparison]::OrdinalIgnoreCase
+            )) {
+            throw 'An authenticated other-ref commit changed after fetch.'
+        }
+        [void] $setOtherTipCommits.Add($strCommitId)
     }
-    foreach ($strPreviousMergeBase in $arrPreviousMergeBases) {
-        & git -C $RepositoryRootPath cat-file -e `
-            "$strPreviousMergeBase`^{commit}" 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            throw 'The synchronize previous topic range contains an unavailable merge base.'
+
+    $arrOtherTipCommits = @($setOtherTipCommits | Sort-Object)
+    $arrRevisionArguments = @(
+        '-C', $RepositoryRootPath, 'rev-list', '--topo-order',
+        "--max-count=$($intMaximumIntroducedCommitCount + 1)",
+        $HeadRevision
+    )
+    if ($arrOtherTipCommits.Count -gt 0) {
+        $arrRevisionArguments += @('--not') + $arrOtherTipCommits
+    }
+    $arrIntroducedCommits = @(
+        & git @arrRevisionArguments 2>$null |
+            ForEach-Object { ([string] $_).Trim() }
+    )
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Could not derive the created-push introduced commit set.'
+    }
+    if ($arrIntroducedCommits.Count -gt $intMaximumIntroducedCommitCount) {
+        throw "The created-push introduced set exceeds $intMaximumIntroducedCommitCount commits."
+    }
+    $setIntroducedCommits = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($strIntroducedCommit in $arrIntroducedCommits) {
+        if ($strIntroducedCommit -notmatch $strObjectIdPattern -or
+            $strIntroducedCommit -match $strZeroObjectIdPattern -or
+            -not $setIntroducedCommits.Add($strIntroducedCommit)) {
+            throw 'Git returned invalid or duplicate created-push introduced history.'
         }
     }
-    $boolSingleTopicBase = $arrMergeBases.Count -eq 1 -and
-        $arrPreviousMergeBases.Count -eq 1
+    $boolHeadIntroduced = $setIntroducedCommits.Contains($HeadRevision)
+    if (($EventHeadDistinct -ceq 'true') -ne $boolHeadIntroduced -or
+        $arrIntroducedCommits.Count -ne $intPushDistinctCommitCount) {
+        throw 'The created-push payload contradicts the authenticated introduced graph.'
+    }
+
+    try {
+        $objCommitEvidence = ConvertFrom-Json `
+            -InputObject $PushCommitEvidenceJson -NoEnumerate
+        if ($objCommitEvidence -isnot [System.Array]) {
+            throw 'Commit evidence is not an array.'
+        }
+        $arrCommitEvidence = @($objCommitEvidence)
+    }
+    catch {
+        throw 'The created-push commit evidence is malformed.'
+    }
+    $intExpectedEvidenceCount = [Math]::Min(
+        $intPushCommitCount,
+        $intMaximumPayloadCommitCount
+    )
+    if ($arrCommitEvidence.Count -ne $intExpectedEvidenceCount) {
+        throw 'The created-push commit array is truncated or inconsistent.'
+    }
+    $setPayloadCommits = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($objCommit in $arrCommitEvidence) {
+        $strCommit = [string] $objCommit
+        if ($strCommit -notmatch $strObjectIdPattern -or
+            $strCommit -match $strZeroObjectIdPattern -or
+            -not $setPayloadCommits.Add($strCommit) -or
+            -not $setIntroducedCommits.Contains($strCommit)) {
+            throw 'The created-push commit array contradicts the authenticated graph.'
+        }
+    }
+
+    $setBoundaries = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($strIntroducedCommit in $arrIntroducedCommits) {
+        $strCommitAndParents = [string] (& git -C $RepositoryRootPath `
+                rev-list --parents -n 1 $strIntroducedCommit 2>$null)
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not inspect created-push parent boundaries.'
+        }
+        $arrCommitAndParents = @($strCommitAndParents.Trim() -split '\s+')
+        if ($arrCommitAndParents.Count -lt 1 -or
+            $arrCommitAndParents.Count -gt ($intMetadataMaximumBoundaries + 1) -or
+            $arrCommitAndParents[0] -cne $strIntroducedCommit) {
+            throw 'Git returned invalid created-push parent evidence.'
+        }
+        foreach ($strParent in @($arrCommitAndParents | Select-Object -Skip 1)) {
+            if ($strParent -notmatch $strObjectIdPattern) {
+                throw 'Git returned an invalid created-push parent identity.'
+            }
+            if (-not $setIntroducedCommits.Contains($strParent)) {
+                [void] $setBoundaries.Add($strParent)
+            }
+        }
+    }
+    $arrBoundaries = @($setBoundaries | Sort-Object)
+    if ($arrBoundaries.Count -gt $intMetadataMaximumBoundaries) {
+        throw 'The created-push outside-parent boundary exceeds 64 commits.'
+    }
+    foreach ($strBoundary in $arrBoundaries) {
+        $boolAuthenticatedBoundary = $false
+        foreach ($strOtherTip in $arrOtherTipCommits) {
+            & git -C $RepositoryRootPath merge-base --is-ancestor `
+                $strBoundary $strOtherTip 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                $boolAuthenticatedBoundary = $true
+                break
+            }
+            if ($LASTEXITCODE -ne 1) {
+                throw 'Git could not verify created-push boundary reachability.'
+            }
+        }
+        if (-not $boolAuthenticatedBoundary) {
+            throw 'A created-push boundary lacks authenticated other-ref provenance.'
+        }
+    }
+
     return [pscustomobject]@{
-        HistoryBaseRevision = $strHistoryBase
-        HistoryBaseRevisions = $arrMergeBases
-        FreshnessBaseRevision = $PreviousHeadRevision
-        FreshnessBaseRevisions = @($PreviousHeadRevision)
-        EvaluateFreshness = $true
-        PreviousTopicBaseRevision = if ($boolSingleTopicBase) {
-            $arrPreviousMergeBases[0]
+        IntroducedCommitRevisions = @($arrIntroducedCommits | Sort-Object)
+        BoundaryRevisions = @($arrBoundaries)
+        EffectiveBaselineRevision = if ($arrIntroducedCommits.Count -eq 0) {
+            $HeadRevision
+        } elseif ($arrBoundaries.Count -eq 1) {
+            $arrBoundaries[0]
         } else { '' }
-        PreviousTopicHeadRevision = $PreviousHeadRevision
-        CurrentTopicBaseRevision = if ($boolSingleTopicBase) {
-            $arrMergeBases[0]
-        } else { '' }
-        CurrentTopicHeadRevision = $HeadRevision
+        IsGenuineRootIntroduction =
+            $arrIntroducedCommits.Count -gt 0 -and $arrBoundaries.Count -eq 0
     }
 }
 
@@ -5058,7 +4818,8 @@ function Get-DocumentMetadataContext {
     $arrRequiredFields = @(
         [pscustomobject]@{
             Name = 'Status'
-            Pattern = '^- \*\*Status:\*\* (?<Value>Draft|Active|Deprecated)$'
+            Pattern = '^- \*\*Status:\*\* ' +
+                '(?<Value>Draft|Proposed|Active|Accepted|Superseded|Deprecated)$'
         },
         [pscustomobject]@{
             Name = 'Owner'
@@ -5129,6 +4890,8 @@ function Get-DocumentMetadataContext {
 
     return [pscustomobject]@{
         Failure = $null
+        Major = if ($RequiresVersion) {$objVersionMatch.Groups['Major'].Value} else {$null}
+        Minor = if ($RequiresVersion) {$objVersionMatch.Groups['Minor'].Value} else {$null}
         VersionDate = if ($RequiresVersion) {$objVersionMatch.Groups['Date'].Value} else {$null}
         UpdatedDate = $objUpdatedMatch.Groups['Date'].Value
         Revision = if ($RequiresVersion) {$objVersionMatch.Groups['Revision'].Value} else {$null}
@@ -5137,7 +4900,7 @@ function Get-DocumentMetadataContext {
     }
 }
 
-function Get-DocumentMetadataTransitionFailure {
+function Get-PublishedEndpointMetadataFailure {
     # .SYNOPSIS
     # Finds metadata failures in one document transition.
     #
@@ -5164,7 +4927,7 @@ function Get-DocumentMetadataTransitionFailure {
     # True to require the expected date after rendered changes.
     #
     # .EXAMPLE
-    # $arrFailure = @(Get-DocumentMetadataTransitionFailure `
+    # $arrFailure = @(Get-PublishedEndpointMetadataFailure `
     #     -Name 'AGENTS.md' -CurrentContent $strCurrent `
     #     -ParentContent $strParent -ExpectedUtcDate '2026-08-27' `
     #     -IsNewDocumentTransition $false)
@@ -5229,6 +4992,16 @@ function Get-DocumentMetadataTransitionFailure {
         return
     }
 
+    $intCurrentMajor = [int64] 0
+    $intCurrentMinor = [int64] 0
+    $intCurrentRevision = [int64] 0
+    if (-not [int64]::TryParse($objCurrentMetadata.Major, [ref] $intCurrentMajor) -or
+        -not [int64]::TryParse($objCurrentMetadata.Minor, [ref] $intCurrentMinor) -or
+        -not [int64]::TryParse($objCurrentMetadata.Revision, [ref] $intCurrentRevision)) {
+        Write-Output "$Name Version major, minor, and revision must fit in signed 64-bit integers."
+        return
+    }
+
     if ([string]::IsNullOrEmpty($ParentContent)) {
         if (-not $IsNewDocumentTransition) {
             return
@@ -5246,6 +5019,11 @@ function Get-DocumentMetadataTransitionFailure {
         if ($strCurrentUpdatedDate -cne $ExpectedUtcDate) {
             Write-Output (
                 "$Name Last Updated must be $ExpectedUtcDate after a rendered-content change."
+            )
+        }
+        if ($intCurrentRevision -ne 0) {
+            Write-Output (
+                "$Name Version revision must be exactly 0 when no published baseline exists."
             )
         }
         return
@@ -5275,17 +5053,16 @@ function Get-DocumentMetadataTransitionFailure {
         return
     }
 
-    $intCurrentRevision = [int64] 0
+    $intParentMajor = [int64] 0
+    $intParentMinor = [int64] 0
     $intParentRevision = [int64] 0
-    if (-not [int64]::TryParse(
-            $objCurrentMetadata.Revision,
-            [ref] $intCurrentRevision
-        ) -or
-        -not [int64]::TryParse(
-            $objParentMetadata.Revision,
-            [ref] $intParentRevision
-        )) {
-        Write-Output "$Name Version revision must fit in a signed 64-bit integer."
+    if (-not [int64]::TryParse($objParentMetadata.Major, [ref] $intParentMajor) -or
+        -not [int64]::TryParse($objParentMetadata.Minor, [ref] $intParentMinor) -or
+        -not [int64]::TryParse($objParentMetadata.Revision, [ref] $intParentRevision)) {
+        Write-Output (
+            "The published baseline $Name Version major, minor, and revision must fit " +
+            'in signed 64-bit integers.'
+        )
         return
     }
 
@@ -5293,6 +5070,13 @@ function Get-DocumentMetadataTransitionFailure {
         $strCurrentVersionDate,
         $strParentVersionDate
     )
+    $intMajorMinorComparison = if ($intCurrentMajor -ne $intParentMajor) {
+        $intCurrentMajor.CompareTo($intParentMajor)
+    }
+    elseif ($intCurrentMinor -ne $intParentMinor) {
+        $intCurrentMinor.CompareTo($intParentMinor)
+    }
+    else { 0 }
     $strCurrentComparison = ConvertTo-MetadataComparisonText `
         -Content $CurrentContent -MetadataContext $objCurrentMetadata
     $strParentComparison = ConvertTo-MetadataComparisonText `
@@ -5303,13 +5087,23 @@ function Get-DocumentMetadataTransitionFailure {
             "$Name Version date must not move backward from $strParentVersionDate to " +
             "$strCurrentVersionDate."
         )
+        return
     }
-    elseif ($intVersionDateComparison -eq 0 -and
-        $intCurrentRevision -lt $intParentRevision) {
+    if ($intMajorMinorComparison -lt 0) {
+        Write-Output (
+            "$Name Version major and minor tuple must not move backward from " +
+            "$intParentMajor.$intParentMinor to $intCurrentMajor.$intCurrentMinor."
+        )
+        return
+    }
+    $boolSameVersionTuple = $intMajorMinorComparison -eq 0 -and
+        $intVersionDateComparison -eq 0
+    if ($boolSameVersionTuple -and $intCurrentRevision -lt $intParentRevision) {
         Write-Output (
             "$Name Version revision must not decrease from $intParentRevision to " +
             "$intCurrentRevision."
         )
+        return
     }
 
     if (-not $boolRenderedContentChanged) {
@@ -5330,91 +5124,214 @@ function Get-DocumentMetadataTransitionFailure {
         }
     }
 
-    if ($intVersionDateComparison -eq 0) {
+    if ($boolSameVersionTuple) {
         if ($intParentRevision -eq [int64]::MaxValue) {
-            Write-Output "The parent $Name Version revision cannot be incremented safely."
-        }
-        elseif ($intCurrentRevision -eq $intParentRevision) {
             Write-Output (
-                "$Name Version revision must be greater than $intParentRevision after a " +
-                'same-day content change.'
+                "The published baseline $Name Version revision cannot be incremented safely."
+            )
+            return
+        }
+        $intMinimumRevision = $intParentRevision + 1
+        if ($intCurrentRevision -lt $intMinimumRevision) {
+            Write-Output (
+                "$Name Version revision must be at least $intMinimumRevision after a " +
+                'rendered-content change with an unchanged published-baseline major, ' +
+                'minor, and date tuple.'
             )
         }
     }
 }
 
-function Get-DocumentMetadataRangeTransitionFailure {
+function Read-GitIntroducedCommitRevision {
     # .SYNOPSIS
-    # Finds metadata-policy failures across document transition records.
-    #
+    # Reads a bounded authenticated introduced commit set.
     # .DESCRIPTION
-    # Evaluates direct-parent metadata transitions.
-    #
-    # .PARAMETER Name
-    # The governed document display name used in diagnostic output.
-    #
-    # .PARAMETER TransitionContext
-    # Ordered transition records. Each record supplies CurrentContent,
-    # ParentContent, ExpectedUtcDate, CurrentRevision, and ParentRevision. The
-    # optional RequireExpectedUtcDateForRenderedChange property defaults to true.
-    #
+    # Returns commits reachable from one exact head and not reachable from any
+    # authenticated base. The result fails closed above the configured cap.
+    # .PARAMETER RepositoryRootPath
+    # The absolute path of the trusted Git repository.
+    # .PARAMETER HeadRevision
+    # The exact authenticated head commit.
+    # .PARAMETER BaseRevision
+    # One through 64 authenticated commits that bound the introduced history.
     # .EXAMPLE
-    # $arrFailure = @(Get-DocumentMetadataRangeTransitionFailure `
-    #     -Name 'AGENTS.md' -TransitionContext $arrTransitions)
+    # Read-GitIntroducedCommitRevision @hashtableArguments
     #
-    # # Returns no strings when every transition satisfies the metadata policy.
-    #
-    # .EXAMPLE
-    # Get-DocumentMetadataRangeTransitionFailure `
-    #     -Name 'AGENTS.md' -TransitionContext $arrTransitions
-    #
-    # # Writes one commit-prefixed string for every failed transition rule.
-    #
+    # # Returns commits reachable from the head and outside every base.
     # .INPUTS
-    # None. You can't pipe objects to this function.
-    #
+    # None. No pipeline input.
     # .OUTPUTS
-    # [string] Zero or more diagnostics in the form Name transition
-    # ParentRevision..CurrentRevision followed by the transition failure. No
-    # output means every supplied transition passed.
-    #
+    # [string] Zero or more commit IDs.
     # .NOTES
     # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
     # Parameters, return shape, and positional contract can change without notice.
     # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
+    # Version: 1.0.20260831.0.
     [CmdletBinding(PositionalBinding = $false)]
     [OutputType([string])]
     param(
-        [Parameter(Mandatory)]
-        [string] $Name,
-
-        [Parameter(Mandatory)]
-        [AllowEmptyCollection()]
-        [pscustomobject[]] $TransitionContext
+        [Parameter(Mandatory)][string] $RepositoryRootPath,
+        [Parameter(Mandatory)][string] $HeadRevision,
+        [Parameter(Mandatory)][AllowEmptyCollection()][string[]] $BaseRevision
     )
 
-    foreach ($objTransition in $TransitionContext) {
-        $objDateRequirementProperty =
-            $objTransition.PSObject.Properties['RequireExpectedUtcDateForRenderedChange']
-        $boolRequireExpectedUtcDate = if ($null -eq $objDateRequirementProperty) {
-            $true
+    $arrBases = @($BaseRevision)
+    if ($arrBases.Count -lt 1 -or
+        $arrBases.Count -gt $intMetadataMaximumBoundaries) {
+        throw 'Introduced history requires 1 through 64 authenticated bases.'
+    }
+    $arrArguments = @(
+        '-C', $RepositoryRootPath, 'rev-list', '--topo-order',
+        "--max-count=$($intMaximumIntroducedCommitCount + 1)",
+        $HeadRevision, '--not'
+    ) + $arrBases
+    $arrCommits = @(
+        & git @arrArguments 2>$null |
+            ForEach-Object { ([string] $_).Trim() }
+    )
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Could not enumerate authenticated introduced history.'
+    }
+    if ($arrCommits.Count -gt $intMaximumIntroducedCommitCount) {
+        throw "Authenticated introduced history exceeds $intMaximumIntroducedCommitCount commits."
+    }
+    return @($arrCommits)
+}
+
+function Get-GovernedMetadataHistoryFailure {
+    # .SYNOPSIS
+    # Validates every introduced commit transition for one governed document.
+    # .DESCRIPTION
+    # Reads Git blobs as inert data and applies metadata policy to each changed
+    # parent edge. Candidate scripts or workflows are never invoked.
+    # .PARAMETER Name
+    # The trusted document name for diagnostics.
+    # .PARAMETER RepositoryRootPath
+    # The absolute path of the trusted Git repository.
+    # .PARAMETER RepositoryRelativePath
+    # The exact governed document path.
+    # .PARAMETER MaximumBytes
+    # The maximum permitted document byte count.
+    # .PARAMETER CommitRevision
+    # The bounded introduced commit set to validate.
+    # .PARAMETER RequiresVersion
+    # True when the document must contain Version metadata.
+    # .PARAMETER RequiredDocument
+    # True when deletion of the document is prohibited.
+    # .EXAMPLE
+    # Get-GovernedMetadataHistoryFailure @hashtableArguments
+    #
+    # # Returns one diagnostic for each invalid commit transition.
+    # .INPUTS
+    # None. No pipeline input.
+    # .OUTPUTS
+    # [string] Zero or more validation diagnostics.
+    # .NOTES
+    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
+    # Parameters, return shape, and positional contract can change without notice.
+    # Positional parameters are disabled; internal callers use named arguments.
+    # Version: 1.0.20260831.0.
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory)][string] $RepositoryRootPath,
+        [Parameter(Mandatory)][string] $RepositoryRelativePath,
+        [Parameter(Mandatory)][ValidateRange(1, 2147483646)][int] $MaximumBytes,
+        [Parameter(Mandatory)][AllowEmptyCollection()][string[]] $CommitRevision,
+        [Parameter(Mandatory)][bool] $RequiresVersion,
+        [Parameter(Mandatory)][bool] $RequiredDocument
+    )
+
+    foreach ($strCommit in @($CommitRevision)) {
+        $strCommitAndParents = [string] (& git -C $RepositoryRootPath `
+                rev-list --parents -n 1 $strCommit 2>$null)
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not inspect metadata transition commit $strCommit."
         }
-        else {
-            [bool] $objDateRequirementProperty.Value
+        $arrCommitAndParents = @($strCommitAndParents.Trim() -split '\s+')
+        if ($arrCommitAndParents.Count -lt 1 -or
+            $arrCommitAndParents.Count -gt ($intMetadataMaximumBoundaries + 1) -or
+            $arrCommitAndParents[0] -cne $strCommit) {
+            throw "Git returned invalid metadata parents for $strCommit."
         }
-        $arrTransitionFailures = @(Get-DocumentMetadataTransitionFailure `
-                -Name $Name `
-                -CurrentContent $objTransition.CurrentContent `
-                -ParentContent $objTransition.ParentContent `
-                -ExpectedUtcDate $objTransition.ExpectedUtcDate `
-                -IsNewDocumentTransition ($null -eq $objTransition.ParentContent) `
-                -RequireExpectedUtcDateForRenderedChange $boolRequireExpectedUtcDate)
-        foreach ($strFailure in $arrTransitionFailures) {
-            Write-Output (
-                "$Name transition $($objTransition.ParentRevision).." +
-                "$($objTransition.CurrentRevision): $strFailure"
-            )
+        $arrParents = @($arrCommitAndParents | Select-Object -Skip 1)
+        if ($arrParents.Count -eq 0) {
+            $arrParents = @('')
+        }
+        foreach ($strParent in $arrParents) {
+            & git -C $RepositoryRootPath cat-file -e `
+                "$strCommit`:$RepositoryRelativePath" 2>$null
+            $boolCurrentExists = $LASTEXITCODE -eq 0
+            $boolParentExists = $false
+            if (-not [string]::IsNullOrEmpty($strParent)) {
+                & git -C $RepositoryRootPath cat-file -e `
+                    "$strParent`:$RepositoryRelativePath" 2>$null
+                $boolParentExists = $LASTEXITCODE -eq 0
+            }
+            if (-not $boolCurrentExists -and -not $boolParentExists) {
+                continue
+            }
+            $strCurrentBlob = if ($boolCurrentExists) {
+                [string] (& git -C $RepositoryRootPath rev-parse --verify `
+                        "$strCommit`:$RepositoryRelativePath" 2>$null)
+            } else { '' }
+            if ($boolCurrentExists -and $LASTEXITCODE -ne 0) {
+                throw "Could not resolve $Name at $strCommit."
+            }
+            $strParentBlob = if ($boolParentExists) {
+                [string] (& git -C $RepositoryRootPath rev-parse --verify `
+                        "$strParent`:$RepositoryRelativePath" 2>$null)
+            } else { '' }
+            if ($boolParentExists -and $LASTEXITCODE -ne 0) {
+                throw "Could not resolve the parent of $Name at $strCommit."
+            }
+            if ($strCurrentBlob.Trim() -ceq $strParentBlob.Trim()) {
+                continue
+            }
+            if (-not $boolCurrentExists) {
+                if ($RequiredDocument) {
+                    Write-Output "$Name is required and must not be deleted by $strCommit."
+                }
+                continue
+            }
+            $strCurrentContent = Read-GitRevisionText `
+                -RepositoryRootPath $RepositoryRootPath `
+                -Revision $strCommit `
+                -RepositoryRelativePath $RepositoryRelativePath `
+                -MaximumBytes $MaximumBytes `
+                -RequireRegularFile
+            $strParentContent = if ($boolParentExists) {
+                Read-GitRevisionText `
+                    -RepositoryRootPath $RepositoryRootPath `
+                    -Revision $strParent `
+                    -RepositoryRelativePath $RepositoryRelativePath `
+                    -MaximumBytes $MaximumBytes `
+                    -RequireRegularFile
+            } else { $null }
+            $strCommitEpoch = [string] (& git -C $RepositoryRootPath show `
+                    -s --format=%ct $strCommit 2>$null)
+            if ($LASTEXITCODE -ne 0 -or $strCommitEpoch.Trim() -cnotmatch '^\d+$') {
+                throw "Could not read the trusted commit date for $strCommit."
+            }
+            $strCommitUtcDate = (
+                ConvertFrom-TrustedEventTimestamp -Timestamp $strCommitEpoch.Trim()
+            ).ToString('yyyy-MM-dd')
+            if ($RequiresVersion) {
+                Get-PublishedEndpointMetadataFailure `
+                    -Name $Name `
+                    -CurrentContent $strCurrentContent `
+                    -ParentContent $strParentContent `
+                    -ExpectedUtcDate $strCommitUtcDate `
+                    -IsNewDocumentTransition (-not $boolParentExists)
+            }
+            else {
+                Get-PublishedEndpointLastUpdatedFailure `
+                    -Name $Name `
+                    -CurrentContent $strCurrentContent `
+                    -BaseContent $strParentContent `
+                    -TrustedEventUtcDate $strCommitUtcDate
+            }
         }
     }
 }
@@ -5438,6 +5355,8 @@ function Get-TrustRootRangeMutationFailure {
     #
     # .PARAMETER RepositoryRelativePath
     # The exact repository-relative trust-root paths.
+    # .PARAMETER ExactAuthorizedMaintenanceProductionCall
+    # Bypasses this one production call only after exact trusted authorization.
     #
     # .EXAMPLE
     # Get-TrustRootRangeMutationFailure `
@@ -5471,8 +5390,20 @@ function Get-TrustRootRangeMutationFailure {
 
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [string[]] $RepositoryRelativePath
+        [string[]] $RepositoryRelativePath,
+
+        [Parameter()]
+        [switch] $ExactAuthorizedMaintenanceProductionCall
     )
+
+    if ($ExactAuthorizedMaintenanceProductionCall -and
+        -not $script:boolTrustedMaintenanceAuthorizationValidated) {
+        throw 'The production maintenance call requires exact trusted authorization.'
+    }
+    if ($ExactAuthorizedMaintenanceProductionCall -and
+        $script:boolTrustedMaintenanceAuthorizationValidated) {
+        return
+    }
 
     $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
     $arrBaseRevisions = @($BaseRevision)
@@ -5519,709 +5450,6 @@ function Get-TrustRootRangeMutationFailure {
             "Pull request changes trusted validation path $strTrustPath. " +
             'Update this trust root only through an authorized trusted-base maintenance path.'
         )
-    }
-}
-
-function Get-GovernedDocumentCommitTransitionFailure {
-    # .SYNOPSIS
-    # Finds an invalid governed-document transition in one commit.
-    #
-    # .DESCRIPTION
-    # Validates one commit against each parent as a governed-document transition.
-    #
-    # .PARAMETER Name
-    # The fixture or document name to use in diagnostics.
-    #
-    # .PARAMETER RepositoryRootPath
-    # The absolute path of the trusted Git repository.
-    #
-    # .PARAMETER RepositoryRelativePath
-    # The canonical repository-relative path to inspect.
-    #
-    # .PARAMETER MaximumBytes
-    # The maximum permitted output size in bytes.
-    #
-    # .PARAMETER CommitRevision
-    # The exact commit whose parent transitions must be validated.
-    #
-    # .PARAMETER PolicyRepositoryRelativePath
-    # The repository-relative policy document path.
-    #
-    # .PARAMETER PolicyMaximumBytes
-    # The maximum permitted policy document size in bytes.
-    #
-    # .PARAMETER PolicyMarker
-    # The exact marker that activates the historical policy.
-    #
-    # .PARAMETER RequireExpectedUtcDateForRenderedChange
-    # Requires a rendered change to use the expected UTC date.
-    #
-    # .PARAMETER RequiresVersion
-    # Indicates whether the document header must contain Version metadata.
-    #
-    # .PARAMETER RequiredDocument
-    # Indicates whether deletion of the governed document is prohibited.
-    #
-    # .EXAMPLE
-    # Get-GovernedDocumentCommitTransitionFailure @hashtableArguments
-    #
-    # # Runs with validated named arguments.
-    #
-    # .INPUTS
-    # None. No pipeline input.
-    #
-    # .OUTPUTS
-    # [System.String] Zero or more validated values or diagnostics described in the function description.
-    #
-    # .NOTES
-    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
-    # Parameters, return shape, and positional contract can change without notice.
-    # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
-    [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory)]
-        [string] $Name,
-
-        [Parameter(Mandatory)]
-        [string] $RepositoryRootPath,
-
-        [Parameter(Mandatory)]
-        [string] $RepositoryRelativePath,
-
-        [Parameter(Mandatory)]
-        [ValidateRange(1, 2147483646)]
-        [int] $MaximumBytes,
-
-        [Parameter(Mandatory)]
-        [string] $CommitRevision,
-
-        [Parameter(Mandatory)]
-        [string] $PolicyRepositoryRelativePath,
-
-        [Parameter(Mandatory)]
-        [ValidateRange(1, 2147483646)]
-        [int] $PolicyMaximumBytes,
-
-        [Parameter(Mandatory)]
-        [string] $PolicyMarker,
-
-        [Parameter()]
-        [bool] $RequireExpectedUtcDateForRenderedChange = $false,
-
-        [Parameter()]
-        [bool] $RequiresVersion = $true,
-
-        [Parameter()]
-        [bool] $RequiredDocument = $false
-    )
-
-    $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
-    if ($CommitRevision -notmatch $strObjectIdPattern) {
-        throw "The governed direct-transition commit is invalid: $CommitRevision"
-    }
-    & git -C $RepositoryRootPath cat-file -e "$CommitRevision`^{commit}" 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        throw "The governed direct-transition commit is unavailable: $CommitRevision"
-    }
-    $strParentLine = [string] (
-        & git -C $RepositoryRootPath rev-list --parents -n 1 $CommitRevision
-    )
-    if ($LASTEXITCODE -ne 0) {
-        throw "Could not read the parents of metadata range commit $CommitRevision."
-    }
-    $arrCommitAndParents = @($strParentLine.Trim() -split '\s+')
-    if ($arrCommitAndParents.Count -eq 0 -or
-        $arrCommitAndParents[0] -notmatch $strObjectIdPattern -or
-        -not [string]::Equals(
-            $arrCommitAndParents[0],
-            $CommitRevision,
-            [StringComparison]::OrdinalIgnoreCase
-        )) {
-        throw "Git returned an invalid identity for metadata range commit $CommitRevision."
-    }
-    $intParentCount = $arrCommitAndParents.Count - 1
-    if ($intParentCount -gt $intMetadataMaximumParents) {
-        throw (
-            "Metadata range commit $CommitRevision has $intParentCount parents; " +
-            "the maximum is $intMetadataMaximumParents."
-        )
-    }
-    $listParentContexts = [Collections.Generic.List[pscustomobject]]::new()
-    $boolHasPolicyActiveParent = $false
-    for ($intParentIndex = 1;
-        $intParentIndex -lt $arrCommitAndParents.Count;
-        $intParentIndex++) {
-        $strParentRevision = [string]$arrCommitAndParents[$intParentIndex]
-        if ($strParentRevision -notmatch $strObjectIdPattern) {
-            throw "Git returned an invalid parent for metadata range commit $CommitRevision."
-        }
-        & git -C $RepositoryRootPath cat-file -e `
-            "$strParentRevision`^{commit}" 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            throw "Git returned an unavailable parent for metadata range commit $CommitRevision."
-        }
-        $boolParentHasPolicyMarker = Test-HistoricalPolicyMarker `
-            -RepositoryRootPath $RepositoryRootPath `
-            -Revision $strParentRevision `
-            -RepositoryRelativePath $PolicyRepositoryRelativePath `
-            -Literal $PolicyMarker
-        if ($boolParentHasPolicyMarker) {
-            $boolHasPolicyActiveParent = $true
-        }
-        $listParentContexts.Add([pscustomobject]@{
-                Revision = $strParentRevision
-                HasPolicyMarker = $boolParentHasPolicyMarker
-            })
-    }
-    $arrCurrentTreeEntries = @(& git -C $RepositoryRootPath ls-tree `
-            $CommitRevision -- $RepositoryRelativePath 2>&1)
-    if ($LASTEXITCODE -ne 0) {
-        throw (
-            "Could not inspect $RepositoryRelativePath for metadata range commit " +
-            "$CommitRevision."
-        )
-    }
-    $boolUseWorktreePolicy = $false
-    if ($CommitRevision -ceq $script:strCheckedOutRevision) {
-        & git -C $RepositoryRootPath diff --quiet --no-ext-diff --no-textconv `
-            $CommitRevision -- $PolicyRepositoryRelativePath
-        if ($LASTEXITCODE -eq 1) {
-            $boolUseWorktreePolicy = $true
-        } elseif ($LASTEXITCODE -ne 0) {
-            throw 'Could not compare the checked-out policy with its commit.'
-        }
-    }
-    if ($boolUseWorktreePolicy) {
-        $arrPolicyBytes = [byte[]] @(
-            Read-RepositoryInputData `
-                -Path (Join-Path $RepositoryRootPath $PolicyRepositoryRelativePath) `
-                -RepositoryRootPath $RepositoryRootPath `
-                -RepositoryRelativePath $PolicyRepositoryRelativePath `
-                -DisplayName $PolicyRepositoryRelativePath `
-                -MaximumBytes $PolicyMaximumBytes
-        )
-        $strPolicy = ConvertFrom-StrictUtf8Data `
-            -Bytes $arrPolicyBytes -DisplayName $PolicyRepositoryRelativePath
-        if (-not $strPolicy.Contains($PolicyMarker, [StringComparison]::Ordinal)) {
-            throw 'The checked-out policy is missing its governance marker.'
-        }
-    } elseif (-not (Test-HistoricalPolicyMarker `
-                -RepositoryRootPath $RepositoryRootPath `
-                -Revision $CommitRevision `
-                -RepositoryRelativePath $PolicyRepositoryRelativePath `
-                -Literal $PolicyMarker)) {
-        if ($boolHasPolicyActiveParent) {
-            Write-Output (
-                "$PolicyRepositoryRelativePath governance marker $PolicyMarker " +
-                "must not be removed at metadata range commit $CommitRevision."
-            )
-        }
-        if ($RequiredDocument -and $arrCurrentTreeEntries.Count -eq 0) {
-            Write-Output "Required governed document $RepositoryRelativePath must exist in $CommitRevision."
-        }
-        return
-    }
-
-    $listChangedParents = [Collections.Generic.List[pscustomobject]]::new()
-    $boolMatchesPolicyActiveParent = $false
-    foreach ($objParentContext in $listParentContexts) {
-        & git -C $RepositoryRootPath diff --quiet --no-ext-diff --no-textconv `
-            $objParentContext.Revision $CommitRevision -- $RepositoryRelativePath
-        $intDiffExitCode = $LASTEXITCODE
-        if ($intDiffExitCode -eq 0) {
-            if ($objParentContext.HasPolicyMarker) {
-                $boolMatchesPolicyActiveParent = $true
-            }
-            continue
-        }
-        if ($intDiffExitCode -ne 1) {
-            throw (
-                "Could not compare $RepositoryRelativePath for metadata range commit " +
-                "$CommitRevision."
-            )
-        }
-        $boolRestoresFirstParentBlob = $false
-        $strChangedParentFirstParent = [string] (
-            & git -C $RepositoryRootPath rev-parse --verify `
-                "$($objParentContext.Revision)`^1`^{commit}" 2>$null
-        )
-        if ($LASTEXITCODE -eq 0 -and
-            -not [string]::IsNullOrEmpty($strChangedParentFirstParent.Trim())) {
-            & git -C $RepositoryRootPath diff --quiet --no-ext-diff --no-textconv `
-                $strChangedParentFirstParent.Trim() $CommitRevision -- `
-                $RepositoryRelativePath
-            $intRestorationDiffExitCode = $LASTEXITCODE
-            if ($intRestorationDiffExitCode -eq 0) {
-                $boolRestoresFirstParentBlob = $true
-            }
-            elseif ($intRestorationDiffExitCode -ne 1) {
-                throw (
-                    "Could not verify exact restoration of $RepositoryRelativePath " +
-                    "for metadata range commit $CommitRevision."
-                )
-            }
-        }
-        $listChangedParents.Add([pscustomobject]@{
-                Revision = $objParentContext.Revision
-                HasPolicyMarker = $objParentContext.HasPolicyMarker
-                RestoresFirstParentBlob = $boolRestoresFirstParentBlob
-            })
-    }
-    if ($intParentCount -ne 0 -and $listChangedParents.Count -eq 0) {
-        return [string[]] @()
-    }
-
-    $strCommitTimestamp = [string] (
-        & git -C $RepositoryRootPath show -s --format=%cI $CommitRevision
-    )
-    if ($LASTEXITCODE -ne 0) {
-        throw "Could not read the timestamp of metadata range commit $CommitRevision."
-    }
-    $objCommitTimestamp = [DateTimeOffset]::MinValue
-    if (-not [DateTimeOffset]::TryParse(
-            $strCommitTimestamp.Trim(),
-            [ref] $objCommitTimestamp
-        )) {
-        throw "Metadata range commit $CommitRevision has an invalid timestamp."
-    }
-    if ($objCommitTimestamp -gt $script:objMaximumCommitUtcTimestamp) {
-        Write-Output (
-            "Metadata range commit $CommitRevision timestamp " +
-            "$($objCommitTimestamp.ToUniversalTime().ToString('o')) must not be later than " +
-            "trusted UTC $($script:objMaximumCommitUtcTimestamp.ToString('o'))."
-        )
-        return
-    }
-
-    if ($arrCurrentTreeEntries.Count -eq 0) {
-        if ($RequiredDocument) {
-            Write-Output "Required governed document $RepositoryRelativePath must exist in $CommitRevision."
-        }
-        return [string[]] @()
-    }
-
-    $strCurrentContent = Read-GitRevisionText `
-        -RepositoryRootPath $RepositoryRootPath `
-        -Revision $CommitRevision `
-        -RepositoryRelativePath $RepositoryRelativePath `
-        -MaximumBytes $MaximumBytes `
-        -RequireRegularFile
-    $listTransitions = [Collections.Generic.List[pscustomobject]]::new()
-    if ($intParentCount -eq 0) {
-        $listTransitions.Add([pscustomobject]@{
-                CurrentContent = $strCurrentContent
-                ParentContent = $null
-                ExpectedUtcDate = $objCommitTimestamp.UtcDateTime.ToString('yyyy-MM-dd')
-                CurrentRevision = $CommitRevision
-                ParentRevision = ''
-                AllowSameDateForExactRestoration = $false
-                RequireExpectedUtcDateForRenderedChange =
-                    $RequireExpectedUtcDateForRenderedChange
-            })
-    }
-    foreach ($objChangedParent in $listChangedParents) {
-        $strParentContent = if ($objChangedParent.HasPolicyMarker) {
-            & git -C $RepositoryRootPath cat-file -e `
-                "$($objChangedParent.Revision)`:$RepositoryRelativePath" 2>$null
-            if ($LASTEXITCODE -ne 0) {
-                $null
-            }
-            else {
-            Read-GitRevisionText `
-                -RepositoryRootPath $RepositoryRootPath `
-                    -Revision $objChangedParent.Revision `
-                -RepositoryRelativePath $RepositoryRelativePath `
-                -MaximumBytes $MaximumBytes `
-                -RequireRegularFile
-            }
-        }
-        else {
-            $null
-        }
-        $listTransitions.Add([pscustomobject]@{
-                CurrentContent = $strCurrentContent
-                ParentContent = $strParentContent
-                ExpectedUtcDate = $objCommitTimestamp.UtcDateTime.ToString('yyyy-MM-dd')
-                CurrentRevision = $CommitRevision
-                ParentRevision = $objChangedParent.Revision
-                AllowSameDateForExactRestoration =
-                    $objChangedParent.RestoresFirstParentBlob
-                RequireExpectedUtcDateForRenderedChange =
-                    $RequireExpectedUtcDateForRenderedChange -and
-                    $objChangedParent.HasPolicyMarker -and
-                    -not $boolMatchesPolicyActiveParent
-            })
-    }
-
-    if ($RequiresVersion) {
-        return Get-DocumentMetadataRangeTransitionFailure `
-            -Name $Name `
-            -TransitionContext $listTransitions.ToArray()
-    }
-    foreach ($objTransition in $listTransitions) {
-        Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $Name `
-            -CurrentContent $objTransition.CurrentContent `
-            -BaseContent $objTransition.ParentContent `
-            -TrustedEventUtcDate $(if (
-                $objTransition.RequireExpectedUtcDateForRenderedChange) {
-                    $objTransition.ExpectedUtcDate
-                } else { '' }) `
-            -ModifyingCommitUtcDate $objTransition.ExpectedUtcDate `
-            -AllowSameDateForExactRestoration `
-                $objTransition.AllowSameDateForExactRestoration
-    }
-}
-
-function Get-GovernedDocumentRangeTransitionFailure {
-    # .SYNOPSIS
-    # Finds an invalid governed-document transition across a revision range.
-    #
-    # .DESCRIPTION
-    # Validates endpoint state and every touched commit in the authenticated range.
-    #
-    # .PARAMETER Name
-    # The fixture or document name to use in diagnostics.
-    #
-    # .PARAMETER RepositoryRootPath
-    # The absolute path of the trusted Git repository.
-    #
-    # .PARAMETER RepositoryRelativePath
-    # The canonical repository-relative path to inspect.
-    #
-    # .PARAMETER MaximumBytes
-    # The maximum permitted output size in bytes.
-    #
-    # .PARAMETER BaseRevision
-    # The authenticated base Git object IDs to exclude from the topic range.
-    #
-    # .PARAMETER HeadRevision
-    # The authenticated head Git object ID.
-    #
-    # .PARAMETER InputRevision
-    # The exact revision used to read current validation inputs.
-    #
-    # .PARAMETER IsNewRefRange
-    # Indicates whether the range represents a newly created ref.
-    #
-    # .PARAMETER PolicyRepositoryRelativePath
-    # The repository-relative policy document path.
-    #
-    # .PARAMETER PolicyMaximumBytes
-    # The maximum permitted policy document size in bytes.
-    #
-    # .PARAMETER PolicyMarker
-    # The exact marker that activates the historical policy.
-    #
-    # .PARAMETER RequireExpectedUtcDateForRenderedChange
-    # Requires a rendered change to use the expected UTC date.
-    #
-    # .PARAMETER CommitDateFreshnessRevision
-    # The revision whose trusted commit date bounds metadata freshness.
-    #
-    # .PARAMETER RequiresVersion
-    # Indicates whether the document header must contain Version metadata.
-    #
-    # .PARAMETER RequiredDocument
-    # Indicates whether deletion of the governed document is prohibited.
-    #
-    # .EXAMPLE
-    # Get-GovernedDocumentRangeTransitionFailure @hashtableArguments
-    #
-    # # Runs with validated named arguments.
-    #
-    # .INPUTS
-    # None. No pipeline input.
-    #
-    # .OUTPUTS
-    # [System.String] Zero or more validated values or diagnostics described in the function description.
-    #
-    # .NOTES
-    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
-    # Parameters, return shape, and positional contract can change without notice.
-    # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
-    [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory)]
-        [string] $Name,
-
-        [Parameter(Mandatory)]
-        [string] $RepositoryRootPath,
-
-        [Parameter(Mandatory)]
-        [string] $RepositoryRelativePath,
-
-        [Parameter(Mandatory)]
-        [ValidateRange(1, 2147483646)]
-        [int] $MaximumBytes,
-
-        [Parameter(Mandatory)]
-        [AllowEmptyCollection()]
-        [AllowEmptyString()]
-        [string[]] $BaseRevision,
-
-        [Parameter(Mandatory)]
-        [AllowEmptyString()]
-        [string] $HeadRevision,
-
-        [Parameter()]
-        [AllowEmptyString()]
-        [string] $InputRevision = '',
-
-        [Parameter(Mandatory)]
-        [bool] $IsNewRefRange,
-
-        [Parameter(Mandatory)]
-        [string] $PolicyRepositoryRelativePath,
-
-        [Parameter(Mandatory)]
-        [ValidateRange(1, 2147483646)]
-        [int] $PolicyMaximumBytes,
-
-        [Parameter(Mandatory)]
-        [string] $PolicyMarker,
-
-        [Parameter()]
-        [bool] $RequireExpectedUtcDateForRenderedChange = $false,
-
-        [Parameter()]
-        [AllowEmptyCollection()]
-        [string[]] $CommitDateFreshnessRevision = @(),
-
-        [Parameter()]
-        [bool] $RequiresVersion = $true,
-
-        [Parameter()]
-        [bool] $RequiredDocument = $false
-    )
-
-    $arrBaseRevisions = @($BaseRevision)
-    if ($arrBaseRevisions.Count -eq 1 -and
-        [string]::IsNullOrEmpty($arrBaseRevisions[0])) {
-        $arrBaseRevisions = @()
-    }
-    elseif (@($arrBaseRevisions | Where-Object {
-                [string]::IsNullOrEmpty($_)
-            }).Count -ne 0) {
-        throw 'The metadata event range contains an empty base revision.'
-    }
-    if ($arrBaseRevisions.Count -eq 0 -and
-        [string]::IsNullOrEmpty($HeadRevision)) {
-        if ($IsNewRefRange) {
-            throw 'A new-ref metadata event range must supply base and head revisions.'
-        }
-        return [string[]] @()
-    }
-    if ($arrBaseRevisions.Count -eq 0 -or
-        [string]::IsNullOrEmpty($HeadRevision)) {
-        throw 'The metadata event range must supply both base and head revisions.'
-    }
-
-    $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
-    $strZeroObjectIdPattern = '^(?:0{40}|0{64})$'
-    $boolBaseIsZeroObjectId = $arrBaseRevisions.Count -eq 1 -and
-        $arrBaseRevisions[0] -match $strZeroObjectIdPattern
-    if ($IsNewRefRange -and -not $boolBaseIsZeroObjectId) {
-        throw 'A new-ref metadata event range requires an all-zero base revision.'
-    }
-    if (-not $IsNewRefRange -and $boolBaseIsZeroObjectId) {
-        throw 'An all-zero metadata event-range base requires the new-ref flag.'
-    }
-    if ($HeadRevision -match $strZeroObjectIdPattern) {
-        throw 'The metadata event-range head must not be an all-zero object ID.'
-    }
-
-    if ($arrBaseRevisions.Count -gt 64 -or
-        @($arrBaseRevisions | Sort-Object -Unique).Count -ne
-            $arrBaseRevisions.Count) {
-        throw 'The metadata event range requires at most 64 unique bases.'
-    }
-    foreach ($strRevision in @($arrBaseRevisions) + @($HeadRevision)) {
-        if ($strRevision -notmatch $strObjectIdPattern) {
-            throw "The metadata event range contains an invalid object ID: $strRevision"
-        }
-        if ($strRevision -eq $arrBaseRevisions[0] -and
-            $boolBaseIsZeroObjectId) {
-            continue
-        }
-        & git -C $RepositoryRootPath cat-file -e "$strRevision`^{commit}" 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            throw "The metadata event-range commit is unavailable: $strRevision"
-        }
-    }
-
-    $strValidationRevision = if ([string]::IsNullOrEmpty($InputRevision)) {
-        'HEAD'
-    }
-    else {
-        $InputRevision
-    }
-    $strCheckedOutHead = [string] (
-        & git -C $RepositoryRootPath rev-parse --verify `
-            "$strValidationRevision`^{commit}"
-    )
-    if ($LASTEXITCODE -ne 0 -or
-        -not [string]::Equals(
-            $strCheckedOutHead.Trim(),
-            $HeadRevision,
-            [StringComparison]::OrdinalIgnoreCase
-        )) {
-        throw "The metadata event-range head does not match the validation revision: $HeadRevision"
-    }
-    if ($arrBaseRevisions.Count -eq 1 -and [string]::Equals(
-            $arrBaseRevisions[0], $HeadRevision,
-            [StringComparison]::OrdinalIgnoreCase)) {
-        return [string[]] @()
-    }
-
-    $boolHeadHasPolicyMarker = Test-HistoricalPolicyMarker `
-        -RepositoryRootPath $RepositoryRootPath `
-        -Revision $HeadRevision `
-        -RepositoryRelativePath $PolicyRepositoryRelativePath `
-        -Literal $PolicyMarker
-    if (-not $boolHeadHasPolicyMarker) {
-        throw "The metadata event-range head does not contain policy marker $PolicyMarker."
-    }
-
-    $boolAnyBaseHasPolicyMarker = $false
-    if (-not $IsNewRefRange) {
-        $boolAnyBaseHasPolicyMarker = @(
-            $arrBaseRevisions | Where-Object {
-                Test-HistoricalPolicyMarker `
-                    -RepositoryRootPath $RepositoryRootPath `
-                    -Revision $_ `
-                    -RepositoryRelativePath $PolicyRepositoryRelativePath `
-                    -Literal $PolicyMarker
-            }
-        ).Count -gt 0
-    }
-    if (-not $boolAnyBaseHasPolicyMarker) {
-        if ($IsNewRefRange) {
-            $arrPolicyPathCommits = @(
-                & git -C $RepositoryRootPath log --reverse --topo-order `
-                    --format=%H "-S$PolicyMarker" $HeadRevision -- `
-                    $PolicyRepositoryRelativePath 2>&1
-            )
-        }
-        else {
-            $arrPolicyLogArguments = @(
-                '-C', $RepositoryRootPath, 'log', '--reverse', '--topo-order',
-                '--format=%H', "-S$PolicyMarker", $HeadRevision, '--not'
-            ) + $arrBaseRevisions + @('--', $PolicyRepositoryRelativePath)
-            $arrPolicyPathCommits = @(& git @arrPolicyLogArguments 2>&1)
-        }
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not enumerate metadata policy-marker changes.'
-        }
-
-        $strPolicyIntroductionCommit = ''
-        foreach ($strPolicyCommitValue in $arrPolicyPathCommits) {
-            $strPolicyCommit = ([string]$strPolicyCommitValue).Trim()
-            if ($strPolicyCommit -notmatch $strObjectIdPattern) {
-                throw "Git returned an invalid metadata policy commit: $strPolicyCommit"
-            }
-            if (Test-HistoricalPolicyMarker `
-                    -RepositoryRootPath $RepositoryRootPath `
-                    -Revision $strPolicyCommit `
-                    -RepositoryRelativePath $PolicyRepositoryRelativePath `
-                    -Literal $PolicyMarker) {
-                $strPolicyIntroductionCommit = $strPolicyCommit
-                break
-            }
-        }
-        if ([string]::IsNullOrEmpty($strPolicyIntroductionCommit)) {
-            throw "Could not locate the introduction of metadata policy marker $PolicyMarker."
-        }
-
-        $strPolicyParentLine = [string] (
-            & git -C $RepositoryRootPath rev-list --parents -n 1 `
-                $strPolicyIntroductionCommit
-        )
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not read the metadata policy-introduction parent.'
-        }
-        $arrPolicyCommitAndParents = @($strPolicyParentLine.Trim() -split ' ')
-        if ($arrPolicyCommitAndParents.Count -eq 1 -and $IsNewRefRange) {
-            $arrEffectiveBaseRevisions = @()
-        }
-        elseif ($arrPolicyCommitAndParents.Count -lt 2 -or
-            $arrPolicyCommitAndParents[1] -notmatch $strObjectIdPattern) {
-            throw 'The metadata policy-introduction commit must have a valid first parent.'
-        }
-        else {
-            $arrEffectiveBaseRevisions = @(
-                if ($IsNewRefRange) {
-                    $arrPolicyCommitAndParents[1]
-                }
-                else {
-                    @($arrBaseRevisions) + @($arrPolicyCommitAndParents[1]) |
-                        Sort-Object -Unique
-                }
-            )
-        }
-    }
-    else {
-        $arrEffectiveBaseRevisions = @($arrBaseRevisions)
-    }
-
-    if ($arrEffectiveBaseRevisions.Count -eq 0) {
-        $arrRangeCommits = @(
-            & git -C $RepositoryRootPath rev-list --reverse --topo-order `
-                $HeadRevision 2>&1
-        )
-    }
-    else {
-        $arrRangeArguments = @(
-            '-C', $RepositoryRootPath, 'rev-list', '--reverse', '--topo-order',
-            $HeadRevision, '--not'
-        ) + $arrEffectiveBaseRevisions
-        $arrRangeCommits = @(& git @arrRangeArguments 2>&1)
-    }
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Could not enumerate the metadata event range.'
-    }
-
-    $setRangeCommits = [Collections.Generic.HashSet[string]]::new(
-        [StringComparer]::OrdinalIgnoreCase
-    )
-    foreach ($strRangeCommitValue in $arrRangeCommits) {
-        [void]$setRangeCommits.Add(([string]$strRangeCommitValue).Trim())
-    }
-    $setCommitDateFreshnessRevisions =
-        [Collections.Generic.HashSet[string]]::new(
-            [StringComparer]::OrdinalIgnoreCase
-        )
-    foreach ($strFreshnessRevision in $CommitDateFreshnessRevision) {
-        if ($strFreshnessRevision -notmatch $strObjectIdPattern -or
-            -not $setRangeCommits.Contains($strFreshnessRevision)) {
-            throw 'A commit-date freshness revision is outside the metadata event range.'
-        }
-        [void]$setCommitDateFreshnessRevisions.Add($strFreshnessRevision)
-    }
-
-    foreach ($strRangeCommitValue in $arrRangeCommits) {
-        $strRangeCommit = ([string]$strRangeCommitValue).Trim()
-        $arrCommitFailures = @(Get-GovernedDocumentCommitTransitionFailure `
-            -Name $Name `
-            -RepositoryRootPath $RepositoryRootPath `
-            -RepositoryRelativePath $RepositoryRelativePath `
-            -MaximumBytes $MaximumBytes `
-            -CommitRevision $strRangeCommit `
-            -PolicyRepositoryRelativePath $PolicyRepositoryRelativePath `
-            -PolicyMaximumBytes $PolicyMaximumBytes `
-            -PolicyMarker $PolicyMarker `
-            -RequireExpectedUtcDateForRenderedChange `
-                ($RequireExpectedUtcDateForRenderedChange -or
-                    $setCommitDateFreshnessRevisions.Contains($strRangeCommit)) `
-            -RequiresVersion $RequiresVersion `
-            -RequiredDocument $RequiredDocument)
-        foreach ($strCommitFailure in $arrCommitFailures) {
-            Write-Output $strCommitFailure
-        }
     }
 }
 
@@ -6838,7 +6066,7 @@ function Get-AgentInstructionFailure {
     }
 
     foreach ($objDocument in $arrDocuments) {
-        $arrMetadataFailures = @(Get-DocumentMetadataTransitionFailure `
+        $arrMetadataFailures = @(Get-PublishedEndpointMetadataFailure `
                 -Name $objDocument.Name `
                 -CurrentContent $objDocument.RawContent `
                 -ParentContent $objDocument.ParentContent `
@@ -7069,24 +6297,19 @@ if ($PushApplicabilityOnly) {
         -not [string]::IsNullOrEmpty($TrustedEventTimestamp) -or
         $EventName -cne 'push' -or
         -not [string]::IsNullOrEmpty($PullRequestAction) -or
-        -not [string]::IsNullOrEmpty($PullRequestBaseChanged) -or
-        -not [string]::IsNullOrEmpty($PreviousHeadRevision) -or
-        -not [string]::IsNullOrEmpty($EventHeadRevision) -or
-        -not [string]::IsNullOrEmpty($EventHeadDistinct) -or
-        -not [string]::IsNullOrEmpty($NewRefCommitCount) -or
-        -not [string]::IsNullOrEmpty($NewRefCommitEvidenceJson)) {
+        -not [string]::IsNullOrEmpty($PullRequestBaseChanged)) {
         throw 'Push-applicability mode received incompatible validation fields.'
     }
     $objPushApplicability = Get-PushGovernedPathApplicability `
         -RepositoryRootPath $strRepositoryRootPath `
-        -BaseRevision $RangeBaseRevision `
-        -HeadRevision $RangeHeadRevision `
-        -IsNewRef ([bool]$RangeIsNewRef) `
-        -IsDeletedRef ([bool]$RangeIsDeletedRef)
+        -BaseRevision $PublishedBaselineRevision `
+        -HeadRevision $PublishedFinalRevision `
+        -IsNewRef ([bool]$PublishedBaselineAbsent) `
+        -IsDeletedRef ([bool]$PublishedFinalDeleted)
     Write-Output $objPushApplicability.ShouldValidate.ToString().ToLowerInvariant()
     return
 }
-if ($RangeIsDeletedRef) {
+if ($PublishedFinalDeleted) {
     throw 'Deleted-ref push validation must stop after its applicability decision.'
 }
 $arrBootstrapFailures = @(Get-MarkdownParserBootstrapFailure `
@@ -7157,70 +6380,86 @@ $arrGovernedMetadataDocuments += @(
     }
 )
 $strValidatedInputRevision = ''
-$boolEventRangeRequested = -not [string]::IsNullOrEmpty($RangeBaseRevision) -or
-    -not [string]::IsNullOrEmpty($RangeHeadRevision)
-$boolCommitDateOnlyEvent = $EventName -ceq 'pull_request_target'
-if ($boolEventRangeRequested -and
+$boolPublishedEndpointsRequested =
+    -not [string]::IsNullOrEmpty($PublishedBaselineRevision) -or
+    -not [string]::IsNullOrEmpty($PublishedFinalRevision)
+if ($boolPublishedEndpointsRequested -and
     ([string]::IsNullOrEmpty($EventName) -or
-        ([string]::IsNullOrEmpty($TrustedEventTimestamp) -and
-            -not $boolCommitDateOnlyEvent))) {
-    throw 'A metadata event range requires a trusted GitHub event name and timestamp.'
+        [string]::IsNullOrEmpty($TrustedEventTimestamp))) {
+    throw 'Published metadata endpoints require a trusted GitHub event name and timestamp.'
 }
-if (-not $boolEventRangeRequested -and
+if (-not $boolPublishedEndpointsRequested -and
     (-not [string]::IsNullOrEmpty($TrustedEventTimestamp) -or
         -not [string]::IsNullOrEmpty($EventName) -or
         -not [string]::IsNullOrEmpty($PullRequestAction) -or
         -not [string]::IsNullOrEmpty($PullRequestBaseChanged) -or
-        -not [string]::IsNullOrEmpty($PreviousHeadRevision) -or
-        $RangeIsDeletedRef -or
+        -not [string]::IsNullOrEmpty($DestinationRef) -or
         -not [string]::IsNullOrEmpty($EventHeadRevision) -or
         -not [string]::IsNullOrEmpty($EventHeadDistinct) -or
-        -not [string]::IsNullOrEmpty($NewRefCommitCount) -or
-        -not [string]::IsNullOrEmpty($NewRefCommitEvidenceJson))) {
-    throw 'Metadata event fields require a complete base and head range.'
+        -not [string]::IsNullOrEmpty($PushCommitCount) -or
+        -not [string]::IsNullOrEmpty($PushDistinctCommitCount) -or
+        -not [string]::IsNullOrEmpty($PushCommitEvidenceJson) -or
+        -not [string]::IsNullOrEmpty($OtherRefEvidenceJson) -or
+        $PublishedBaselineAbsent -or $PublishedFinalDeleted)) {
+    throw 'Metadata event fields require complete published endpoints.'
 }
 if (-not [string]::IsNullOrEmpty($TrustedEventTimestamp)) {
-    [void](ConvertFrom-TrustedEventTimestamp -Timestamp $TrustedEventTimestamp)
+    [void] (
+        ConvertFrom-TrustedEventTimestamp -Timestamp $TrustedEventTimestamp
+    )
 }
-$arrEventHistoryBaseRevisions = @($RangeBaseRevision)
-$arrNewRefBoundaryRevisions = @()
-$arrNewRefIntroducedCommitRevisions = @()
-$boolRequireRangeCommitDateFreshness = $false
-$boolValidateBackwardPushHead = $false
-if ($boolEventRangeRequested -and
-    -not [string]::IsNullOrEmpty($RangeBaseRevision) -and
-    -not [string]::IsNullOrEmpty($RangeHeadRevision)) {
-    $objMetadataEventRevisionContext = Get-MetadataEventRevisionContext `
+if ($boolPublishedEndpointsRequested) {
+    Assert-PublishedEndpointContext `
         -RepositoryRootPath $strRepositoryRootPath `
         -EventName $EventName -PullRequestAction $PullRequestAction `
-        -BaseRevision $RangeBaseRevision -HeadRevision $RangeHeadRevision `
-        -IsNewRefRange ([bool]$RangeIsNewRef) `
-        -PreviousHeadRevision $PreviousHeadRevision `
-        -PullRequestBaseChanged $PullRequestBaseChanged `
+        -BaselineRevision $PublishedBaselineRevision `
+        -FinalRevision $PublishedFinalRevision `
+        -BaselineAbsent ([bool]$PublishedBaselineAbsent) `
+        -PullRequestBaseChanged $PullRequestBaseChanged
+}
+$objCreatedRefContext = $null
+if ($PublishedBaselineAbsent) {
+    $objCreatedRefContext = Get-CreatedRefBoundaryContext `
+        -RepositoryRootPath $strRepositoryRootPath `
+        -DestinationRef $DestinationRef `
+        -HeadRevision $PublishedFinalRevision `
         -EventHeadRevision $EventHeadRevision `
         -EventHeadDistinct $EventHeadDistinct `
-        -NewRefCommitCount $NewRefCommitCount `
-        -NewRefCommitEvidenceJson $NewRefCommitEvidenceJson
-    $arrEventHistoryBaseRevisions = @(
-        $objMetadataEventRevisionContext.HistoryBaseRevisions
-    )
-    if ($RangeIsNewRef) {
-        $arrNewRefBoundaryRevisions = @(
-            $objMetadataEventRevisionContext.NewRefBoundaryRevisions
-        )
-        $arrNewRefIntroducedCommitRevisions = @(
-            $objMetadataEventRevisionContext.NewRefIntroducedCommitRevisions
+        -PushCommitCount $PushCommitCount `
+        -PushDistinctCommitCount $PushDistinctCommitCount `
+        -PushCommitEvidenceJson $PushCommitEvidenceJson `
+        -OtherRefEvidenceJson $OtherRefEvidenceJson
+}
+elseif (-not [string]::IsNullOrEmpty($DestinationRef) -or
+    -not [string]::IsNullOrEmpty($EventHeadRevision) -or
+    -not [string]::IsNullOrEmpty($EventHeadDistinct) -or
+    -not [string]::IsNullOrEmpty($PushCommitCount) -or
+    -not [string]::IsNullOrEmpty($PushDistinctCommitCount) -or
+    -not [string]::IsNullOrEmpty($PushCommitEvidenceJson) -or
+    -not [string]::IsNullOrEmpty($OtherRefEvidenceJson)) {
+    throw 'Created-push evidence is valid only when the destination ref is new.'
+}
+$arrPublishedGraphBases = @()
+$arrPublishedIntroducedCommits = @()
+if ($boolPublishedEndpointsRequested) {
+    if ($PublishedBaselineAbsent) {
+        $arrPublishedGraphBases = @($objCreatedRefContext.BoundaryRevisions)
+        $arrPublishedIntroducedCommits = @(
+            $objCreatedRefContext.IntroducedCommitRevisions
         )
     }
-    $boolRequireRangeCommitDateFreshness =
-        ($EventName -ceq 'push' -and -not $RangeIsNewRef) -or
-        $boolCommitDateOnlyEvent
-    if ($EventName -ceq 'push' -and -not $RangeIsNewRef -and
-        $EventHeadDistinct -ceq 'false' -and
-        $RangeBaseRevision -ne $RangeHeadRevision) {
-        $boolValidateBackwardPushHead = Test-BackwardCommitMove `
-            -RepositoryRootPath $strRepositoryRootPath `
-            -BaseRevision $RangeBaseRevision -HeadRevision $RangeHeadRevision
+    else {
+        $arrPublishedGraphBases = if ($EventName -ceq 'pull_request_target') {
+            @(Get-AuthenticatedMergeBaseRevision `
+                    -RepositoryRootPath $strRepositoryRootPath `
+                    -LeftRevision $PublishedBaselineRevision `
+                    -RightRevision $PublishedFinalRevision)
+        }
+        else { @($PublishedBaselineRevision) }
+        $arrPublishedIntroducedCommits = @(Read-GitIntroducedCommitRevision `
+                -RepositoryRootPath $strRepositoryRootPath `
+                -HeadRevision $PublishedFinalRevision `
+                -BaseRevision $arrPublishedGraphBases)
     }
 }
 
@@ -7241,13 +6480,77 @@ if (-not [string]::IsNullOrEmpty($InputRevision)) {
         throw "The agent-instruction input commit is unavailable: $InputRevision"
     }
     $strValidatedInputRevision = $strValidatedInputRevision.Trim()
-    if (-not [string]::IsNullOrEmpty($RangeHeadRevision) -and
+    if (-not [string]::IsNullOrEmpty($PublishedFinalRevision) -and
         -not [string]::Equals(
             $strValidatedInputRevision,
-            $RangeHeadRevision,
+            $PublishedFinalRevision,
             [StringComparison]::OrdinalIgnoreCase
         )) {
-        throw 'The input revision must match the metadata event-range head.'
+        throw 'The input revision must match the published final revision.'
+    }
+}
+
+if ($SelfTest) {
+    $strAuthorizationFixtureBase = [string] (
+        & git -C $strRepositoryRootPath rev-list --max-parents=0 HEAD |
+            Select-Object -First 1
+    )
+    $strAuthorizationFixtureHead = [string] (
+        & git -C $strRepositoryRootPath rev-parse --verify 'HEAD^{commit}'
+    )
+    if ($LASTEXITCODE -ne 0 -or
+        $strAuthorizationFixtureBase.Trim() -notmatch '^[0-9a-fA-F]{40}$' -or
+        $strAuthorizationFixtureHead.Trim() -notmatch '^[0-9a-fA-F]{40}$') {
+        throw 'Could not resolve the production-authorization fixtures.'
+    }
+    $boolOriginalExactAuthorization =
+        $script:boolTrustedMaintenanceAuthorizationValidated
+    try {
+        $script:boolTrustedMaintenanceAuthorizationValidated = $true
+        $arrAuthorizedProductionFailures = @(
+            Get-TrustRootRangeMutationFailure `
+                -RepositoryRootPath $strRepositoryRootPath `
+                -BaseRevision $strAuthorizationFixtureBase.Trim() `
+                -HeadRevision $strAuthorizationFixtureHead.Trim() `
+                -RepositoryRelativePath $script:arrTrustRootPaths `
+                -ExactAuthorizedMaintenanceProductionCall
+        )
+        if ($arrAuthorizedProductionFailures.Count -ne 0) {
+            throw 'Exact authorized production maintenance did not bypass one call.'
+        }
+        $arrAuthorizedFixtureFailures = @(
+            Get-TrustRootRangeMutationFailure `
+                -RepositoryRootPath $strRepositoryRootPath `
+                -BaseRevision $strAuthorizationFixtureBase.Trim() `
+                -HeadRevision $strAuthorizationFixtureHead.Trim() `
+                -RepositoryRelativePath $script:arrTrustRootPaths
+        )
+        if ($arrAuthorizedFixtureFailures.Count -eq 0) {
+            throw 'An authorized self-test fixture bypassed trust-root mutation checks.'
+        }
+        $script:boolTrustedMaintenanceAuthorizationValidated = $false
+        $boolUnauthorizedProductionRejected = $false
+        try {
+            [void] @(Get-TrustRootRangeMutationFailure `
+                    -RepositoryRootPath $strRepositoryRootPath `
+                    -BaseRevision $strAuthorizationFixtureBase.Trim() `
+                    -HeadRevision $strAuthorizationFixtureHead.Trim() `
+                    -RepositoryRelativePath $script:arrTrustRootPaths `
+                    -ExactAuthorizedMaintenanceProductionCall)
+        }
+        catch {
+            $boolUnauthorizedProductionRejected = $_.Exception.Message.Contains(
+                'requires exact trusted authorization',
+                [StringComparison]::Ordinal
+            )
+        }
+        if (-not $boolUnauthorizedProductionRejected) {
+            throw 'An unauthorized production maintenance call did not fail closed.'
+        }
+    }
+    finally {
+        $script:boolTrustedMaintenanceAuthorizationValidated =
+            $boolOriginalExactAuthorization
     }
 }
 
@@ -7264,16 +6567,15 @@ if (-not [string]::IsNullOrEmpty($strValidatedInputRevision) -and
         $strCheckedOutRevision,
         [StringComparison]::OrdinalIgnoreCase
     )) {
-    $arrTrustRootBaseRevisions = if ($EventName -ceq 'pull_request_target') {
-        $arrEventHistoryBaseRevisions
-    } else { @($RangeBaseRevision) }
+    $arrTrustRootBaseRevisions = @($arrPublishedGraphBases)
     $arrTrustRootFailures = @(Get-TrustRootRangeMutationFailure `
+            -ExactAuthorizedMaintenanceProductionCall `
             -RepositoryRootPath $strRepositoryRootPath `
             -BaseRevision $arrTrustRootBaseRevisions `
-            -HeadRevision $RangeHeadRevision `
+            -HeadRevision $PublishedFinalRevision `
             -RepositoryRelativePath $script:arrTrustRootPaths) |
         Sort-Object -Unique
-    if ($arrTrustRootFailures.Count -gt 0) {
+    if (@($arrTrustRootFailures).Count -gt 0) {
         throw (
             'Trusted validation root changed:' + [Environment]::NewLine + '- ' +
             ($arrTrustRootFailures -join ([Environment]::NewLine + '- '))
@@ -7285,32 +6587,43 @@ $arrTrackedRepositoryPaths = @(Read-GitTrackedPath `
         -RepositoryRootPath $strRepositoryRootPath `
         -Revision $strValidatedInputRevision `
         -MaximumBytes $intGitPathListMaximumBytes)
-$arrRangeTouchedRepositoryPaths = @()
-if ($boolEventRangeRequested) {
-    $arrRangeTouchedRepositoryPaths = @(Read-GitRangeTouchedPath `
+$arrPublishedBaselinePaths = @()
+$arrPublishedChangedPaths = @()
+if ($boolPublishedEndpointsRequested) {
+    if (-not $PublishedBaselineAbsent) {
+        $arrPublishedBaselinePaths = @(Read-GitTrackedPath `
             -RepositoryRootPath $strRepositoryRootPath `
-            -BaseRevision $arrEventHistoryBaseRevisions `
-            -HeadRevision $RangeHeadRevision `
-            -IsNewRefRange ([bool]$RangeIsNewRef) `
-            -NewRefBoundaryRevision $arrNewRefBoundaryRevisions `
-            -NewRefHasIntroducedCommit `
-                ($arrNewRefIntroducedCommitRevisions.Count -gt 0) `
-            -RepositoryRelativePathspec ':(top)**' `
-            -MaximumBytes $intGitPathListMaximumBytes) | Sort-Object -Unique
+            -Revision $PublishedBaselineRevision `
+            -MaximumBytes $intGitPathListMaximumBytes)
+    }
+    $arrPublishedChangedPaths = @(Read-GitPublishedEndpointChangedPath `
+        -RepositoryRootPath $strRepositoryRootPath `
+        -BaselineRevision $PublishedBaselineRevision `
+        -FinalRevision $PublishedFinalRevision `
+        -BaselineAbsent ([bool]$PublishedBaselineAbsent) `
+        -NewRefBoundaryRevision $(if ($null -eq $objCreatedRefContext) {
+                @()
+            } else { @($objCreatedRefContext.BoundaryRevisions) }) `
+        -NewRefIntroducedCommitRevision $(if ($null -eq $objCreatedRefContext) {
+                @()
+            } else { @($objCreatedRefContext.IntroducedCommitRevisions) }) `
+        -MaximumBytes $intGitPathListMaximumBytes) | Sort-Object -Unique
 }
-$arrRangeTouchedDecisionPaths = @(
-    $arrRangeTouchedRepositoryPaths |
+$arrPublishedDecisionPaths = @(
+    @($arrPublishedBaselinePaths + $arrTrackedRepositoryPaths +
+        $arrPublishedChangedPaths) |
         Where-Object { $_ -cmatch $script:strDecisionRecordDirectoryPathPattern }
 )
-$arrRangeTouchedGovernedInstructionPaths = @(
-    $arrRangeTouchedRepositoryPaths |
+$arrPublishedGovernedInstructionPaths = @(
+    @($arrPublishedBaselinePaths + $arrTrackedRepositoryPaths +
+        $arrPublishedChangedPaths) |
         Where-Object {
             Test-GovernedInstructionInventoryPath `
                 -RepositoryRelativePath ([string]$_)
         }
 )
 $arrDecisionRecordInventoryPaths = @(
-    @($arrTrackedRepositoryPaths + $arrRangeTouchedDecisionPaths) |
+    @($arrTrackedRepositoryPaths + $arrPublishedDecisionPaths) |
         Where-Object { $_ -cmatch $script:strDecisionRecordDirectoryPathPattern } |
         Sort-Object -Unique
 )
@@ -7326,7 +6639,7 @@ $arrGovernedMetadataDocuments += @(
         }
 )
 $arrTrackedGovernedInstructionPaths = @(
-    @($arrTrackedRepositoryPaths + $arrRangeTouchedGovernedInstructionPaths) |
+    @($arrTrackedRepositoryPaths + $arrPublishedGovernedInstructionPaths) |
         Where-Object {
             Test-GovernedInstructionInventoryPath `
                 -RepositoryRelativePath ([string] $_)
@@ -7350,7 +6663,7 @@ if ([string]::IsNullOrEmpty($strValidatedInputRevision)) {
     $arrRequiredPaths += @(
         $arrGovernedMetadataDocuments |
             Where-Object {
-                $arrRangeTouchedRepositoryPaths -cnotcontains $_.Path -or
+                $arrPublishedChangedPaths -cnotcontains $_.Path -or
                 $arrTrackedRepositoryPaths -ccontains $_.Path
             } |
             ForEach-Object {
@@ -7448,10 +6761,10 @@ foreach ($objDocumentSpec in $arrGovernedMetadataDocuments) {
     $strDocumentPath = Join-Path `
         -Path $strRepositoryRootPath `
         -ChildPath $objDocumentSpec.Path
-    $boolRangeOnlyGovernedDocument =
-        $arrRangeTouchedRepositoryPaths -ccontains $objDocumentSpec.Path -and
+    $boolPublishedBaselineOnlyDocument =
+        $arrPublishedBaselinePaths -ccontains $objDocumentSpec.Path -and
         $arrTrackedRepositoryPaths -cnotcontains $objDocumentSpec.Path
-    $strDocumentContent = if ($boolRangeOnlyGovernedDocument) {
+    $strDocumentContent = if ($boolPublishedBaselineOnlyDocument) {
         $null
     }
     elseif ([string]::IsNullOrEmpty($strValidatedInputRevision)) {
@@ -7477,79 +6790,64 @@ foreach ($objDocumentSpec in $arrGovernedMetadataDocuments) {
 
 $listGovernedDocumentContexts = [Collections.Generic.List[pscustomobject]]::new()
 foreach ($objDocumentSpec in $arrGovernedMetadataDocuments) {
-    $objParentContext = Get-GovernedDocumentParentContext `
-        -RepositoryRootPath $strRepositoryRootPath `
-        -RepositoryRelativePath $objDocumentSpec.Path `
-        -MaximumBytes $objDocumentSpec.MaximumBytes `
-        -Revision $strValidatedInputRevision
-    $strDocumentPolicyMarker = if (
-        $objDocumentSpec.Path -ceq 'STYLE_GUIDE_RATIONALE.md') {
-        $strStyleGuideRationaleMetadataPolicyMarker
-    } elseif ($objDocumentSpec.Path -in $script:arrOperationalLintGuidePaths) {
-        $strLintGuideMetadataPolicyMarker
-    } else {
-        $strMetadataRangePolicyMarker
+    $objParentContext = if ($boolPublishedEndpointsRequested) {
+        $strPublishedBaselineContent = $null
+        $boolGenuineRootIntroduction = $PublishedBaselineAbsent -and
+            $null -ne $objCreatedRefContext -and
+            $objCreatedRefContext.IsGenuineRootIntroduction
+        if ($PublishedBaselineAbsent -and -not $boolGenuineRootIntroduction) {
+            $strPublishedBaselineContent =
+                $hashtableGovernedInstructionContent[$objDocumentSpec.Path]
+        }
+        elseif (-not $PublishedBaselineAbsent) {
+            & git -C $strRepositoryRootPath cat-file -e `
+                "$PublishedBaselineRevision`:$($objDocumentSpec.Path)" 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                $strPublishedBaselineContent = Read-GitRevisionText `
+                    -RepositoryRootPath $strRepositoryRootPath `
+                    -Revision $PublishedBaselineRevision `
+                    -RepositoryRelativePath $objDocumentSpec.Path `
+                    -MaximumBytes $objDocumentSpec.MaximumBytes `
+                    -RequireRegularFile
+            }
+        }
+        [pscustomobject]@{
+            ParentContent = $strPublishedBaselineContent
+            ExpectedUtcDate = ''
+            ParentRevision = if ($PublishedBaselineAbsent) {
+                $null
+            } else {
+                $PublishedBaselineRevision
+            }
+            IsWorktreeTransition = $false
+        }
     }
-    $boolParentPolicyApplies = $null -ne $objParentContext.ParentRevision -and
-        (Test-HistoricalPolicyMarker `
+    elseif ([string]::IsNullOrEmpty($strValidatedInputRevision)) {
+        Get-PublishedBaselineDocumentContext `
             -RepositoryRootPath $strRepositoryRootPath `
-            -Revision $objParentContext.ParentRevision `
-            -RepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-            -Literal $strDocumentPolicyMarker)
+            -RepositoryRelativePath $objDocumentSpec.Path `
+            -MaximumBytes $objDocumentSpec.MaximumBytes
+    }
+    else {
+        [pscustomobject]@{
+            ParentContent = $hashtableGovernedInstructionContent[$objDocumentSpec.Path]
+            ExpectedUtcDate = ''
+            ParentRevision = $strValidatedInputRevision
+            IsWorktreeTransition = $false
+        }
+    }
     $listGovernedDocumentContexts.Add([pscustomobject]@{
             Path = $objDocumentSpec.Path
             MaximumBytes = $objDocumentSpec.MaximumBytes
             Content = $hashtableGovernedInstructionContent[$objDocumentSpec.Path]
-            ParentContent = if ($boolParentPolicyApplies) {
-                $objParentContext.ParentContent
-            } else { $null }
+            ParentContent = $objParentContext.ParentContent
             ExpectedUtcDate = $objParentContext.ExpectedUtcDate
             IsWorktreeTransition = $objParentContext.IsWorktreeTransition
             RequiresMetadata = $objDocumentSpec.RequiresMetadata
             RequiresVersion = $objDocumentSpec.RequiresVersion
             RequiredDocument = $arrDecisionRecordInventoryPaths -cnotcontains `
                 $objDocumentSpec.Path
-            PolicyMarker = $strDocumentPolicyMarker
         })
-}
-
-$strNoRangeCommitRevision = ''
-$strNoRangeCommitUtcDate = ''
-$boolNoRangeCommitHasParent = $false
-if ([string]::IsNullOrEmpty($RangeBaseRevision) -and
-    [string]::IsNullOrEmpty($RangeHeadRevision)) {
-    $strNoRangeCommitRevision = if ([string]::IsNullOrEmpty($strValidatedInputRevision)) {
-        $strCheckedOutRevision
-    }
-    else {
-        $strValidatedInputRevision
-    }
-    $strNoRangeParentLine = [string] (
-        & git -C $strRepositoryRootPath rev-list --parents -n 1 `
-            $strNoRangeCommitRevision
-    )
-    if ($LASTEXITCODE -ne 0) {
-        throw "Could not read the no-range validation commit: $strNoRangeCommitRevision"
-    }
-    $arrNoRangeCommitAndParents = @($strNoRangeParentLine.Trim() -split '\s+')
-    $boolNoRangeCommitHasParent = $arrNoRangeCommitAndParents.Count -gt 1
-    $strNoRangeCommitTimestamp = [string] (
-        & git -C $strRepositoryRootPath show -s --format=%cI `
-            $strNoRangeCommitRevision
-    )
-    $objNoRangeCommitTimestamp = [DateTimeOffset]::MinValue
-    if ($LASTEXITCODE -ne 0 -or
-        -not [DateTimeOffset]::TryParse(
-            $strNoRangeCommitTimestamp.Trim(),
-            [ref] $objNoRangeCommitTimestamp
-        )) {
-        throw "Could not read the no-range validation commit timestamp: $strNoRangeCommitRevision"
-    }
-    if ($objNoRangeCommitTimestamp -gt $script:objMaximumCommitUtcTimestamp) {
-        throw "The no-range validation commit timestamp is later than trusted UTC."
-    }
-    $strNoRangeCommitUtcDate =
-        $objNoRangeCommitTimestamp.UtcDateTime.ToString('yyyy-MM-dd')
 }
 
 $arrRepositoryFailures = @(Get-AgentInstructionFailure `
@@ -7619,84 +6917,40 @@ foreach ($objDocumentContext in $listGovernedDocumentContexts) {
     if (-not $objDocumentContext.RequiresMetadata) {
         continue
     }
-    if ([string]::IsNullOrEmpty($RangeBaseRevision) -and
-        [string]::IsNullOrEmpty($RangeHeadRevision)) {
-        if (-not $objDocumentContext.RequiresVersion -and
-            ($objDocumentContext.IsWorktreeTransition -or
-                -not $boolNoRangeCommitHasParent)) {
-            $arrRepositoryFailures += @(Get-LastUpdatedMetadataFreshnessFailure `
-                    -Name $objDocumentContext.Path `
-                    -CurrentContent $objDocumentContext.Content `
-                    -BaseContent $objDocumentContext.ParentContent `
-                    -TrustedEventUtcDate $objDocumentContext.ExpectedUtcDate `
-                    -ModifyingCommitUtcDate $(if (
-                        $objDocumentContext.IsWorktreeTransition) {
-                            ''
-                        } else { $strNoRangeCommitUtcDate }) `
-                    -RequireCurrentMaximumDateForRenderedChange `
-                        $objDocumentContext.IsWorktreeTransition)
+    if ($null -eq $objDocumentContext.Content) {
+        if ($objDocumentContext.RequiredDocument) {
+            $arrRepositoryFailures +=
+                "$($objDocumentContext.Path) is required in the published final state."
         }
-        elseif ($objDocumentContext.RequiresVersion -and
-            ($objDocumentContext.IsWorktreeTransition -or
-                -not $boolNoRangeCommitHasParent)) {
-            $arrRepositoryFailures += @(Get-DocumentMetadataTransitionFailure `
-                    -Name $objDocumentContext.Path `
-                    -CurrentContent $objDocumentContext.Content `
-                    -ParentContent $objDocumentContext.ParentContent `
-                    -ExpectedUtcDate $objDocumentContext.ExpectedUtcDate `
-                    -IsNewDocumentTransition (
-                        $null -eq $objDocumentContext.ParentContent -and
-                        -not [string]::IsNullOrEmpty($objDocumentContext.ExpectedUtcDate)
-                    ))
-        }
-        else {
-            $arrRepositoryFailures += @(Get-GovernedDocumentCommitTransitionFailure `
-                    -Name $objDocumentContext.Path `
-                    -RepositoryRootPath $strRepositoryRootPath `
-                    -RepositoryRelativePath $objDocumentContext.Path `
-                    -MaximumBytes $objDocumentContext.MaximumBytes `
-                    -CommitRevision $strNoRangeCommitRevision `
-                    -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                    -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-                    -PolicyMarker $objDocumentContext.PolicyMarker `
-                    -RequiresVersion $objDocumentContext.RequiresVersion `
-                    -RequiredDocument $objDocumentContext.RequiredDocument)
-        }
+        continue
     }
-    $arrRangeTransitionFailures = @(
-        Get-GovernedDocumentRangeTransitionFailure `
-            -Name $objDocumentContext.Path `
-            -RepositoryRootPath $strRepositoryRootPath `
-            -RepositoryRelativePath $objDocumentContext.Path `
-            -MaximumBytes $objDocumentContext.MaximumBytes `
-            -BaseRevision $arrEventHistoryBaseRevisions `
-            -HeadRevision $RangeHeadRevision `
-            -InputRevision $strValidatedInputRevision `
-            -IsNewRefRange ([bool]$RangeIsNewRef) `
-            -PolicyRepositoryRelativePath `
-                '.github/workflows/Test-AgentInstructions.ps1' `
-            -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-            -PolicyMarker $objDocumentContext.PolicyMarker `
-            -RequireExpectedUtcDateForRenderedChange `
-                $boolRequireRangeCommitDateFreshness `
-            -CommitDateFreshnessRevision `
-                $arrNewRefIntroducedCommitRevisions `
-            -RequiresVersion $objDocumentContext.RequiresVersion `
-            -RequiredDocument $objDocumentContext.RequiredDocument
-    ) | Sort-Object -Unique
-    $arrRepositoryFailures += @($arrRangeTransitionFailures)
-    if ($EventName -ceq 'push' -and $EventHeadDistinct -ceq 'false' -and
-        ($RangeIsNewRef -or $boolValidateBackwardPushHead)) {
-        $arrRepositoryFailures += @(Get-GovernedDocumentCommitTransitionFailure `
+    if ($objDocumentContext.RequiresVersion) {
+        $arrRepositoryFailures += @(Get-PublishedEndpointMetadataFailure `
+                -Name $objDocumentContext.Path `
+                -CurrentContent $objDocumentContext.Content `
+                -ParentContent $objDocumentContext.ParentContent `
+                -ExpectedUtcDate $objDocumentContext.ExpectedUtcDate `
+                -IsNewDocumentTransition ($null -eq $objDocumentContext.ParentContent) `
+                -RequireExpectedUtcDateForRenderedChange `
+                    $objDocumentContext.IsWorktreeTransition)
+    }
+    else {
+        $arrRepositoryFailures += @(Get-PublishedEndpointLastUpdatedFailure `
+                -Name $objDocumentContext.Path `
+                -CurrentContent $objDocumentContext.Content `
+                -BaseContent $objDocumentContext.ParentContent `
+                -TrustedEventUtcDate $objDocumentContext.ExpectedUtcDate `
+                -RequireCurrentMaximumDateForRenderedChange `
+                    $objDocumentContext.IsWorktreeTransition)
+    }
+    if ($boolPublishedEndpointsRequested -and
+        $arrPublishedIntroducedCommits.Count -gt 0) {
+        $arrRepositoryFailures += @(Get-GovernedMetadataHistoryFailure `
                 -Name $objDocumentContext.Path `
                 -RepositoryRootPath $strRepositoryRootPath `
                 -RepositoryRelativePath $objDocumentContext.Path `
                 -MaximumBytes $objDocumentContext.MaximumBytes `
-                -CommitRevision $RangeHeadRevision `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-                -PolicyMarker $objDocumentContext.PolicyMarker `
-                -RequireExpectedUtcDateForRenderedChange $true `
+                -CommitRevision $arrPublishedIntroducedCommits `
                 -RequiresVersion $objDocumentContext.RequiresVersion `
                 -RequiredDocument $objDocumentContext.RequiredDocument)
     }
@@ -7712,9 +6966,8 @@ Write-Output 'Agent-instruction contract passed.'
 if ($SelfTest) {
     #region Mutation self-tests
 
-    if ($intValidatorMaximumInputBytes -ne 573440 -or
-        $intHistoricalPolicyMarkerMaximumBytes -ne 573440) {
-        throw 'The validator and historical policy-marker caps must be 573440 bytes.'
+    if ($intValidatorMaximumInputBytes -ne 573440) {
+        throw 'The validator input cap must be 573440 bytes.'
     }
 
     $strValidatorSource = [IO.File]::ReadAllText($PSCommandPath)
@@ -7733,8 +6986,8 @@ if ($SelfTest) {
         param($objNode)
         $objNode -is [Management.Automation.Language.FunctionDefinitionAst]
     }, $true))
-    if ($arrValidatorFunctionAsts.Count -ne 57) {
-        throw 'The validator function-help inventory must contain exactly 57 functions.'
+    if ($arrValidatorFunctionAsts.Count -ne 56) {
+        throw 'The validator function-help inventory must contain exactly 56 functions.'
     }
     foreach ($objFunctionAst in $arrValidatorFunctionAsts) {
         $objHelp = $objFunctionAst.GetHelpContent()
@@ -7772,9 +7025,9 @@ if ($SelfTest) {
             }
             if ([regex]::Matches(
                     $strFunctionNotes,
-                    '(?m)^Version: 1\.0\.20260830\.0\.$'
+                    '(?m)^Version: 1\.0\.202608(?:30|31)\.0\.$'
                 ).Count -ne 1) {
-                $listMissingHelp.Add('landing Version 1.0.20260830.0')
+                $listMissingHelp.Add('landing or repair helper Version')
             }
             foreach ($objParameterAst in $objFunctionAst.Body.ParamBlock.Parameters) {
                 $strParameterName = $objParameterAst.Name.VariablePath.UserPath
@@ -7794,9 +7047,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strValidatorSource,
-            '(?m)^# Version: 1\.7\.20260830\.7$'
+            '(?m)^# Version: 1\.7\.20260831\.0$'
         ).Count -ne 1) {
-        throw 'The validator script version does not use build date 20260830.'
+        throw 'The validator script version does not use build date 20260831.'
     }
     $boolSavedWindowsPython = $script:useWindowsPythonLauncher
     $arrSavedPythonNames = $script:pythonPathNames
@@ -7872,6 +7125,27 @@ if ($SelfTest) {
             'The documentation claim baseline failed validation: ' +
             ($arrDocumentationClaimFailures -join '; ')
         )
+    }
+    $strDocumentationOwnerEnforcerRelationship =
+        '`.github/workflows/Test-AgentInstructions.ps1` is a non-owner ' +
+        'enforcement mechanism. It checks the named owner at the exact input ' +
+        'revision and rejects stale repository-specific documentation claims.'
+    if (-not $strDocsInstructionsContent.Contains(
+            $strDocumentationOwnerEnforcerRelationship,
+            [StringComparison]::Ordinal
+        )) {
+        throw 'The documentation owner and non-owner enforcer relationship changed.'
+    }
+    $strDocumentationOwnerEnforcerMutation = $strDocsInstructionsContent.Replace(
+        'is a non-owner enforcement mechanism',
+        'is an owner enforcement mechanism'
+    )
+    if ($strDocumentationOwnerEnforcerMutation -ceq $strDocsInstructionsContent -or
+        $strDocumentationOwnerEnforcerMutation.Contains(
+            $strDocumentationOwnerEnforcerRelationship,
+            [StringComparison]::Ordinal
+        )) {
+        throw 'A documentation owner and enforcer mutation was not detected.'
     }
     foreach ($strOwnerPath in $script:arrDocumentationClaimOwnerPaths) {
         $arrMissingOwnerFailures = @(Get-DocumentationClaimFailure `
@@ -7987,7 +7261,7 @@ if ($SelfTest) {
             "- **Last Updated:** $($objDocsMetadataContext.UpdatedDate)",
             "- **Last Updated:** $strNewDocumentDate"
         )
-        $arrNewDocumentFailures = @(Get-DocumentMetadataTransitionFailure `
+        $arrNewDocumentFailures = @(Get-PublishedEndpointMetadataFailure `
                 -Name '.github/instructions/docs.instructions.md' `
                 -CurrentContent $strNewDocumentMutation `
                 -ParentContent $null `
@@ -7997,14 +7271,14 @@ if ($SelfTest) {
             throw "A new document with date $strNewDocumentDate did not fail closed."
         }
     }
-    $arrDocsStaleMetadataFailures = @(Get-DocumentMetadataTransitionFailure `
+    $arrDocsStaleMetadataFailures = @(Get-PublishedEndpointMetadataFailure `
             -Name '.github/instructions/docs.instructions.md' `
             -CurrentContent $strDocsStaleMetadataMutation `
             -ParentContent $strDocsInstructionsContent `
             -ExpectedUtcDate $objDocsMetadataContext.UpdatedDate `
             -IsNewDocumentTransition $false)
     if (-not ($arrDocsStaleMetadataFailures -match [regex]::Escape(
-                '.github/instructions/docs.instructions.md Version revision must be greater than'
+                '.github/instructions/docs.instructions.md Version revision must be at least'
             ))) {
         throw 'The docs-only stale-metadata mutation did not fail closed.'
     }
@@ -8026,13 +7300,13 @@ if ($SelfTest) {
         $strStaleMetadataMutation = $objDocumentContext.Content +
             [Environment]::NewLine + [Environment]::NewLine +
             'Rendered governed-instruction metadata mutation.'
-        $arrStaleMetadataFailures = @(Get-DocumentMetadataTransitionFailure `
+        $arrStaleMetadataFailures = @(Get-PublishedEndpointMetadataFailure `
                 -Name $strNewlyCoveredPath `
                 -CurrentContent $strStaleMetadataMutation `
                 -ParentContent $objDocumentContext.Content `
                 -ExpectedUtcDate $objMetadataContext.UpdatedDate `
                 -IsNewDocumentTransition $false)
-        $strFailure = "$strNewlyCoveredPath Version revision must be greater than"
+        $strFailure = "$strNewlyCoveredPath Version revision must be at least"
         if (-not ($arrStaleMetadataFailures -match [regex]::Escape(
                     $strFailure
                 ))) {
@@ -8112,10 +7386,21 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strExtractedSelfTestSource,
-            '(?m)^# Version: 1\.0\.20260830\.0$'
+            '(?m)^# Version: 1\.2\.20260831\.0$'
         ).Count -ne 1) {
-        throw 'The extracted self-test lacks first-published version 1.0.20260830.0.'
+        throw 'The extracted self-test lacks version 1.2.20260831.0.'
     }
+    $strExtractedSelfTestRevision = if (
+        [string]::IsNullOrEmpty($strValidatedInputRevision)
+    ) {
+        $strCheckedOutRevision
+    }
+    else { $strValidatedInputRevision }
+    & (Join-Path $strRepositoryRootPath $strExtractedSelfTestPath) `
+        -RepositoryRootPath $strRepositoryRootPath `
+        -Revision $strExtractedSelfTestRevision `
+        -MaximumBytes $intGitPathListMaximumBytes `
+        -MaximumMetadataUtcDate $script:strMaximumMetadataUtcDate
     foreach ($strExactValidatorInputPath in $script:arrPushGovernedExactPaths) {
         if (-not (Test-AgentInstructionWorkflowPath `
                     -RepositoryRelativePath $strExactValidatorInputPath)) {
@@ -8137,29 +7422,13 @@ if ($SelfTest) {
         $arrRationaleSpecs[0].RequiresVersion -or
         $intStyleGuideRationaleMaximumInputBytes -ne 196608 -or
         [Text.Encoding]::UTF8.GetByteCount($arrRationaleContexts[0].Content) -gt
-            $intStyleGuideRationaleMaximumInputBytes -or
-        $arrRationaleContexts[0].PolicyMarker -cne
-            $strStyleGuideRationaleMetadataPolicyMarker) {
+            $intStyleGuideRationaleMaximumInputBytes) {
         throw 'The canonical rationale lacks exact bounded Tier 1 catalog enforcement.'
-    }
-    foreach ($objGenericMetadataContext in @(
-            $listGovernedDocumentContexts |
-                Where-Object {
-                    $_.Path -cne $strRationalePath -and
-                    $_.Path -notin $script:arrOperationalLintGuidePaths
-                }
-        )) {
-        if ($objGenericMetadataContext.PolicyMarker -cne
-            $strMetadataRangePolicyMarker) {
-            throw "Generic metadata marker selection changed: $($objGenericMetadataContext.Path)"
-        }
     }
     foreach ($strLintGuidePath in $script:arrOperationalLintGuidePaths) {
         $arrLintGuideContexts = @($listGovernedDocumentContexts |
                 Where-Object { $_.Path -ceq $strLintGuidePath })
-        if ($arrLintGuideContexts.Count -ne 1 -or
-            $arrLintGuideContexts[0].PolicyMarker -cne
-                $strLintGuideMetadataPolicyMarker) {
+        if ($arrLintGuideContexts.Count -ne 1) {
             throw "Lint guide is outside Tier 1 policy: $strLintGuidePath"
         }
     }
@@ -8366,14 +7635,14 @@ if ($SelfTest) {
     if ($arrCatalogedNestedGeminiFailures.Count -ne 0) {
         throw 'A cataloged nested GEMINI.md did not enter the governed inventory.'
     }
-    $arrNestedGeminiMetadataFailures = @(Get-DocumentMetadataTransitionFailure `
+    $arrNestedGeminiMetadataFailures = @(Get-PublishedEndpointMetadataFailure `
             -Name 'tools/GEMINI.md' `
             -CurrentContent $strDocsStaleMetadataMutation `
             -ParentContent $strDocsInstructionsContent `
             -ExpectedUtcDate $objDocsMetadataContext.UpdatedDate `
             -IsNewDocumentTransition $false)
     if (-not ($arrNestedGeminiMetadataFailures -match [regex]::Escape(
-                'tools/GEMINI.md Version revision must be greater than'
+                'tools/GEMINI.md Version revision must be at least'
             ))) {
         throw 'A cataloged nested GEMINI.md bypassed rendered metadata transition.'
     }
@@ -8388,15 +7657,13 @@ if ($SelfTest) {
         }
         $strMutation = $objDocumentContext.Content -creplace
             '(?m)^## Metadata(?=\r?$)', ''
-        $arrFailures = @(Get-LastUpdatedMetadataFreshnessFailure -Name `
+        $arrFailures = @(Get-PublishedEndpointLastUpdatedFailure -Name `
                 $objDocumentContext.Path -CurrentContent $strMutation -BaseContent `
                 $objDocumentContext.Content -TrustedEventUtcDate $objMetadata.UpdatedDate)
         if (-not ($arrFailures -match 'first level-two heading immediately after the H1')) {
             throw "$($objDocumentContext.Path) accepted missing Metadata."
         }
     }
-    $objUnversionedDocument = $arrUnversionedMetadataContexts[0]
-
     $arrRequiredFieldNames = @('Status', 'Owner', 'Last Updated', 'Scope')
     foreach ($objDocumentContext in @(
             $listGovernedDocumentContexts |
@@ -8415,14 +7682,14 @@ if ($SelfTest) {
                 $objFieldLineMatch.Length
             )
             $arrFieldFailures = if ($objDocumentContext.RequiresVersion) {
-                @(Get-DocumentMetadataTransitionFailure -Name $objDocumentContext.Path `
+                @(Get-PublishedEndpointMetadataFailure -Name $objDocumentContext.Path `
                         -CurrentContent $strFieldDeletion `
                         -ParentContent $objDocumentContext.Content `
                         -ExpectedUtcDate $objDocumentContext.ExpectedUtcDate `
                         -IsNewDocumentTransition $false)
             }
             else {
-                @(Get-LastUpdatedMetadataFreshnessFailure -Name $objDocumentContext.Path `
+                @(Get-PublishedEndpointLastUpdatedFailure -Name $objDocumentContext.Path `
                         -CurrentContent $strFieldDeletion `
                         -BaseContent $objDocumentContext.Content `
                         -TrustedEventUtcDate $objDocumentContext.ExpectedUtcDate)
@@ -8461,7 +7728,7 @@ if ($SelfTest) {
             $objFieldLineMatch.Index,
             $objFieldLineMatch.Length
         ).Insert($objFieldLineMatch.Index, $objFieldMutation.Replacement)
-        $arrFieldFailures = @(Get-DocumentMetadataTransitionFailure `
+        $arrFieldFailures = @(Get-PublishedEndpointMetadataFailure `
                 -Name $objRepresentativeDocument.Path `
                 -CurrentContent $strFieldMutation `
                 -ParentContent $objRepresentativeDocument.Content `
@@ -8488,7 +7755,7 @@ if ($SelfTest) {
             $strStatusLine,
             $strHiddenStatus
         )
-        $arrFieldFailures = @(Get-DocumentMetadataTransitionFailure `
+        $arrFieldFailures = @(Get-PublishedEndpointMetadataFailure `
                 -Name $objRepresentativeDocument.Path `
                 -CurrentContent $strHiddenStatusMutation `
                 -ParentContent $objRepresentativeDocument.Content `
@@ -9123,8 +8390,9 @@ if ($SelfTest) {
         -AgentsContent $strRenderedAgentsMutation `
         -ParentAgentsContent $strAgentsContent `
         -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value `
-        -Failure ("AGENTS.md Version revision must be greater than " +
-            "$intAgentsRevision after a same-day content change.")
+        -Failure ("AGENTS.md Version revision must be at least " +
+            "$intNextAgentsRevision after a rendered-content change with an " +
+            'unchanged published-baseline major, minor, and date tuple.')
 
     $strHigherRevisionParent = $strAgentsContent.Replace(
         $objAgentsVersionMatch.Value,
@@ -9135,13 +8403,13 @@ if ($SelfTest) {
         -ParentAgentsContent $strHigherRevisionParent `
         -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value `
         -Failure ("AGENTS.md Version revision must not decrease from " +
-            "$intNextAgentsRevision to $intAgentsRevision.")
+            "$intNextAgentsRevision to $($intNextAgentsRevision - 1).")
 
     Assert-Failure `
         -ParentAgentsContent $strHigherRevisionParent `
         -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value `
         -Failure ("AGENTS.md Version revision must not decrease from " +
-            "$intNextAgentsRevision to $intAgentsRevision.")
+            "$intNextAgentsRevision to $($intNextAgentsRevision - 1).")
 
     Assert-FixtureAccepted `
         -ParentAgentsContent $strAgentsContent
@@ -9191,7 +8459,6 @@ if ($SelfTest) {
             -TrustedEventUtcDate '2024-02-29').Count -ne 0) {
         throw 'Stable event replay changed.'
     }
-    $strNextEventDate = $objIsoEvent.AddDays(1).ToString('yyyy-MM-dd')
     if (@(Get-CurrentInputMetadataFreshnessFailure `
             -Name 'AGENTS.md' -CurrentContent $strHigherRevisionParent `
             -BaseContent $strAgentsContent -TrustedEventUtcDate '2000-01-01').Count -ne 0) {
@@ -9263,777 +8530,128 @@ if ($SelfTest) {
         -Failure ("AGENTS.md Version date must not move backward from " +
             "$($objAgentsVersionMatch.Groups['Date'].Value) to 20000101.")
 
-    $strEarlierStaleMetadataContent = $strAgentsContent +
-        [Environment]::NewLine + 'Earlier rendered change with stale metadata.'
-    $arrMultiCommitTransitionContexts = @(
-        [pscustomobject]@{
-            CurrentContent = $strEarlierStaleMetadataContent
-            ParentContent = $strAgentsContent
-            ExpectedUtcDate = $objAgentsUpdatedMatch.Groups['Date'].Value
-            CurrentRevision = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-            ParentRevision = '0000000000000000000000000000000000000000'
-        },
-        [pscustomobject]@{
-            CurrentContent = $strEarlierStaleMetadataContent
-            ParentContent = $strEarlierStaleMetadataContent
-            ExpectedUtcDate = $objAgentsUpdatedMatch.Groups['Date'].Value
-            CurrentRevision = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-            ParentRevision = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        }
+    # Published endpoint regressions deliberately ignore intermediate topic commits.
+    $strEndpointBaseline = @(
+        '# Endpoint fixture'
+        '**Version:** 1.0.20260830.0'
+        '## Metadata'
+        '- **Status:** Active'
+        '- **Owner:** Repository Maintainers'
+        '- **Last Updated:** 2026-08-30'
+        '- **Scope:** Endpoint metadata regression.'
+        '## Content'
+        'Published baseline.'
+    ) -join "`n"
+    $strEndpointFinal = @(
+        '# Endpoint fixture'
+        '**Version:** 1.0.20260831.0'
+        '## Metadata'
+        '- **Status:** Active'
+        '- **Owner:** Repository Maintainers'
+        '- **Last Updated:** 2026-08-31'
+        '- **Scope:** Endpoint metadata regression.'
+        '## Content'
+        'Corrected published final state.'
+    ) -join "`n"
+    $strInvalidIntermediate = $strEndpointBaseline.Replace(
+        'Published baseline.',
+        'Intermediate rendered change without metadata advancement.'
     )
-    $arrTransitionFailures = @(
-        Get-DocumentMetadataRangeTransitionFailure `
-            -Name 'AGENTS.md' `
-            -TransitionContext $arrMultiCommitTransitionContexts
-    )
-    if ($arrTransitionFailures.Count -ne 1 -or
-        -not $arrTransitionFailures[0].Contains(
-            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            [StringComparison]::Ordinal
-        ) -or
-        -not $arrTransitionFailures[0].Contains(
-            'Version revision must be greater',
-            [StringComparison]::Ordinal
+    if ($strInvalidIntermediate -ceq $strEndpointBaseline) {
+        throw 'The deterministic intermediate fixture changed zero bytes.'
+    }
+    $arrPublishedFinalFailures = @(Get-PublishedEndpointMetadataFailure `
+        -Name 'endpoint-fixture.md' -CurrentContent $strEndpointFinal `
+        -ParentContent $strEndpointBaseline -ExpectedUtcDate '2026-08-31' `
+        -IsNewDocumentTransition $false)
+    if ($arrPublishedFinalFailures.Count -ne 0) {
+        throw ('A corrected multi-commit published final state failed: ' +
+            ($arrPublishedFinalFailures -join '; '))
+    }
+    $strHigherRevisionPublishedFinal = $strEndpointFinal.Replace(
+        '**Version:** 1.0.20260831.0', '**Version:** 1.0.20260831.2')
+    $arrHigherRevisionPublishedFinalFailures = @(Get-PublishedEndpointMetadataFailure `
+        -Name 'endpoint-fixture.md' -CurrentContent $strHigherRevisionPublishedFinal `
+        -ParentContent $strEndpointBaseline -ExpectedUtcDate '2026-08-31' `
+        -IsNewDocumentTransition $false)
+    if ($arrHigherRevisionPublishedFinalFailures.Count -ne 0) {
+        throw 'A higher published final revision was rejected.'
+    }
+    $strSameTupleFinal = $strEndpointBaseline.Replace(
+        '**Version:** 1.0.20260830.0', '**Version:** 1.0.20260830.1'
+    ).Replace('Published baseline.', 'Published final on the same tuple.')
+    if (@(Get-PublishedEndpointMetadataFailure -Name 'endpoint-fixture.md' `
+            -CurrentContent $strSameTupleFinal -ParentContent $strEndpointBaseline `
+            -ExpectedUtcDate '2026-08-30' -IsNewDocumentTransition $false).Count -ne 0) {
+        throw 'An exact published-baseline revision increment did not pass.'
+    }
+    $strSkippedRevisionFinal = $strSameTupleFinal.Replace(
+        '**Version:** 1.0.20260830.1', '**Version:** 1.0.20260830.2')
+    if (@(Get-PublishedEndpointMetadataFailure -Name 'endpoint-fixture.md' `
+            -CurrentContent $strSkippedRevisionFinal `
+            -ParentContent $strEndpointBaseline -ExpectedUtcDate '2026-08-30' `
+            -IsNewDocumentTransition $false).Count -ne 0) {
+        throw 'A higher same-tuple published final revision was rejected.'
+    }
+    foreach ($strLifecycleStatus in @(
+            'Draft', 'Proposed', 'Active', 'Accepted', 'Superseded', 'Deprecated'
         )) {
-        throw 'Multi-commit metadata validation did not preserve an earlier invalid transition.'
+        $strLifecycleFixture = $strEndpointFinal.Replace(
+            '- **Status:** Active', "- **Status:** $strLifecycleStatus")
+        if ($null -ne (Get-DocumentMetadataContext `
+                -Content $strLifecycleFixture).Failure) {
+            throw "ADR lifecycle status was rejected: $strLifecycleStatus"
+        }
     }
-
-    $strNewRefZeroRevision = '0' * 40
-    $strNewRefTestHead = [string] (
-        & git -C $strRepositoryRootPath rev-parse --verify HEAD
-    )
-    if ($LASTEXITCODE -ne 0 -or
-        $strNewRefTestHead.Trim() -notmatch '^[0-9a-fA-F]{40}$') {
-        throw 'Could not resolve the new-ref metadata self-test head.'
+    Assert-PublishedEndpointContext -RepositoryRootPath $strRepositoryRootPath `
+        -EventName 'pull_request_target' -PullRequestAction 'opened' `
+        -BaselineRevision $strCheckedOutRevision `
+        -FinalRevision $strCheckedOutRevision -BaselineAbsent $false `
+        -PullRequestBaseChanged ''
+    Assert-PublishedEndpointContext -RepositoryRootPath $strRepositoryRootPath `
+        -EventName 'push' -PullRequestAction '' `
+        -BaselineRevision $strCheckedOutRevision `
+        -FinalRevision $strCheckedOutRevision -BaselineAbsent $false `
+        -PullRequestBaseChanged ''
+    if (@(Read-GitPublishedEndpointChangedPath `
+            -RepositoryRootPath $strRepositoryRootPath `
+            -BaselineRevision $strCheckedOutRevision `
+            -FinalRevision $strCheckedOutRevision -BaselineAbsent $false `
+            -MaximumBytes $intGitPathListMaximumBytes).Count -ne 0) {
+        throw 'Identical published endpoint trees reported changed paths.'
     }
-    $strNewRefTestHead = $strNewRefTestHead.Trim()
-    $objNewRef = Get-PushGovernedPathApplicability `
+    $strNewRefTestHead = $strCheckedOutRevision
+    $strNewRefZeroRevision = '0' * $strNewRefTestHead.Length
+    $objNewRefApplicability = Get-PushGovernedPathApplicability `
         -RepositoryRootPath $strRepositoryRootPath `
         -BaseRevision $strNewRefZeroRevision `
-        -HeadRevision $strNewRefTestHead `
-        -IsNewRef $true -IsDeletedRef $false
-    if (-not $objNewRef.ShouldValidate -or
-        $objNewRef.Decision -cne
-            'NEW_REF_REQUIRES_FAIL_CLOSED_VALIDATION') {
-        throw 'A new-ref push did not select fail-closed validation.'
+        -HeadRevision $strNewRefTestHead -IsNewRef $true -IsDeletedRef $false
+    if (-not $objNewRefApplicability.ShouldValidate -or
+        $objNewRefApplicability.Decision -cne
+            'NEW_REF_REQUIRES_FAIL_CLOSED_VALIDATION' -or
+        $objNewRefApplicability.ChangedPathCount -ne 0) {
+        throw 'A new ref did not require fail-closed validation of the exact checked-out head.'
     }
-    $objDeleted = Get-PushGovernedPathApplicability `
-        -RepositoryRootPath $strRepositoryRootPath `
-        -BaseRevision $strNewRefTestHead `
-        -HeadRevision $strNewRefZeroRevision `
-        -IsNewRef $false -IsDeletedRef $true
-    if ($objDeleted.ShouldValidate -or
-        $objDeleted.Decision -cne
-            'DELETED_REF_HAS_NO_REMAINING_BYTES') {
-        throw 'A deleted-ref push did not select its exact no-op.'
-    }
-    $objUnchanged = Get-PushGovernedPathApplicability `
-        -RepositoryRootPath $strRepositoryRootPath `
-        -BaseRevision $strNewRefTestHead `
-        -HeadRevision $strNewRefTestHead `
-        -IsNewRef $false -IsDeletedRef $false
-    if ($objUnchanged.ShouldValidate -or
-        $objUnchanged.ChangedPathCount -ne 0) {
-        throw 'An unchanged existing-ref push did not select its exact no-op.'
-    }
-
-    $strPushRoot = [IO.Path]::GetFullPath(
-        [IO.Path]::Combine(
-            [IO.Path]::GetTempPath(),
-            'agent-instruction-push-' + [guid]::NewGuid().ToString('N')
-        )
-    )
-    $strPushTempRoot = [IO.Path]::GetFullPath(
-        [IO.Path]::GetTempPath()
-    )
-    if (-not $strPushRoot.StartsWith(
-            $strPushTempRoot,
-            [StringComparison]::OrdinalIgnoreCase
-        )) {
-        throw 'The push-applicability fixture escaped the system temporary directory.'
-    }
+    $strDifferentNewRefHead =
+        $(if ($strNewRefTestHead[0] -ceq '0') { '1' } else { '0' }) +
+        $strNewRefTestHead.Substring(1)
     try {
-        [void][System.IO.Directory]::CreateDirectory($strPushRoot)
-        & git -C $strPushRoot init --quiet
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not initialize the push-applicability fixture.'
-        }
-        $objImportText = [Text.StringBuilder]::new()
-        foreach ($strHeaderLine in @(
-                'commit refs/heads/base',
-                'mark :1',
-                'author Fixture <fixture@example.invalid> 1700000000 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000000 +0000',
-                'data 4',
-                'base',
-                'deleteall',
-                'commit refs/heads/ungoverned',
-                'mark :2',
-                'author Fixture <fixture@example.invalid> 1700000001 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000001 +0000',
-                'data 10',
-                'ungoverned',
-                'from :1'
-            )) {
-            [void]$objImportText.AppendLine($strHeaderLine)
-        }
-        foreach ($intFixturePath in 1..3000) {
-            [void]$objImportText.AppendLine(
-                'M 100644 inline bulk/file' +
-                    $intFixturePath.ToString('D4') + '.txt'
-            )
-            [void]$objImportText.AppendLine('data 0')
-            [void]$objImportText.AppendLine()
-        }
-        foreach ($strTrailerLine in @(
-                'commit refs/heads/governed',
-                'mark :3',
-                'author Fixture <fixture@example.invalid> 1700000002 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000002 +0000',
-                'data 8',
-                'governed',
-                'from :2',
-                'M 100644 inline zzzz/tools/GEMINI.md',
-                'data 0',
-                '',
-                'commit refs/heads/malformed-decision',
-                'mark :8',
-                'author Fixture <fixture@example.invalid> 1700000002 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000002 +0000',
-                'data 18',
-                'malformed decision',
-                'from :2',
-                'M 100644 inline docs/decisions/archive/0003-new-policy.md',
-                'data 0',
-                '',
-                'commit refs/heads/multi',
-                'mark :5',
-                'author Fixture <fixture@example.invalid> 1700000003 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000003 +0000',
-                'data 5',
-                'multi',
-                'from :3',
-                'M 100644 inline unrelated.txt',
-                'data 0',
-                '',
-                'commit refs/heads/divergent',
-                'mark :4',
-                'author Fixture <fixture@example.invalid> 1700000004 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000004 +0000',
-                'data 9',
-                'divergent',
-                'from :1',
-                'M 100644 inline zzzz/AGENTS.md',
-                'data 0',
-                '',
-                'commit refs/heads/restore-change',
-                'mark :6',
-                'author Fixture <fixture@example.invalid> 1700000005 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000005 +0000',
-                'data 14',
-                'restore change',
-                'from :1',
-                'M 100644 inline AGENTS.md',
-                'data 0',
-                '',
-                'commit refs/heads/restore',
-                'mark :7',
-                'author Fixture <fixture@example.invalid> 1700000006 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000006 +0000',
-                'data 7',
-                'restore',
-                'from :6',
-                'D AGENTS.md',
-                '',
-                'done'
-            )) {
-            [void]$objImportText.AppendLine($strTrailerLine)
-        }
-        $objImportStart = [Diagnostics.ProcessStartInfo]::new('git')
-        $objImportStart.UseShellExecute = $false
-        $objImportStart.CreateNoWindow = $true
-        $objImportStart.RedirectStandardInput = $true
-        $objImportStart.RedirectStandardOutput = $true
-        $objImportStart.RedirectStandardError = $true
-        foreach ($strImportArgument in @(
-                '-C', $strPushRoot, 'fast-import', '--quiet'
-            )) {
-            $objImportStart.ArgumentList.Add($strImportArgument)
-        }
-        $objImportProcess = [Diagnostics.Process]::new()
-        $objImportProcess.StartInfo = $objImportStart
-        if (-not $objImportProcess.Start()) {
-            throw 'Could not start the push-applicability fixture import.'
-        }
-        $objImportErrorTask = $objImportProcess.StandardError.ReadToEndAsync()
-        $objImportOutputTask = $objImportProcess.StandardOutput.ReadToEndAsync()
-        $objImportWriteFailure = $null
-        try {
-            $objImportProcess.StandardInput.Write(
-                $objImportText.ToString().Replace("`r`n", "`n")
-            )
-        }
-        catch {
-            $objImportWriteFailure = $_.Exception
-        }
-        $objImportProcess.StandardInput.Close()
-        if (-not $objImportProcess.WaitForExit(10000)) {
-            $objImportProcess.Kill($true)
-            throw 'The push-applicability fixture import timed out.'
-        }
-        $strImportError = $objImportErrorTask.GetAwaiter().GetResult()
-        [void]$objImportOutputTask.GetAwaiter().GetResult()
-        if ($null -ne $objImportWriteFailure -or
-            $objImportProcess.ExitCode -ne 0) {
-            throw (
-                'Could not import the push-applicability fixture: ' +
-                $strImportError.Trim()
-            )
-        }
-        $objImportProcess.Dispose()
-
-        $strPushBase = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/base
-        )
-        $strPushUngoverned = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/ungoverned
-        )
-        $strPushGoverned = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/governed
-        )
-        $strPushMalformedDecision = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/malformed-decision
-        )
-        $strPushMulti = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/multi
-        )
-        $strPushDivergent = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/divergent
-        )
-        $strPushRestore = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/restore
-        )
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not resolve the push-applicability fixture commits.'
-        }
-        $strPushBase = $strPushBase.Trim()
-        $strPushUngoverned = $strPushUngoverned.Trim()
-        $strPushGoverned = $strPushGoverned.Trim()
-        $strPushMalformedDecision = $strPushMalformedDecision.Trim()
-        $strPushMulti = $strPushMulti.Trim()
-        $strPushDivergent = $strPushDivergent.Trim()
-        $strPushRestore = $strPushRestore.Trim()
-
-        $strMultiEvidence = ConvertTo-Json -Compress -InputObject @(
-            $strPushMulti,
-            $strPushUngoverned,
-            $strPushGoverned
-        )
-        $objMultiContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strPushRoot `
-            -EventName 'push' -PullRequestAction '' `
-            -BaseRevision ('0' * 40) -HeadRevision $strPushMulti `
-            -IsNewRefRange $true -PreviousHeadRevision '' `
-            -EventHeadRevision $strPushMulti -EventHeadDistinct 'true' `
-            -NewRefCommitCount '3' `
-            -NewRefCommitEvidenceJson $strMultiEvidence
-        if ($objMultiContext.FreshnessBaseRevision -cne
-                $strPushBase -or
-            @($objMultiContext.FreshnessBaseRevisions).Count -ne 1 -or
-            $objMultiContext.FreshnessBaseRevisions[0] -cne $strPushBase -or
-            -not $objMultiContext.EvaluateFreshness) {
-            throw 'Complete multi-commit new-ref evidence did not select its full boundary.'
-        }
-        $strZeroRevision = '0' * 40
-        $objExistingContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strPushRoot -EventName 'push' -PullRequestAction '' `
-            -BaseRevision $strZeroRevision -HeadRevision $strPushMulti `
-            -IsNewRefRange $true -PreviousHeadRevision '' -EventHeadRevision $strPushMulti `
-            -EventHeadDistinct 'false' `
-            -NewRefCommitCount '0' -NewRefCommitEvidenceJson '[]'
-        if ($objExistingContext.HistoryBaseRevision -cne
-                $strZeroRevision -or
-            $objExistingContext.FreshnessBaseRevision -cne '' -or
-            $objExistingContext.EvaluateFreshness) {
-            throw 'Existing new-ref context is invalid.'
-        }
-        $strLongHead = $strPushMulti
-        $arrLongEvidence = @(foreach ($intLongCommit in 1..21) {
-            $strLongHead = ([string](& git -C $strPushRoot -c user.name=Fixture `
-                        -c user.email=fixture@example.invalid commit-tree `
-                        "$strLongHead`^{tree}" -p $strLongHead `
-                        -m "long $intLongCommit")).Trim()
-            if ($LASTEXITCODE -ne 0) { throw 'Could not create long new-ref history.' }
-            $strLongHead
-        })
-        $objLongContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strPushRoot -EventName push -PullRequestAction '' `
-            -BaseRevision ('0' * 40) -HeadRevision $strLongHead `
-            -IsNewRefRange $true -PreviousHeadRevision '' `
-            -EventHeadRevision $strLongHead -EventHeadDistinct true `
-            -NewRefCommitCount 21 -NewRefCommitEvidenceJson `
-                (ConvertTo-Json -Compress -InputObject $arrLongEvidence[0..19])
-        if ($objLongContext.FreshnessBaseRevision -cne $strPushMulti) {
-            throw 'Truncated evidence for a 21-commit new-ref push was not recovered.'
-        }
-        foreach ($objInvalidNewRefEvidence in @(
-                [pscustomobject]@{
-                    Name = 'non-array evidence'
-                    Count = '1'
-                    Json = ConvertTo-Json -Compress -InputObject $strPushMulti
-                    Failure = 'commit evidence is malformed'
-                },
-                [pscustomobject]@{
-                    Name = 'duplicate evidence'
-                    Count = '3'
-                    Json = ConvertTo-Json -Compress -InputObject @(
-                        $strPushUngoverned,
-                        $strPushUngoverned,
-                        $strPushMulti
-                    )
-                    Failure = 'contains a duplicate commit'
-                },
-                [pscustomobject]@{
-                    Name = 'missing head evidence'
-                    Count = '1'
-                    Json = ConvertTo-Json -Compress -InputObject @($strPushUngoverned)
-                    Failure = 'does not contain the event head'
-                },
-                [pscustomobject]@{
-                    Name = 'disconnected evidence'
-                    Count = '2'
-                    Json = ConvertTo-Json -Compress -InputObject @(
-                        $strPushMulti,
-                        $strPushDivergent
-                    )
-                    Failure = 'contains a disconnected commit'
-                },
-                [pscustomobject]@{
-                    Name = 'unavailable evidence'
-                    Count = '1'
-                    Json = ConvertTo-Json -Compress -InputObject @(('f' * 40))
-                    Failure = 'commit evidence is unavailable'
-                },
-                [pscustomobject]@{
-                    Name = 'excessive evidence count'
-                    Count = '2049'
-                    Json = '[]'
-                    Failure = 'commit count exceeds the maximum of 2048'
-                }
-            )) {
-            $boolInvalidEvidenceRejected = $false
-            try {
-                [void](Get-MetadataEventRevisionContext `
-                        -RepositoryRootPath $strPushRoot `
-                        -EventName 'push' -PullRequestAction '' `
-                        -BaseRevision ('0' * 40) -HeadRevision $strPushMulti `
-                        -IsNewRefRange $true -PreviousHeadRevision '' `
-                        -EventHeadRevision $strPushMulti -EventHeadDistinct 'true' `
-                        -NewRefCommitCount $objInvalidNewRefEvidence.Count `
-                        -NewRefCommitEvidenceJson $objInvalidNewRefEvidence.Json)
-            }
-            catch {
-                $boolInvalidEvidenceRejected = $_.Exception.Message.Contains(
-                    $objInvalidNewRefEvidence.Failure,
-                    [StringComparison]::Ordinal
-                )
-            }
-            if (-not $boolInvalidEvidenceRejected) {
-                throw "$($objInvalidNewRefEvidence.Name) did not fail closed."
-            }
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushUngoverned
-        $objUngoverned = Get-PushGovernedPathApplicability `
-            -RepositoryRootPath $strPushRoot `
-            -BaseRevision $strPushBase `
-            -HeadRevision $strPushUngoverned `
-            -IsNewRef $false -IsDeletedRef $false
-        if ($objUngoverned.ShouldValidate -or
-            $objUngoverned.ChangedPathCount -ne 3000) {
-            throw 'An exact 3,000-path ungoverned push did not select no-op.'
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushGoverned
-        $objGoverned = Get-PushGovernedPathApplicability `
-            -RepositoryRootPath $strPushRoot `
-            -BaseRevision $strPushBase `
-            -HeadRevision $strPushGoverned `
-            -IsNewRef $false -IsDeletedRef $false
-        if (-not $objGoverned.ShouldValidate -or
-            $objGoverned.ChangedPathCount -ne 3001) {
-            throw 'A governed path after 3,000 other paths was not validated.'
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushMalformedDecision
-        $arrMalformedDecisionPaths = @(& git -C $strPushRoot diff `
-                --name-only $strPushUngoverned $strPushMalformedDecision --)
-        $objMalformedDecision = Get-PushGovernedPathApplicability `
-            -RepositoryRootPath $strPushRoot `
-            -BaseRevision $strPushUngoverned `
-            -HeadRevision $strPushMalformedDecision `
-            -IsNewRef $false -IsDeletedRef $false
-        if ($arrMalformedDecisionPaths.Count -ne 1 -or
-            $arrMalformedDecisionPaths[0] -cne
-                'docs/decisions/archive/0003-new-policy.md' -or
-            -not $objMalformedDecision.ShouldValidate -or
-            $objMalformedDecision.ChangedPathCount -ne 1) {
-            throw 'A nested decision-record push escaped exact applicability.'
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushDivergent
-        $objDivergent = Get-PushGovernedPathApplicability `
-            -RepositoryRootPath $strPushRoot `
-            -BaseRevision $strPushUngoverned `
-            -HeadRevision $strPushDivergent `
-            -IsNewRef $false -IsDeletedRef $false
-        if (-not $objDivergent.ShouldValidate) {
-            throw 'A divergent governed push did not use exact endpoint trees.'
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushRestore
-        $objRestore = Get-PushGovernedPathApplicability `
-            -RepositoryRootPath $strPushRoot `
-            -BaseRevision $strPushBase `
-            -HeadRevision $strPushRestore `
-            -IsNewRef $false -IsDeletedRef $false
-        if (-not $objRestore.ShouldValidate -or
-            $objRestore.ChangedPathCount -ne 2) {
-            throw 'A governed change-then-restore push escaped range applicability.'
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushUngoverned
-        $objBackward = Get-PushGovernedPathApplicability `
-            -RepositoryRootPath $strPushRoot `
-            -BaseRevision $strPushGoverned `
-            -HeadRevision $strPushUngoverned `
-            -IsNewRef $false -IsDeletedRef $false
-        if (-not $objBackward.ShouldValidate -or
-            $objBackward.ChangedPathCount -ne 1) {
-            throw 'A backward governed endpoint change escaped applicability.'
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushDivergent
-        $boolMissingPushEndpointRejected = $false
-        try {
-            [void](Get-PushGovernedPathApplicability `
-                    -RepositoryRootPath $strPushRoot `
-                    -BaseRevision ('f' * 40) `
-                    -HeadRevision $strPushDivergent `
-                    -IsNewRef $false -IsDeletedRef $false)
-        }
-        catch {
-            $boolMissingPushEndpointRejected = $_.Exception.Message.Contains(
-                'Push endpoint commit is unavailable',
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolMissingPushEndpointRejected) {
-            throw 'A missing push endpoint did not fail closed.'
-        }
-    }
-    finally {
-        if ([System.IO.Directory]::Exists($strPushRoot) -and
-            $strPushRoot.StartsWith(
-                $strPushTempRoot,
-                [StringComparison]::OrdinalIgnoreCase
-            )) {
-            Remove-Item -LiteralPath $strPushRoot -Recurse -Force
-        }
-    }
-    $strRevisionAgentsFixture = Read-GitRevisionText `
-        -RepositoryRootPath $strRepositoryRootPath `
-        -Revision $strNewRefTestHead `
-        -RepositoryRelativePath 'AGENTS.md' `
-        -MaximumBytes $intAgentsMaximumInputBytes `
-        -RequireRegularFile
-    if (-not [string]::Equals(
-            $strRevisionAgentsFixture,
-            (Read-GitRevisionText `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -Revision $strNewRefTestHead `
-                -RepositoryRelativePath 'AGENTS.md' `
-                -MaximumBytes $intAgentsMaximumInputBytes),
-            [StringComparison]::Ordinal
-        )) {
-        throw 'Regular revision input validation changed the accepted blob content.'
-    }
-    $boolMissingRevisionInputRejected = $false
-    try {
-        [void](Read-GitRevisionText `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -Revision $strNewRefTestHead `
-                -RepositoryRelativePath '.missing-agent-instruction-input' `
-                -MaximumBytes 128 `
-                -RequireRegularFile)
-    }
-    catch {
-        $boolMissingRevisionInputRejected = $_.Exception.Message.Contains(
-            'not one regular 100644 blob',
-            [StringComparison]::Ordinal
-        )
-    }
-    if (-not $boolMissingRevisionInputRejected) {
-        throw 'A missing revision input did not fail the regular-blob check.'
-    }
-    & "$PSScriptRoot/Test-AgentInstructions.SelfTest.ps1" `
-        -RepositoryRootPath $strRepositoryRootPath `
-        -Revision $strNewRefTestHead -MaximumBytes $intAgentsMaximumInputBytes `
-        -MaximumMetadataUtcDate $script:strMaximumMetadataUtcDate
-    $arrNewRefRangeFailures = @(Get-GovernedDocumentRangeTransitionFailure `
-            -Name 'AGENTS.md' `
+        $null = Get-PushGovernedPathApplicability `
             -RepositoryRootPath $strRepositoryRootPath `
-            -RepositoryRelativePath 'AGENTS.md' `
-            -MaximumBytes $intAgentsMaximumInputBytes `
             -BaseRevision $strNewRefZeroRevision `
-            -HeadRevision $strNewRefTestHead `
-            -IsNewRefRange $true `
-            -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-            -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-            -PolicyMarker $strMetadataRangePolicyMarker)
-    if ($arrNewRefRangeFailures.Count -ne 0) {
-        throw "Valid new-ref metadata range failed: $($arrNewRefRangeFailures -join '; ')"
-    }
-    $boolInconsistentNewRefEvidenceRejected = $false
-    try {
-        [void](Get-MetadataEventRevisionContext `
-                -RepositoryRootPath $strRepositoryRootPath -EventName 'push' `
-                -PullRequestAction '' -BaseRevision $strNewRefZeroRevision `
-                -HeadRevision $strNewRefTestHead -IsNewRefRange $true `
-                -PreviousHeadRevision '' -EventHeadRevision $strNewRefTestHead `
-                -EventHeadDistinct 'false' -NewRefCommitCount '1' `
-                -NewRefCommitEvidenceJson (ConvertTo-Json -Compress `
-                    -InputObject @($strNewRefTestHead)))
+            -HeadRevision $strDifferentNewRefHead `
+            -IsNewRef $true -IsDeletedRef $false
+        throw 'A new ref accepted a final revision other than the exact checked-out event head.'
     }
     catch {
-        $boolInconsistentNewRefEvidenceRejected = $_.Exception.Message.Contains(
-            'must report zero introduced commits',
-            [StringComparison]::Ordinal
-        )
-    }
-    if (-not $boolInconsistentNewRefEvidenceRejected) {
-        throw 'Inconsistent new-ref evidence did not fail closed.'
-    }
-    if (@(Get-CurrentInputMetadataFreshnessFailure -Name 'AGENTS.md' `
-            -CurrentContent $strSameDayRevisionJump -BaseContent $strAgentsContent `
-            -TrustedEventUtcDate $strNextEventDate).Count -ne 1) {
-        throw 'Stale new-ref head passed.'
-    }
-
-    $strExistingPushBase = [string] (
-        & git -C $strRepositoryRootPath rev-parse --verify 'HEAD^'
-    )
-    if ($LASTEXITCODE -ne 0 -or
-        $strExistingPushBase.Trim() -notmatch '^[0-9a-fA-F]{40}$') {
-        throw 'Could not resolve the existing-ref metadata self-test base.'
-    }
-    $strExistingPushBase = $strExistingPushBase.Trim()
-    $arrTruncatedPushCommitIds = @(
-        foreach ($intCommitId in 1..2048) {
-            $intCommitId.ToString('x40')
-        }
-    )
-    if ($arrTruncatedPushCommitIds.Count -ne 2048 -or
-        $arrTruncatedPushCommitIds -contains $strNewRefTestHead) {
-        throw 'The truncated push payload fixture is invalid.'
-    }
-    $objTruncatedPushContext = Get-MetadataEventRevisionContext `
-        -RepositoryRootPath $strRepositoryRootPath -EventName 'push' `
-        -PullRequestAction '' -BaseRevision $strExistingPushBase `
-        -HeadRevision $strNewRefTestHead -IsNewRefRange $false `
-        -PreviousHeadRevision '' -EventHeadRevision $strNewRefTestHead `
-        -EventHeadDistinct 'true'
-    if ($objTruncatedPushContext.HistoryBaseRevision -cne $strExistingPushBase -or
-        $objTruncatedPushContext.FreshnessBaseRevision -cne $strExistingPushBase) {
-        throw 'A truncated push payload suppressed exact pushed-head freshness.'
-    }
-    $objExistingHeadPushContext = Get-MetadataEventRevisionContext `
-        -RepositoryRootPath $strRepositoryRootPath -EventName 'push' `
-        -PullRequestAction '' -BaseRevision $strExistingPushBase `
-        -HeadRevision $strNewRefTestHead -IsNewRefRange $false `
-        -PreviousHeadRevision '' -EventHeadRevision $strNewRefTestHead `
-        -EventHeadDistinct 'false'
-    if ($objExistingHeadPushContext.FreshnessBaseRevision -cne '') {
-        throw 'A move to an existing pushed head required event-date freshness.'
-    }
-
-    foreach ($objInvalidPushHead in @(
-            [pscustomobject]@{
-                Name = 'missing expanded head'
-                Revision = ''
-                Distinct = 'true'
-                Failure = 'requires a valid expanded head revision'
-            },
-            [pscustomobject]@{
-                Name = 'mismatched expanded head'
-                Revision = $strExistingPushBase
-                Distinct = 'true'
-                Failure = 'must match the event after revision'
-            },
-            [pscustomobject]@{
-                Name = 'missing distinct value'
-                Revision = $strNewRefTestHead
-                Distinct = ''
-                Failure = 'distinct value must be true or false'
-            },
-            [pscustomobject]@{
-                Name = 'null distinct value'
-                Revision = $strNewRefTestHead
-                Distinct = 'null'
-                Failure = 'distinct value must be true or false'
-            },
-            [pscustomobject]@{
-                Name = 'wrong-case distinct value'
-                Revision = $strNewRefTestHead
-                Distinct = 'True'
-                Failure = 'distinct value must be true or false'
-            }
-        )) {
-        $boolInvalidPushHeadRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strRepositoryRootPath -EventName 'push' `
-                    -PullRequestAction '' -BaseRevision $strExistingPushBase `
-                    -HeadRevision $strNewRefTestHead -IsNewRefRange $false `
-                    -PreviousHeadRevision '' `
-                    -EventHeadRevision $objInvalidPushHead.Revision `
-                    -EventHeadDistinct $objInvalidPushHead.Distinct)
-        }
-        catch {
-            $boolInvalidPushHeadRejected = $_.Exception.Message.Contains(
-                $objInvalidPushHead.Failure,
+        if (-not $_.Exception.Message.Contains(
+                'does not match the exact event head',
                 [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolInvalidPushHeadRejected) {
-            throw "Invalid push head passed: $($objInvalidPushHead.Name)"
+            )) {
+            throw
         }
     }
 
-    $boolUnflaggedZeroBaseRejected = $false
-    try {
-        [void](Get-GovernedDocumentRangeTransitionFailure `
-                -Name 'AGENTS.md' `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -RepositoryRelativePath 'AGENTS.md' `
-                -MaximumBytes $intAgentsMaximumInputBytes `
-                -BaseRevision $strNewRefZeroRevision `
-                -HeadRevision $strNewRefTestHead `
-                -IsNewRefRange $false `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-                -PolicyMarker $strMetadataRangePolicyMarker)
-    }
-    catch {
-        $boolUnflaggedZeroBaseRejected = $_.Exception.Message.Contains(
-            'requires the new-ref flag',
-            [StringComparison]::Ordinal
-        )
-    }
-    if (-not $boolUnflaggedZeroBaseRejected) {
-        throw 'An unflagged all-zero metadata range base did not fail closed.'
-    }
-
-    $boolFlaggedNonzeroBaseRejected = $false
-    try {
-        [void](Get-GovernedDocumentRangeTransitionFailure `
-                -Name 'AGENTS.md' `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -RepositoryRelativePath 'AGENTS.md' `
-                -MaximumBytes $intAgentsMaximumInputBytes `
-                -BaseRevision $strNewRefTestHead `
-                -HeadRevision $strNewRefTestHead `
-                -IsNewRefRange $true `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-                -PolicyMarker $strMetadataRangePolicyMarker)
-    }
-    catch {
-        $boolFlaggedNonzeroBaseRejected = $_.Exception.Message.Contains(
-            'requires an all-zero base revision',
-            [StringComparison]::Ordinal
-        )
-    }
-    if (-not $boolFlaggedNonzeroBaseRejected) {
-        throw 'A flagged nonzero metadata range base did not fail closed.'
-    }
-
-    $arrOrdinarySameHeadFailures = @(Get-GovernedDocumentRangeTransitionFailure `
-            -Name 'AGENTS.md' `
-            -RepositoryRootPath $strRepositoryRootPath `
-            -RepositoryRelativePath 'AGENTS.md' `
-            -MaximumBytes $intAgentsMaximumInputBytes `
-            -BaseRevision $strNewRefTestHead `
-            -HeadRevision $strNewRefTestHead `
-            -InputRevision $strNewRefTestHead `
-            -IsNewRefRange $false `
-            -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-            -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-            -PolicyMarker $strMetadataRangePolicyMarker)
-    if ($arrOrdinarySameHeadFailures.Count -ne 0) {
-        throw 'An unchanged ordinary metadata range did not retain its prior behavior.'
-    }
-
-    $strMergeFixtureRoot = [IO.Path]::GetFullPath(
-        [IO.Path]::Combine(
-            [IO.Path]::GetTempPath(),
-            'agent-instruction-merge-' + [guid]::NewGuid().ToString('N')
-        )
-    )
-    $strSystemTempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
-    if (-not $strMergeFixtureRoot.StartsWith(
-            $strSystemTempRoot,
-            [StringComparison]::OrdinalIgnoreCase
-        )) {
-        throw 'The merge-transition fixture path escaped the system temporary directory.'
-    }
-    $boolHadAuthorDate = Test-Path -LiteralPath Env:GIT_AUTHOR_DATE
-    $boolHadCommitterDate = Test-Path -LiteralPath Env:GIT_COMMITTER_DATE
-    $strOriginalAuthorDate = if ($boolHadAuthorDate) { $env:GIT_AUTHOR_DATE } else { '' }
-    $strOriginalCommitterDate = if ($boolHadCommitterDate) {
-        $env:GIT_COMMITTER_DATE
-    }
-    else {
-        ''
-    }
-    try {
-        [void][System.IO.Directory]::CreateDirectory($strMergeFixtureRoot)
-        & git -C $strMergeFixtureRoot init --quiet
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not initialize the merge-transition fixture repository.'
-        }
-        & git -C $strMergeFixtureRoot config core.autocrlf false
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not configure the merge-transition fixture repository.'
-        }
-        $strMergePolicyPath = [IO.Path]::Combine(
-            $strMergeFixtureRoot,
-            '.github',
-            'workflows',
-            'Test-AgentInstructions.ps1'
-        )
-        $strMergeUnversionedRelativePath = 'docs/ISSUE_EVALUATION_PROMPT.md'
-        $strMergeUnversionedPath = [IO.Path]::Combine(
-            $strMergeFixtureRoot,
-            'docs',
-            'ISSUE_EVALUATION_PROMPT.md'
-        )
-        $strRationaleFixtureRelativePath = 'STYLE_GUIDE_RATIONALE.md'
-        $strRationaleFixturePath = [IO.Path]::Combine(
-            $strMergeFixtureRoot,
-            $strRationaleFixtureRelativePath
-        )
-        $strMergeGitIgnorePath = [IO.Path]::Combine(
-            $strMergeFixtureRoot,
-            '.gitignore'
-        )
-        [void][System.IO.Directory]::CreateDirectory(
-            [IO.Path]::GetDirectoryName($strMergePolicyPath)
-        )
-        [void][System.IO.Directory]::CreateDirectory(
-            [IO.Path]::GetDirectoryName($strMergeUnversionedPath)
-        )
-        $objUtf8WithoutBom = [System.Text.UTF8Encoding]::new($false)
         $objMergeCurrentDate = [DateTime]::ParseExact(
             $objAgentsUpdatedMatch.Groups['Date'].Value,
             'yyyy-MM-dd',
@@ -10043,7 +8661,7 @@ if ($SelfTest) {
             'yyyy-MM-dd',
             [System.Globalization.CultureInfo]::InvariantCulture
         )
-        $strMergeCurrentTimestamp = $script:objValidationUtcNow.ToString('o')
+        $strMergeCurrentTimestamp = $strMergeCurrentDate + 'T12:00:00Z'
         $strMergeHistoricalDate = $objMergeCurrentDate.AddDays(-1).ToString(
             'yyyy-MM-dd',
             [System.Globalization.CultureInfo]::InvariantCulture
@@ -10065,1777 +8683,96 @@ if ($SelfTest) {
             '',
             'Pre-policy rationale content.'
         ) -join "`n"
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strMergeBaseContent,
-            $objUtf8WithoutBom
-        )
-        [IO.File]::WriteAllText(
-            $strMergePolicyPath,
-            $strMetadataRangePolicyMarker,
-            $objUtf8WithoutBom
-        )
-        [IO.File]::WriteAllText(
-            $strMergeUnversionedPath,
-            $objUnversionedDocument.Content,
-            $objUtf8WithoutBom
-        )
-        [IO.File]::WriteAllText(
-            $strRationaleFixturePath,
-            $strRationaleFixturePrePolicy + "`n",
-            $objUtf8WithoutBom
-        )
-        [IO.File]::WriteAllText(
-            $strMergeGitIgnorePath,
-            "/CLAUDE.local.md`n",
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- `
-            'AGENTS.md' '.github/workflows/Test-AgentInstructions.ps1' `
-            $strMergeUnversionedRelativePath $strRationaleFixtureRelativePath `
-            '.gitignore'
-        $strMergeBaseTree = [string] (& git -C $strMergeFixtureRoot write-tree)
-        if ($LASTEXITCODE -ne 0 -or
-            $strMergeBaseTree.Trim() -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-            throw 'Could not create the merge-transition base tree.'
-        }
-        $strMergeBaseTree = $strMergeBaseTree.Trim()
-
-        $scriptBlockNewPolicyTree = {
-            param([byte[]] $Bytes, [string] $Mode = '100644')
-            [IO.File]::WriteAllBytes($strMergePolicyPath, $Bytes)
-            $strBlob = ([string](& git -C $strMergeFixtureRoot hash-object -w -- `
-                        $strMergePolicyPath)).Trim()
-            & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-            & git -C $strMergeFixtureRoot update-index --cacheinfo `
-                "$Mode,$strBlob,.github/workflows/Test-AgentInstructions.ps1"
-            $strTree = ([string](& git -C $strMergeFixtureRoot write-tree)).Trim()
-            if ($LASTEXITCODE -ne 0 -or $strTree -notmatch '^[0-9a-fA-F]{40}$') {
-                throw 'Could not create an immutable policy-marker fixture.'
-            }
-            return $strTree
-        }
-        $scriptBlockAssertHistoryFailure = {
-            param([string] $Tree, [string] $Message)
-            $boolRejected = $false
-            try {
-                [void](Test-HistoricalPolicyMarker -RepositoryRootPath $strMergeFixtureRoot `
-                        -Revision $Tree -RepositoryRelativePath `
-                        '.github/workflows/Test-AgentInstructions.ps1' `
-                        -Literal $strMetadataRangePolicyMarker)
-            }
-            catch {
-                $boolRejected = $_.Exception.Message.Contains(
-                    $Message, [StringComparison]::Ordinal)
-            }
-            if (-not $boolRejected) { throw "Historical policy fixture was not rejected: $Message" }
-        }
-        $arrBoundedHistory = [Text.Encoding]::UTF8.GetBytes(
-            $strMetadataRangePolicyMarker +
-            ('x' * (393217 - $strMetadataRangePolicyMarker.Length)))
-        $strBoundedHistoryTree = & $scriptBlockNewPolicyTree $arrBoundedHistory
-        if (-not (Test-HistoricalPolicyMarker -RepositoryRootPath $strMergeFixtureRoot `
-                    -Revision $strBoundedHistoryTree -RepositoryRelativePath `
-                    '.github/workflows/Test-AgentInstructions.ps1' `
-                    -Literal $strMetadataRangePolicyMarker)) {
-            throw 'A bounded immutable historical marker was not found.'
-        }
-        $strAbsentHistoryTree = & $scriptBlockNewPolicyTree `
-            ([Text.Encoding]::UTF8.GetBytes('marker absent'))
-        if (Test-HistoricalPolicyMarker -RepositoryRootPath $strMergeFixtureRoot `
-                -Revision $strAbsentHistoryTree -RepositoryRelativePath `
-                '.github/workflows/Test-AgentInstructions.ps1' `
-                -Literal $strMetadataRangePolicyMarker) {
-            throw 'A historical marker-absent policy was classified as governed.'
-        }
-        & $scriptBlockAssertHistoryFailure `
-            (& $scriptBlockNewPolicyTree ([byte[]]::new(573441))) 'must not exceed 573440 bytes'
-        & $scriptBlockAssertHistoryFailure `
-            (& $scriptBlockNewPolicyTree ([byte[]] @(0xC3, 0x28))) 'valid UTF-8 without a BOM'
-        & $scriptBlockAssertHistoryFailure `
-            (& $scriptBlockNewPolicyTree `
-                ([Text.Encoding]::UTF8.GetBytes($strMetadataRangePolicyMarker)) '120000') `
-            'not one regular 100644 blob'
-
-        $scriptBlockCreateMergeFixtureCommit = {
-            param(
-                [string] $Tree,
-                [string[]] $Parents,
-                [string] $Timestamp,
-                [string] $Message
-            )
-
-            $env:GIT_AUTHOR_DATE = $Timestamp
-            $env:GIT_COMMITTER_DATE = $Timestamp
-            $arrCommitArguments = @(
-                '-C', $strMergeFixtureRoot,
-                '-c', 'user.name=Agent Instruction Validator',
-                '-c', 'user.email=validator@example.invalid',
-                'commit-tree', $Tree
-            )
-            foreach ($strFixtureParent in $Parents) {
-                $arrCommitArguments += @('-p', $strFixtureParent)
-            }
-            $arrCommitArguments += @('-m', $Message)
-            $strFixtureCommit = [string] (& git @arrCommitArguments)
-            if ($LASTEXITCODE -ne 0 -or
-                $strFixtureCommit.Trim() -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-                throw "Could not create merge-transition fixture commit: $Message"
-            }
-            return $strFixtureCommit.Trim()
-        }
-        $scriptBlockGetMergeRangeFailure = {
-            param(
-                [string[]] $Base,
-                [string] $Head,
-                [bool] $RequireCommitDate = $false,
-                [string] $Path = 'AGENTS.md',
-                [int] $MaximumBytes = $intAgentsMaximumInputBytes,
-                [bool] $IsNewRef = $false,
-                [string[]] $FreshnessRevision = @(),
-                [bool] $RequiresVersion = $true,
-                [bool] $RequiredDocument = $true
-            )
-            Get-GovernedDocumentRangeTransitionFailure -Name $Path `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -RepositoryRelativePath $Path `
-                -MaximumBytes $MaximumBytes `
-                -BaseRevision $Base -HeadRevision $Head -InputRevision $Head `
-                -IsNewRefRange $IsNewRef `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes 1024 -PolicyMarker $strMetadataRangePolicyMarker `
-                -RequireExpectedUtcDateForRenderedChange $RequireCommitDate `
-                -CommitDateFreshnessRevision $FreshnessRevision `
-                -RequiresVersion $RequiresVersion -RequiredDocument $RequiredDocument
-        }
-        $scriptBlockGetDirectFailure = {
-            param([string] $Commit)
-            Get-GovernedDocumentCommitTransitionFailure -Name 'AGENTS.md' `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -RepositoryRelativePath 'AGENTS.md' `
-                -MaximumBytes $intAgentsMaximumInputBytes `
-                -CommitRevision $Commit `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes 1024 -PolicyMarker $strMetadataRangePolicyMarker `
-                -RequireExpectedUtcDateForRenderedChange $true
-        }
-        $scriptBlockGetUnversionedRangeFailure = {
-            param([string] $Base, [string] $Head)
-            Get-GovernedDocumentRangeTransitionFailure `
-                -Name $strMergeUnversionedRelativePath `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -RepositoryRelativePath $strMergeUnversionedRelativePath `
-                -MaximumBytes $intInstructionDocumentMaximumInputBytes `
-                -BaseRevision $Base -HeadRevision $Head -InputRevision $Head `
-                -IsNewRefRange $false `
-                -PolicyRepositoryRelativePath `
-                    '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes 1024 `
-                -PolicyMarker $strMetadataRangePolicyMarker `
-                -RequireExpectedUtcDateForRenderedChange $true `
-                -RequiresVersion $false
-        }
-
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-        $strCaseFixtureBlob = [string] (
-            'case-folded instruction fixture' |
-                & git -C $strMergeFixtureRoot hash-object -w --stdin
-        )
-        if ($LASTEXITCODE -ne 0 -or
-            $strCaseFixtureBlob.Trim() -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-            throw 'Could not create the case-folded instruction fixture blob.'
-        }
-        foreach ($strCaseFoldedGovernedPath in $arrCaseFoldedGovernedPaths) {
-            & git -C $strMergeFixtureRoot update-index --add --cacheinfo `
-                "100644,$($strCaseFixtureBlob.Trim()),$strCaseFoldedGovernedPath"
-            if ($LASTEXITCODE -ne 0) {
-                throw "Could not add case-folded instruction fixture: $strCaseFoldedGovernedPath"
-            }
-        }
-        $strCaseFoldedTree = ([string] (
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $arrCaseFoldedTreePaths = @(Read-GitTrackedPath `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -Revision $strCaseFoldedTree `
-                -MaximumBytes $intGitPathListMaximumBytes)
-        foreach ($strCaseFoldedGovernedPath in $arrCaseFoldedGovernedPaths) {
-            if ($arrCaseFoldedTreePaths -cnotcontains $strCaseFoldedGovernedPath) {
-                throw "A case-folded path was lost from the synthetic Git tree: $strCaseFoldedGovernedPath"
-            }
-        }
-        $arrCaseFoldedInventoryPaths = @(
-            $arrCaseFoldedTreePaths |
-                Where-Object {
-                    Test-GovernedInstructionInventoryPath `
-                        -RepositoryRelativePath ([string] $_)
-                }
-        )
-        foreach ($strCaseFoldedGovernedPath in $arrCaseFoldedGovernedPaths) {
-            if ($arrCaseFoldedInventoryPaths -cnotcontains $strCaseFoldedGovernedPath) {
-                throw "A case-folded path escaped the synthetic tracked inventory: $strCaseFoldedGovernedPath"
-            }
-            $arrCaseFoldedInventoryFailures = @(
-                Get-GovernedInstructionInventoryFailure `
-                    -CatalogPaths @($arrGovernedInstructionDocuments.Path) `
-                    -TrackedPaths @(
-                        $arrTrackedGovernedInstructionPaths +
-                            $strCaseFoldedGovernedPath
-                    )
-            )
-            if (-not ($arrCaseFoldedInventoryFailures -ccontains (
-                        'Tracked governed instruction is missing from the catalog: ' +
-                        $strCaseFoldedGovernedPath
-                    ))) {
-                throw "A case-folded exact path did not fail ordinal inventory: $strCaseFoldedGovernedPath"
-            }
-        }
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-
-        $strMergeBaseCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents @() `
-            -Timestamp ($strMergeHistoricalDate + 'T08:00:00Z') `
-            -Message 'merge fixture base'
-
-        $scriptBlockNewFixturePathTree = {
-            param(
-                [string] $BaseTree,
-                [hashtable] $PathContent
-            )
-
-            & git -C $strMergeFixtureRoot read-tree $BaseTree
-            if ($LASTEXITCODE -ne 0) {
-                throw 'Could not reset the range-path fixture tree.'
-            }
-            foreach ($strFixturePath in $PathContent.Keys) {
-                $strFixtureFile = [IO.Path]::Combine(
-                    $strMergeFixtureRoot,
-                    $strFixturePath.Replace('/', [IO.Path]::DirectorySeparatorChar)
-                )
-                [void][IO.Directory]::CreateDirectory(
-                    [IO.Path]::GetDirectoryName($strFixtureFile)
-                )
-                [IO.File]::WriteAllText(
-                    $strFixtureFile,
-                    [string]$PathContent[$strFixturePath],
-                    $objUtf8WithoutBom
-                )
-                & git -C $strMergeFixtureRoot add -- $strFixturePath
-                if ($LASTEXITCODE -ne 0) {
-                    throw "Could not add range-path fixture: $strFixturePath"
-                }
-            }
-            $strFixtureTree = ([string] (
-                    & git -C $strMergeFixtureRoot write-tree
-                )).Trim()
-            if ($LASTEXITCODE -ne 0 -or
-                $strFixtureTree -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-                throw 'Could not create the range-path fixture tree.'
-            }
-            return $strFixtureTree
-        }
-        $scriptBlockNewFixtureDeletionTree = {
-            param(
-                [string] $BaseTree,
-                [string[]] $Path
-            )
-
-            & git -C $strMergeFixtureRoot read-tree $BaseTree
-            foreach ($strFixturePath in $Path) {
-                & git -C $strMergeFixtureRoot update-index `
-                    --force-remove -- $strFixturePath
-                if ($LASTEXITCODE -ne 0) {
-                    throw "Could not delete range-path fixture: $strFixturePath"
-                }
-            }
-            $strFixtureTree = ([string] (
-                    & git -C $strMergeFixtureRoot write-tree
-                )).Trim()
-            if ($LASTEXITCODE -ne 0 -or
-                $strFixtureTree -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-                throw 'Could not create the deleted range-path fixture tree.'
-            }
-            return $strFixtureTree
-        }
-
-        if (@(& $scriptBlockGetDirectFailure $strMergeBaseCommit).Count -ne 0) {
-            throw 'Valid policy-active root metadata failed.'
-        }
-        $strMalformedRootTree = & $scriptBlockNewFixturePathTree `
-            -BaseTree $strMergeBaseTree -PathContent @{'AGENTS.md' = 'invalid'}
-        $strMalformedRootCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMalformedRootTree -Parents @() `
-            -Timestamp ($strMergeHistoricalDate + 'T08:00:00Z') `
-            -Message 'malformed policy-active root'
-        if (-not ((@(& $scriptBlockGetDirectFailure $strMalformedRootCommit) -join '; ').Contains(
-                    'must contain exactly one document-level H1',
-                    [StringComparison]::Ordinal))) {
-            throw 'Malformed policy-active root metadata passed.'
-        }
-
-        $strIntroducedStaleVersion = $strMergeBaseVersion -replace '\.0$', '.1'
-        $strIntroducedRestoredVersion = $strMergeBaseVersion -replace '\.0$', '.2'
-        $strIntroducedStaleContent = $strMergeBaseContent.Replace(
-            $strMergeBaseVersion,
-            $strIntroducedStaleVersion
-        ) + "`nIntroduced stale rendered content.`n"
-        $strIntroducedStaleTree = & $scriptBlockNewFixturePathTree `
-            -BaseTree $strMergeBaseTree `
-            -PathContent @{'AGENTS.md' = $strIntroducedStaleContent}
-        $strIntroducedStaleCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strIntroducedStaleTree -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'introduced stale new-ref content'
-        $strIntroducedRestoreContent = $strMergeBaseContent.Replace(
-            $strMergeBaseVersion,
-            $strIntroducedRestoredVersion
-        )
-        $strIntroducedRestoreTree = & $scriptBlockNewFixturePathTree `
-            -BaseTree $strIntroducedStaleTree `
-            -PathContent @{'AGENTS.md' = $strIntroducedRestoreContent}
-        $strIntroducedRestoreCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strIntroducedRestoreTree `
-            -Parents @($strIntroducedStaleCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'introduced endpoint restore'
-        $objIntroducedRestoreContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'push' -PullRequestAction '' `
-            -BaseRevision ('0' * 40) `
-            -HeadRevision $strIntroducedRestoreCommit `
-            -IsNewRefRange $true -PreviousHeadRevision '' `
-            -EventHeadRevision $strIntroducedRestoreCommit `
-            -EventHeadDistinct 'true' -NewRefCommitCount '2' `
-            -NewRefCommitEvidenceJson (ConvertTo-Json -Compress -InputObject @(
-                    $strIntroducedStaleCommit,
-                    $strIntroducedRestoreCommit
-                ))
-        $arrIntroducedRestoreFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base ('0' * 40) -Head $strIntroducedRestoreCommit `
-                -IsNewRef $true -FreshnessRevision `
-                    $objIntroducedRestoreContext.NewRefIntroducedCommitRevisions)
-        if (-not ($arrIntroducedRestoreFailures -join '; ').Contains(
-                "Last Updated must be $strMergeCurrentDate",
-                [StringComparison]::Ordinal
-            )) {
-            throw 'A stale introduced new-ref commit escaped commit-date freshness.'
-        }
-
-        $strInheritedStaleVersion = $strMergeBaseVersion -replace '\.0$', '.3'
-        $strInheritedStaleContent = $strMergeBaseContent.Replace(
-            $strMergeBaseVersion,
-            $strInheritedStaleVersion
-        ) + "`nInherited stale rendered content.`n"
-        $strInheritedStaleTree = & $scriptBlockNewFixturePathTree `
-            -BaseTree $strMergeBaseTree `
-            -PathContent @{'AGENTS.md' = $strInheritedStaleContent}
-        $strInheritedStaleCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strInheritedStaleTree -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'inherited stale boundary content'
-        $strInheritedBoundaryHead = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strInheritedStaleTree -Parents @($strInheritedStaleCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'introduced unchanged boundary head'
-        $objInheritedBoundaryContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'push' -PullRequestAction '' `
-            -BaseRevision ('0' * 40) `
-            -HeadRevision $strInheritedBoundaryHead `
-            -IsNewRefRange $true -PreviousHeadRevision '' `
-            -EventHeadRevision $strInheritedBoundaryHead `
-            -EventHeadDistinct 'true' -NewRefCommitCount '1' `
-            -NewRefCommitEvidenceJson (ConvertTo-Json -Compress `
-                -InputObject @($strInheritedBoundaryHead))
-        if (@($objInheritedBoundaryContext.NewRefIntroducedCommitRevisions).Count -ne 1 -or
-            $objInheritedBoundaryContext.NewRefIntroducedCommitRevisions[0] -cne
-                $strInheritedBoundaryHead) {
-            throw 'The new-ref freshness allowlist included inherited history.'
-        }
-        $arrInheritedBoundaryFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base ('0' * 40) -Head $strInheritedBoundaryHead `
-                -IsNewRef $true -FreshnessRevision `
-                    $objInheritedBoundaryContext.NewRefIntroducedCommitRevisions)
-        if ($arrInheritedBoundaryFailures.Count -ne 0) {
-            throw (
-                'Inherited new-ref history received introduced-commit freshness: ' +
-                ($arrInheritedBoundaryFailures -join '; ')
-            )
-        }
-
-        $strDecisionPath = 'docs/decisions/0001-range-fixture.md'
-        $strMalformedDecisionPath = 'docs/decisions/range-fixture.md'
-        $strUnrelatedRangePath = 'docs/range-fixture.md'
-        $arrTransientGovernedPaths = @(
-            '.cursor/rules/transient.mdc',
-            'tools/AGENTS.md'
-        )
-        $strDecisionContentPrefix = @(
-            '# Range fixture decision',
-            '',
-            '## Metadata',
-            '',
-            '- **Status:** Active',
-            '- **Owner:** Repository Maintainer'
-        ) -join "`n"
-        $strStaleDecisionContent = $strDecisionContentPrefix + "`n" +
-            "- **Last Updated:** $strMergeHistoricalDate`n" +
-            "- **Scope:** Tests range-only decision records.`n"
-        $strMalformedDecisionContent = $strStaleDecisionContent.Replace(
-            '# Range fixture decision',
-            '# Malformed range fixture decision'
-        )
-        $strDecisionAddTree = & $scriptBlockNewFixturePathTree `
-            -BaseTree $strMergeBaseTree `
-            -PathContent @{
-                $strDecisionPath = $strStaleDecisionContent
-                $strMalformedDecisionPath = $strMalformedDecisionContent
-                $strUnrelatedRangePath = 'Unrelated range fixture.'
-                '.cursor/rules/transient.mdc' = 'Transient Cursor instruction.'
-                'tools/AGENTS.md' = 'Transient nested agent instruction.'
-            }
-        $strDecisionAddCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strDecisionAddTree -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'add range-only decision fixtures'
-        $strDecisionDeleteTree = & $scriptBlockNewFixtureDeletionTree `
-            -BaseTree $strDecisionAddTree `
-            -Path @(
-                $strDecisionPath,
-                $strMalformedDecisionPath,
-                $strUnrelatedRangePath,
-                $arrTransientGovernedPaths[0],
-                $arrTransientGovernedPaths[1]
-            )
-        $strDecisionDeleteCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strDecisionDeleteTree -Parents @($strDecisionAddCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'delete range-only decision fixtures'
-        $arrTouchedDecisionPaths = @(Read-GitRangeTouchedPath `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $strMergeBaseCommit `
-                -HeadRevision $strDecisionDeleteCommit `
-                -IsNewRefRange $false `
-                -RepositoryRelativePathspec 'docs/decisions/' `
-                -MaximumBytes $intGitPathListMaximumBytes)
-        if ($arrTouchedDecisionPaths -cnotcontains $strDecisionPath -or
-            $arrTouchedDecisionPaths -cnotcontains $strMalformedDecisionPath -or
-            $arrTouchedDecisionPaths -ccontains $strUnrelatedRangePath) {
-            throw 'Authenticated range-touched decision discovery was incomplete.'
-        }
-        $arrTouchedRepositoryPaths = @(Read-GitRangeTouchedPath `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $strMergeBaseCommit `
-                -HeadRevision $strDecisionDeleteCommit `
-                -IsNewRefRange $false `
-                -RepositoryRelativePathspec ':(top)**' `
-                -MaximumBytes $intGitPathListMaximumBytes)
-        $arrTouchedGovernedPaths = @(
-            $arrTouchedRepositoryPaths |
-                Where-Object {
-                    Test-GovernedInstructionInventoryPath `
-                        -RepositoryRelativePath ([string]$_)
-                }
-        )
-        $arrTransientInventoryFailures = @(
-            Get-GovernedInstructionInventoryFailure `
-                -CatalogPaths @($arrGovernedInstructionDocuments.Path) `
-                -TrackedPaths @(
-                    $arrTrackedGovernedInstructionPaths + $arrTouchedGovernedPaths
-                )
-        )
-        foreach ($strTransientGovernedPath in $arrTransientGovernedPaths) {
-            $strExpectedTransientFailure =
-                'Tracked governed instruction is missing from the catalog: ' +
-                $strTransientGovernedPath
-            if ($arrTouchedGovernedPaths -cnotcontains $strTransientGovernedPath -or
-                $arrTransientInventoryFailures -cnotcontains $strExpectedTransientFailure) {
-                throw "Transient governed path escaped range inventory: $strTransientGovernedPath"
-            }
-        }
-        $arrMalformedDecisionFailures = @(Get-DecisionRecordPathFailure `
-                -RepositoryRelativePath $strMalformedDecisionPath)
-        if ($arrMalformedDecisionFailures.Count -ne 1) {
-            throw 'A deleted malformed decision path escaped range inventory validation.'
-        }
-        $arrStaleDecisionFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strMergeBaseCommit -Head $strDecisionDeleteCommit `
-                -RequireCommitDate $true -Path $strDecisionPath `
-                -MaximumBytes $intInstructionDocumentMaximumInputBytes `
-                -RequiresVersion $false -RequiredDocument $false)
-        if (-not ($arrStaleDecisionFailures -join '; ').Contains(
-                "Last Updated must be $strMergeCurrentDate",
-                [StringComparison]::Ordinal
-            )) {
-            throw 'A stale add-then-delete decision record escaped range validation.'
-        }
-
-        $strFreshDecisionContent = $strStaleDecisionContent.Replace(
-            $strMergeHistoricalDate,
-            $strMergeCurrentDate
-        )
-        $strFreshDecisionAddTree = & $scriptBlockNewFixturePathTree `
-            -BaseTree $strMergeBaseTree `
-            -PathContent @{$strDecisionPath = $strFreshDecisionContent}
-        $strFreshDecisionAddCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strFreshDecisionAddTree -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'add valid range-only decision fixture'
-        $strFreshDecisionDeleteTree = & $scriptBlockNewFixtureDeletionTree `
-            -BaseTree $strFreshDecisionAddTree -Path @($strDecisionPath)
-        $strFreshDecisionDeleteCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strFreshDecisionDeleteTree `
-            -Parents @($strFreshDecisionAddCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'delete valid range-only decision fixture'
-        $arrFreshDecisionFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strMergeBaseCommit -Head $strFreshDecisionDeleteCommit `
-                -RequireCommitDate $true -Path $strDecisionPath `
-                -MaximumBytes $intInstructionDocumentMaximumInputBytes `
-                -RequiresVersion $false -RequiredDocument $false)
-        if ($arrFreshDecisionFailures.Count -ne 0) {
-            throw (
-                'A valid add-then-delete decision record failed validation: ' +
-                ($arrFreshDecisionFailures -join '; ')
-            )
-        }
-
-        $strRationaleFixturePolicy = $strMetadataRangePolicyMarker + "`n" +
-            $strStyleGuideRationaleMetadataPolicyMarker + "`n"
-        $strRationaleFixtureActive = @(
-            '# Rationale fixture',
-            '',
-            '## Metadata',
-            '',
-            '- **Status:** Active',
-            '- **Owner:** Repository Maintainer',
-            "- **Last Updated:** $strMergeHistoricalDate",
-            '- **Scope:** Explains the rationale fixture.',
-            '',
-            '## Rationale body',
-            '',
-            'Activation content.'
-        ) -join "`n"
-        $strRationaleFixtureActive += "`n"
-        $scriptBlockNewRationaleTree = {
-            param([string] $PolicyContent, [string] $RationaleContent)
-
-            & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-            if ($LASTEXITCODE -ne 0) {
-                throw 'Could not reset the rationale adoption fixture tree.'
-            }
-            [IO.File]::WriteAllText(
-                $strMergePolicyPath,
-                $PolicyContent,
-                $objUtf8WithoutBom
-            )
-            [IO.File]::WriteAllText(
-                $strRationaleFixturePath,
-                $RationaleContent,
-                $objUtf8WithoutBom
-            )
-            & git -C $strMergeFixtureRoot add -- `
-                '.github/workflows/Test-AgentInstructions.ps1' `
-                $strRationaleFixtureRelativePath
-            $strRationaleTree = ([string] (
-                    & git -C $strMergeFixtureRoot write-tree
-                )).Trim()
-            if ($LASTEXITCODE -ne 0 -or
-                $strRationaleTree -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-                throw 'Could not create the rationale adoption fixture tree.'
-            }
-            return $strRationaleTree
-        }
-        $scriptBlockGetRationaleRangeFailure = {
-            param([string] $Base, [string] $Head)
-
-            Get-GovernedDocumentRangeTransitionFailure `
-                -Name $strRationaleFixtureRelativePath `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -RepositoryRelativePath $strRationaleFixtureRelativePath `
-                -MaximumBytes $intStyleGuideRationaleMaximumInputBytes `
-                -BaseRevision $Base -HeadRevision $Head -InputRevision $Head `
-                -IsNewRefRange $false `
-                -PolicyRepositoryRelativePath `
-                    '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes 1024 `
-                -PolicyMarker $strStyleGuideRationaleMetadataPolicyMarker `
-                -RequireExpectedUtcDateForRenderedChange $true `
-                -RequiresVersion $false
-        }
-        if (Test-HistoricalPolicyMarker `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -Revision $strMergeBaseCommit `
-                -RepositoryRelativePath `
-                    '.github/workflows/Test-AgentInstructions.ps1' `
-                -Literal $strStyleGuideRationaleMetadataPolicyMarker) {
-            throw 'The rationale pre-policy parent contained the adoption marker.'
-        }
-        $strRationaleActivationTree = & $scriptBlockNewRationaleTree `
-            -PolicyContent $strRationaleFixturePolicy `
-            -RationaleContent $strRationaleFixtureActive
-        $strRationaleActivationCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strRationaleActivationTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T09:00:00Z') `
-            -Message 'activate rationale metadata policy'
-        if (-not (Test-HistoricalPolicyMarker `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -Revision $strRationaleActivationCommit `
-                -RepositoryRelativePath `
-                    '.github/workflows/Test-AgentInstructions.ps1' `
-                -Literal $strStyleGuideRationaleMetadataPolicyMarker)) {
-            throw 'The rationale activation child lacked the dedicated marker.'
-        }
-        $arrRationaleActivationFailures = @(
-            & $scriptBlockGetRationaleRangeFailure `
-                -Base $strMergeBaseCommit `
-                -Head $strRationaleActivationCommit
-        )
-        if ($arrRationaleActivationFailures.Count -ne 0) {
-            throw (
-                'The first governed rationale revision failed adoption: ' +
-                ($arrRationaleActivationFailures -join '; ')
-            )
-        }
-
-        $strRationaleFixtureMissingOwner = $strRationaleFixtureActive.Replace(
-            '- **Owner:** Repository Maintainer' + "`n",
-            ''
-        )
-        $strRationaleFixtureStale = $strRationaleFixtureActive.Replace(
-            'Activation content.',
-            'Rendered content changed after activation.'
-        )
-        $strRationaleFixtureMalformed = @(
-            '# Rationale fixture',
-            '',
-            '## Rationale body',
-            '',
-            'Metadata has the wrong position.',
-            '',
-            '## Metadata',
-            '',
-            '- **Status:** Active',
-            '- **Owner:** Repository Maintainer',
-            "- **Last Updated:** $strMergeCurrentDate",
-            '- **Scope:** Explains the rationale fixture.'
-        ) -join "`n"
-        $strRationaleFixtureMalformed += "`n"
-        $strRationaleFixtureRemoved = @(
-            '# Rationale fixture',
-            '',
-            '## Rationale body',
-            '',
-            'The complete metadata block was removed.'
-        ) -join "`n"
-        $strRationaleFixtureRemoved += "`n"
-        $arrRationaleNegativeCases = @(
-            [pscustomobject]@{
-                Name = 'missing owner'
-                Content = $strRationaleFixtureMissingOwner
-                Failure = 'must contain one exact top-level Owner list item'
-            },
-            [pscustomobject]@{
-                Name = 'stale date'
-                Content = $strRationaleFixtureStale
-                Failure = "Last Updated must be $strMergeCurrentDate"
-            },
-            [pscustomobject]@{
-                Name = 'malformed placement'
-                Content = $strRationaleFixtureMalformed
-                Failure = 'must place Metadata as the first level-two heading'
-            },
-            [pscustomobject]@{
-                Name = 'removed metadata'
-                Content = $strRationaleFixtureRemoved
-                Failure = 'must place Metadata as the first level-two heading'
-            }
-        )
-        $intRationaleNegativeCase = 0
-        foreach ($objRationaleNegativeCase in $arrRationaleNegativeCases) {
-            $intRationaleNegativeCase++
-            $strRationaleNegativeTree = & $scriptBlockNewRationaleTree `
-                -PolicyContent $strRationaleFixturePolicy `
-                -RationaleContent $objRationaleNegativeCase.Content
-            $strRationaleNegativeCommit = & $scriptBlockCreateMergeFixtureCommit `
-                -Tree $strRationaleNegativeTree `
-                -Parents @($strRationaleActivationCommit) `
-                -Timestamp $strMergeCurrentTimestamp `
-                -Message "rationale $($objRationaleNegativeCase.Name)"
-            $arrRationaleNegativeFailures = @(
-                & $scriptBlockGetRationaleRangeFailure `
-                    -Base $strRationaleActivationCommit `
-                    -Head $strRationaleNegativeCommit
-            )
-            if (-not ($arrRationaleNegativeFailures -join '; ').Contains(
-                    $objRationaleNegativeCase.Failure,
-                    [StringComparison]::Ordinal
-                )) {
-                throw (
-                    "Rationale $($objRationaleNegativeCase.Name) did not fail closed: " +
-                    ($arrRationaleNegativeFailures -join '; ')
-                )
-            }
-        }
-
-        $strRationaleMarkerRemovalTree = & $scriptBlockNewRationaleTree `
-            -PolicyContent ($strMetadataRangePolicyMarker + "`n") `
-            -RationaleContent ($strRationaleFixtureActive.Replace(
-                'Activation content.',
-                'Content changed while the rationale marker was absent.'
-            ))
-        $strRationaleMarkerRemovalCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strRationaleMarkerRemovalTree `
-            -Parents @($strRationaleActivationCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'remove rationale metadata policy marker'
-        $strRationaleMarkerRestoreCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strRationaleActivationTree `
-            -Parents @($strRationaleMarkerRemovalCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'restore rationale marker and endpoint bytes'
-        $arrRationaleMarkerRemovalFailures = @(
-            & $scriptBlockGetRationaleRangeFailure `
-                -Base $strRationaleActivationCommit `
-                -Head $strRationaleMarkerRestoreCommit
-        )
-        $strRationaleMarkerRemovalFailure =
-            'governance marker style-guide-rationale-metadata-policy-v1 ' +
-            'must not be removed'
-        if (-not ($arrRationaleMarkerRemovalFailures -join '; ').Contains(
-                $strRationaleMarkerRemovalFailure,
-                [StringComparison]::Ordinal
-            )) {
-            throw 'An intermediate rationale policy-marker removal escaped validation.'
-        }
-
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-        [IO.File]::WriteAllText(
-            $strMergeGitIgnorePath,
-            "node_modules/`n",
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- '.gitignore'
-        $strProposedGitIgnoreTree = ([string] (
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $strProposedGitIgnoreCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strProposedGitIgnoreTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'proposed gitignore deletion'
-        $strProposedGitIgnore = Read-GitRevisionText `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -Revision $strProposedGitIgnoreCommit `
-            -RepositoryRelativePath '.gitignore' `
-            -MaximumBytes $intGitIgnoreMaximumInputBytes `
-            -RequireRegularFile
-        if ($strProposedGitIgnore -cmatch '(?m)^/CLAUDE\.local\.md$') {
-            throw 'The proposed .gitignore deletion fixture retained the required rule.'
-        }
-        [IO.File]::WriteAllText(
-            $strMergeGitIgnorePath,
-            "/CLAUDE.local.md`n",
-            $objUtf8WithoutBom
-        )
-
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-        [IO.File]::WriteAllText(
-            $strMergeUnversionedPath,
-            $objUnversionedDocument.Content + "`nRendered stale range change.`n",
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- $strMergeUnversionedRelativePath
-        $strUnversionedStaleTree = ([string] (
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $strUnversionedStaleCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strUnversionedStaleTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'stale unversioned transition'
-        $strUnversionedRestoreCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents @($strUnversionedStaleCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'restore unversioned endpoint'
-        $arrUnversionedRangeFailures = @(
-            & $scriptBlockGetUnversionedRangeFailure `
-                -Base $strMergeBaseCommit -Head $strUnversionedRestoreCommit
-        )
-        if (($arrUnversionedRangeFailures -join "`n") -cnotmatch
-                'Last Updated must') {
-            throw 'A stale change-then-restore unversioned range escaped validation.'
-        }
-        [IO.File]::WriteAllText(
-            $strMergeUnversionedPath,
-            $objUnversionedDocument.Content,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-
-        & git -C $strMergeFixtureRoot rm --cached --force --quiet -- `
-            '.github/workflows/Test-AgentInstructions.ps1'
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not remove the policy marker from the transition fixture index.'
-        }
-        & git -C $strMergeFixtureRoot rm --cached --force --quiet -- 'AGENTS.md'
-        $strMarkerRemovalTree = ([string] (
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $strMarkerRemovalCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMarkerRemovalTree -Parents @($strMergeBaseCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T00:47:00Z') `
-            -Message 'remove marker during governed transition'
-        $strMarkerRestoreCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strMarkerRemovalCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T00:48:00Z') `
-            -Message 'restore marker and endpoint bytes'
-        $arrMarkerRemovalFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strMergeBaseCommit -Head $strMarkerRestoreCommit)
-        if (-not ($arrMarkerRemovalFailures -join '; ').Contains(
-                'governance marker metadata-range-transition-policy-v1 must not be removed',
-                [StringComparison]::Ordinal
-            )) {
-            throw 'An intermediate policy-marker removal escaped edge validation.'
-        }
-        if (($arrMarkerRemovalFailures -join '; ') -cnotmatch
-                'Required governed document AGENTS\.md must exist') {
-            throw 'An intermediate required-document deletion escaped range validation.'
-        }
-        if ((@(& $scriptBlockGetMergeRangeFailure -Base $strMergeBaseCommit `
-                    -Head $strMarkerRestoreCommit -RequiredDocument $false) -join '; ') -cmatch
-                'Required governed document') {
-            throw 'An optional document deletion was rejected as required.'
-        }
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-
-        & git -C $strMergeFixtureRoot rm --cached --force --quiet -- `
-            '.github/workflows/Test-AgentInstructions.ps1'
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not remove the policy marker from the pre-policy fixture index.'
-        }
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            'pre-policy root',
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strPrePolicyRootTree = (& git -C $strMergeFixtureRoot write-tree).Trim()
-        $strPrePolicyRootCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strPrePolicyRootTree -Parents @() `
-            -Timestamp ($strMergeHistoricalDate + 'T01:00:00Z') `
-            -Message 'pre-policy root'
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            'changed pre-policy side',
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strPrePolicySideTree = (& git -C $strMergeFixtureRoot write-tree).Trim()
-        $strPrePolicySideCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strPrePolicySideTree -Parents @($strPrePolicyRootCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T02:00:00Z') `
-            -Message 'pre-policy side'
-        if (@(& $scriptBlockGetDirectFailure `
-                -Commit $strPrePolicySideCommit).Count -ne 0) {
-            throw 'A wholly pre-policy transition failed marker-continuity validation.'
-        }
-        $strSideAdoptsPolicy = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strPrePolicySideCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'side adopts policy'
-        if (@(& $scriptBlockGetMergeRangeFailure -Base $strPrePolicySideCommit `
-                -Head $strSideAdoptsPolicy -RequireCommitDate $true).Count -ne 0) {
-            throw 'A side branch could not adopt the policy.'
-        }
-        $strPolicyBaseCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strPrePolicyRootCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T03:00:00Z') `
-            -Message 'policy introduction'
-        $strPolicyMergeCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents @($strPolicyBaseCommit, $strPrePolicySideCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T04:00:00Z') `
-            -Message 'compliant pre-policy merge'
-        $arrPrePolicyMergeFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strPolicyBaseCommit -Head $strPolicyMergeCommit)
-        if ($arrPrePolicyMergeFailures.Count -ne 0) {
-            throw 'A compliant merge of a pre-policy side branch failed.'
-        }
-        & git -C $strMergeFixtureRoot read-tree $strPrePolicySideTree
-        $strPolicyBlob = (& git -C $strMergeFixtureRoot rev-parse `
-                "$strMergeBaseTree`:.github/workflows/Test-AgentInstructions.ps1").Trim()
-        & git -C $strMergeFixtureRoot update-index --add --cacheinfo `
-            "100644,$strPolicyBlob,.github/workflows/Test-AgentInstructions.ps1"
-        $strImportedTree = (& git -C $strMergeFixtureRoot write-tree).Trim()
-        $strImportedMerge = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strImportedTree `
-            -Parents @($strPolicyBaseCommit, $strPrePolicySideCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T05:00:00Z') `
-            -Message 'noncompliant side import'
-        $arrImportedFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strPolicyBaseCommit -Head $strImportedMerge)
-        if ($arrImportedFailures.Count -eq 0) {
-            throw 'A marker-bearing merge imported noncompliant side content.'
-        }
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-        $strMergeTopicVersion = '**Version:** ' +
-            $objAgentsVersionMatch.Groups['Prefix'].Value +
-            $strMergeHistoricalDate.Replace('-', '') + '.1'
-        $strMergeTopicContent = $strMergeBaseContent.Replace(
-            $strMergeBaseVersion,
-            $strMergeTopicVersion
-        ) + [Environment]::NewLine + 'Inherited merge fixture.' +
-            [Environment]::NewLine
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strMergeTopicContent,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strMergeTopicTree = ([string] (& git -C $strMergeFixtureRoot write-tree)).Trim()
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not create the inherited merge-transition tree.'
-        }
-        $strMergeTopicCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeTopicTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T12:00:00Z') `
-            -Message 'merge fixture topic'
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-        $strAdvancedBaseContent = $strMergeBaseContent +
-            [Environment]::NewLine + 'Base-only governed fixture.' +
-            [Environment]::NewLine
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strAdvancedBaseContent,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strAdvancedBaseTree = ([string](& git -C $strMergeFixtureRoot write-tree)).Trim()
-        $strAdvancedBaseCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAdvancedBaseTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture advanced base'
-        $strAdvancedBaseDescendant = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAdvancedBaseTree `
-            -Parents @($strAdvancedBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture unchanged advanced-base descendant'
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-        $strBaseOnlyTrustBlob = [string] (
-            'base-only trust-root fixture' |
-                & git -C $strMergeFixtureRoot hash-object -w --stdin
-        )
-        & git -C $strMergeFixtureRoot update-index --add --cacheinfo `
-            "100644,$($strBaseOnlyTrustBlob.Trim()),.gitattributes"
-        $strAdvancedTrustBaseTree = ([string] (
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $strAdvancedTrustBaseCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAdvancedTrustBaseTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture advanced trust base'
-        & git -C $strMergeFixtureRoot read-tree $strMergeTopicTree
-        & git -C $strMergeFixtureRoot update-index --add --cacheinfo `
-            "100644,$($strBaseOnlyTrustBlob.Trim()),.gitattributes"
-        $strTopicTrustTree = ([string] (
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $strTopicTrustCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strTopicTrustTree `
-            -Parents @($strMergeTopicCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture topic trust-root change'
-        $strTrustMergeCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeTopicTree `
-            -Parents @($strMergeTopicCommit, $strTopicTrustCommit) `
-            -Timestamp $strMergeCurrentTimestamp -Message 'topic trust-root merge restore'
-        $arrRestoredTrustFailures = @(Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $strMergeTopicCommit -HeadRevision $strTrustMergeCommit `
-                -RepositoryRelativePath @('.gitattributes'))
-        if ($arrRestoredTrustFailures.Count -ne 1) {
-            throw 'A restored merge-parent trust-root mutation passed.'
-        }
-        & git -C $strMergeFixtureRoot read-tree $strMergeTopicTree
-        $strSynchronizedTopicCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeTopicTree `
-            -Parents @($strMergeTopicCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture synchronized topic'
-        $arrDirectStaleFailures = @(
-            & $scriptBlockGetDirectFailure $strAdvancedBaseCommit
-        )
-        if (($arrDirectStaleFailures -join "`n") -cnotmatch
-                "Last Updated must be $strMergeCurrentDate") {
-            throw 'A non-distinct governed change escaped commit-date freshness.'
-        }
-        $arrNonDistinctRangeFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strMergeBaseCommit -Head $strAdvancedBaseDescendant `
-                -RequireCommitDate $true)
-        if (($arrNonDistinctRangeFailures -join "`n") -cnotmatch
-                "Last Updated must be $strMergeCurrentDate") {
-            throw 'An earlier non-distinct range transition escaped commit-date freshness.'
-        }
-        foreach ($objDirectPassingFixture in @(
-                [pscustomobject]@{ Commit = $strMergeTopicCommit; Name = 'matching metadata' },
-                [pscustomobject]@{ Commit = $strSynchronizedTopicCommit; Name = 'unchanged head' }
-            )) {
-            if (@(& $scriptBlockGetDirectFailure $objDirectPassingFixture.Commit).Count -ne 0) {
-                throw "A non-distinct $($objDirectPassingFixture.Name) fixture failed."
-            }
-        }
-        foreach ($strHistoryOnlyAction in @('opened', 'reopened')) {
-            $objHistoryOnlyContext = Get-MetadataEventRevisionContext `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -EventName 'pull_request_target' `
-                -PullRequestAction $strHistoryOnlyAction `
-                -BaseRevision $strAdvancedBaseCommit `
-                -HeadRevision $strSynchronizedTopicCommit `
-                -IsNewRefRange $false -PreviousHeadRevision '' `
-                -EventHeadRevision '' -EventHeadDistinct ''
-            if ($objHistoryOnlyContext.HistoryBaseRevision -cne $strMergeBaseCommit -or
-                $objHistoryOnlyContext.FreshnessBaseRevision -cne $strMergeBaseCommit) {
-                throw "$strHistoryOnlyAction did not use its bounded merge base."
-            }
-            $arrInitialFreshnessFailures = @(& $scriptBlockGetMergeRangeFailure `
-                    -Base $objHistoryOnlyContext.HistoryBaseRevision `
-                    -Head $strSynchronizedTopicCommit -RequireCommitDate $true)
-            if ($arrInitialFreshnessFailures.Count -ne 0) {
-                throw "$strHistoryOnlyAction rejected correctly dated commit metadata."
-            }
-        }
-        $objEditedContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'pull_request_target' -PullRequestAction 'edited' `
-            -BaseRevision $strAdvancedBaseCommit `
-            -HeadRevision $strSynchronizedTopicCommit `
-            -IsNewRefRange $false -PreviousHeadRevision '' `
-            -PullRequestBaseChanged 'true' `
-            -EventHeadRevision '' -EventHeadDistinct ''
-        if ($objEditedContext.HistoryBaseRevision -cne $strMergeBaseCommit -or
-            $objEditedContext.FreshnessBaseRevision -cne $strMergeBaseCommit) {
-            throw 'A base-changing edited event did not rebind to its merge base.'
-        }
-        if (@(& $scriptBlockGetMergeRangeFailure `
-                -Base $objEditedContext.HistoryBaseRevision `
-                -Head $strSynchronizedTopicCommit -RequireCommitDate $true).Count -ne 0) {
-            throw 'A base-changing edited event rejected commit-dated metadata.'
-        }
-        $boolEditedWithoutProofRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -EventName 'pull_request_target' -PullRequestAction 'edited' `
-                    -BaseRevision $strAdvancedBaseCommit `
-                    -HeadRevision $strSynchronizedTopicCommit `
-                    -IsNewRefRange $false -PreviousHeadRevision '' `
-                    -EventHeadRevision '' -EventHeadDistinct '')
-        }
-        catch {
-            $boolEditedWithoutProofRejected = $_.Exception.Message.Contains(
-                'requires trusted base-change proof',
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolEditedWithoutProofRejected) {
-            throw 'An edited event without base-change proof did not fail closed.'
-        }
-        $boolNonEditedProofRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -EventName 'pull_request_target' -PullRequestAction 'opened' `
-                    -BaseRevision $strAdvancedBaseCommit `
-                    -HeadRevision $strSynchronizedTopicCommit `
-                    -IsNewRefRange $false -PreviousHeadRevision '' `
-                    -PullRequestBaseChanged 'true' `
-                    -EventHeadRevision '' -EventHeadDistinct '')
-        }
-        catch {
-            $boolNonEditedProofRejected = $_.Exception.Message.Contains(
-                'Only an edited pull request event',
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolNonEditedProofRejected) {
-            throw 'A nonedited event accepted base-change proof.'
-        }
-        $objSynchronizeContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'pull_request_target' -PullRequestAction 'synchronize' `
-            -BaseRevision $strAdvancedBaseCommit `
-            -HeadRevision $strSynchronizedTopicCommit `
-            -IsNewRefRange $false `
-            -PreviousHeadRevision $strMergeTopicCommit `
-            -EventHeadRevision '' -EventHeadDistinct ''
-        if ($objSynchronizeContext.HistoryBaseRevision -cne $strMergeBaseCommit -or
-            $objSynchronizeContext.FreshnessBaseRevision -cne $strMergeTopicCommit) {
-            throw 'Synchronize did not separate merge-base history from topic introduction.'
-        }
-        $objDivergentSynchronizeContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'pull_request_target' `
-            -PullRequestAction 'synchronize' `
-            -BaseRevision $strAdvancedBaseCommit `
-            -HeadRevision $strSynchronizedTopicCommit `
-            -IsNewRefRange $false `
-            -PreviousHeadRevision $strAdvancedBaseCommit `
-            -EventHeadRevision '' -EventHeadDistinct ''
-        if ($objDivergentSynchronizeContext.HistoryBaseRevision -cne
-                $strMergeBaseCommit -or
-            $objDivergentSynchronizeContext.FreshnessBaseRevision -cne
-                $strAdvancedBaseCommit) {
-            throw 'A divergent synchronize lost its independent comparison bases.'
-        }
-        $arrDivergentFreshnessFailures = @(
-            Get-CurrentInputMetadataFreshnessFailure `
-                -Name 'AGENTS.md' `
-                -CurrentContent $strMergeTopicContent `
-                -BaseContent $strMergeBaseContent `
-                -TrustedEventUtcDate $strMergeCurrentDate
-        )
-        if ($arrDivergentFreshnessFailures.Count -ne 1) {
-            throw 'A divergent governed replacement bypassed current-event freshness.'
-        }
-
-        & git -C $strMergeFixtureRoot read-tree $strAdvancedBaseTree
-        $strRebasedTopicContent = $strAdvancedBaseContent.Replace(
-            $strMergeBaseVersion,
-            $strMergeTopicVersion
-        ) +
-            [Environment]::NewLine + 'Inherited merge fixture.' +
-            [Environment]::NewLine
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strRebasedTopicContent,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strRebasedTopicTree = ([string](& git -C $strMergeFixtureRoot write-tree)).Trim()
-        $strRebasedTopicCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strRebasedTopicTree -Parents @($strAdvancedBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture rebased topic'
-        $objRebasedSynchronizeContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'pull_request_target' `
-            -PullRequestAction 'synchronize' `
-            -BaseRevision $strAdvancedBaseCommit `
-            -HeadRevision $strRebasedTopicCommit `
-            -IsNewRefRange $false `
-            -PreviousHeadRevision $strMergeTopicCommit `
-            -EventHeadRevision '' -EventHeadDistinct ''
-        if ($objRebasedSynchronizeContext.HistoryBaseRevision -cne
-                $strAdvancedBaseCommit -or
-            $objRebasedSynchronizeContext.FreshnessBaseRevision -cne
-                $strMergeTopicCommit) {
-            throw 'A rebased topic did not retain authenticated topic delta context.'
-        }
-        if (-not (Test-TopicOwnedGitPathDeltaEqual `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -PreviousBaseRevision $objRebasedSynchronizeContext.PreviousTopicBaseRevision `
-                    -PreviousHeadRevision $objRebasedSynchronizeContext.PreviousTopicHeadRevision `
-                    -CurrentBaseRevision $objRebasedSynchronizeContext.CurrentTopicBaseRevision `
-                    -CurrentHeadRevision $objRebasedSynchronizeContext.CurrentTopicHeadRevision `
-                    -RepositoryRelativePath 'AGENTS.md')) {
-            throw 'A base-only governed rebase was falsely attributed to the topic.'
-        }
-        $strChangedRebasedTopicContent = $strRebasedTopicContent.Replace(
-            $strMergeHistoricalDate.Replace('-', '') + '.1',
-            $strMergeHistoricalDate.Replace('-', '') + '.2'
-        )
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strChangedRebasedTopicContent,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strChangedRebasedTopicTree = ([string](
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $strChangedRebasedTopicCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strChangedRebasedTopicTree -Parents @($strAdvancedBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture changed rebased topic'
-        if (Test-TopicOwnedGitPathDeltaEqual `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -PreviousBaseRevision $objRebasedSynchronizeContext.PreviousTopicBaseRevision `
-                -PreviousHeadRevision $objRebasedSynchronizeContext.PreviousTopicHeadRevision `
-                -CurrentBaseRevision $strAdvancedBaseCommit `
-                -CurrentHeadRevision $strChangedRebasedTopicCommit `
-                -RepositoryRelativePath 'AGENTS.md') {
-            throw 'An actual rebased topic delta change was ignored.'
-        }
-        & git -C $strMergeFixtureRoot read-tree $strRebasedTopicTree
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strRebasedTopicContent,
-            $objUtf8WithoutBom
-        )
-
-        $boolMissingPreviousHeadRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -EventName 'pull_request_target' `
-                    -PullRequestAction 'synchronize' `
-                    -BaseRevision $strAdvancedBaseCommit `
-                    -HeadRevision $strRebasedTopicCommit `
-                    -IsNewRefRange $false `
-                    -PreviousHeadRevision ('f' * 40) `
-                    -EventHeadRevision '' -EventHeadDistinct '')
-        }
-        catch {
-            $boolMissingPreviousHeadRejected = $_.Exception.Message.Contains(
-                'previous topic head is unavailable',
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolMissingPreviousHeadRejected) {
-            throw 'An unavailable synchronize previous head did not fail closed.'
-        }
-        $boolSamePreviousHeadRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -EventName 'pull_request_target' `
-                    -PullRequestAction 'synchronize' `
-                    -BaseRevision $strAdvancedBaseCommit `
-                    -HeadRevision $strRebasedTopicCommit `
-                    -IsNewRefRange $false `
-                    -PreviousHeadRevision $strRebasedTopicCommit `
-                    -EventHeadRevision '' -EventHeadDistinct '')
-        }
-        catch {
-            $boolSamePreviousHeadRejected = $_.Exception.Message.Contains(
-                'distinct valid previous topic head',
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolSamePreviousHeadRejected) {
-            throw 'A synchronize event accepted the new head as its previous head.'
-        }
-        foreach ($strHistoryOnlyAction in @('opened', 'reopened')) {
-            $boolUnexpectedPreviousHeadRejected = $false
-            try {
-                [void](Get-MetadataEventRevisionContext `
-                        -RepositoryRootPath $strMergeFixtureRoot `
-                        -EventName 'pull_request_target' `
-                        -PullRequestAction $strHistoryOnlyAction `
-                        -BaseRevision $strAdvancedBaseCommit `
-                        -HeadRevision $strRebasedTopicCommit `
-                        -IsNewRefRange $false `
-                        -PreviousHeadRevision $strMergeTopicCommit `
-                        -EventHeadRevision '' -EventHeadDistinct '')
-            }
-            catch {
-                $boolUnexpectedPreviousHeadRejected = $_.Exception.Message.Contains(
-                    'must not supply a previous head',
-                    [StringComparison]::Ordinal
-                )
-            }
-            if (-not $boolUnexpectedPreviousHeadRejected) {
-                throw "$strHistoryOnlyAction accepted a previous-head field."
-            }
-        }
-        $arrAdvancedBaseHistoryFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $objSynchronizeContext.HistoryBaseRevision `
-                -Head $strSynchronizedTopicCommit)
-        if ($arrAdvancedBaseHistoryFailures.Count -ne 0) {
-            throw 'Merge-base history validation rejected an advanced-base topic.'
-        }
-        $arrAdvancedBaseTrustFailures = @(Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $strMergeBaseCommit `
-                -HeadRevision $strSynchronizedTopicCommit `
-                -RepositoryRelativePath $script:arrTrustRootPaths)
-        if ($arrAdvancedBaseTrustFailures.Count -ne 0) {
-            throw 'A base-only trust-root change was attributed to the topic.'
-        }
-        $arrBaseTipTrustFailures = @(Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $strAdvancedTrustBaseCommit `
-                -HeadRevision $strSynchronizedTopicCommit `
-                -RepositoryRelativePath $script:arrTrustRootPaths)
-        if ($arrBaseTipTrustFailures.Count -ne 1) {
-            throw 'The advanced-base trust-root reproduction did not distinguish the base tip.'
-        }
-        $arrTopicTrustFailures = @(Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $strMergeBaseCommit `
-                -HeadRevision $strTopicTrustCommit `
-                -RepositoryRelativePath $script:arrTrustRootPaths)
-        if ($arrTopicTrustFailures.Count -ne 1 -or
-            -not ($arrTopicTrustFailures -match [regex]::Escape('.gitattributes'))) {
-            throw 'A topic trust-root change did not fail closed.'
-        }
-        $strMixedPolicyPreBase = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAbsentHistoryTree -Parents @() `
-            -Timestamp ($strMergeHistoricalDate + 'T12:50:00Z') `
-            -Message 'mixed policy pre-base'
-        $strMixedPolicyActiveBase = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strMixedPolicyPreBase) `
-            -Timestamp ($strMergeHistoricalDate + 'T12:51:00Z') `
-            -Message 'mixed policy active base'
-        $strMixedPolicyInactiveBase = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAbsentHistoryTree -Parents @($strMixedPolicyPreBase) `
-            -Timestamp ($strMergeHistoricalDate + 'T12:52:00Z') `
-            -Message 'mixed policy inactive base'
-        $strMixedPolicyHead = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents @($strMixedPolicyActiveBase, $strMixedPolicyInactiveBase) `
-            -Timestamp ($strMergeHistoricalDate + 'T12:53:00Z') `
-            -Message 'mixed policy head'
-        $arrMixedPolicyOutsideBases = @(
-            & git -C $strMergeFixtureRoot log --reverse --topo-order `
-                --format=%H "-S$strMetadataRangePolicyMarker" `
-                $strMixedPolicyHead --not $strMixedPolicyActiveBase `
-                $strMixedPolicyInactiveBase -- `
-                '.github/workflows/Test-AgentInstructions.ps1'
-        )
-        if ($LASTEXITCODE -ne 0 -or $arrMixedPolicyOutsideBases.Count -ne 0) {
-            throw 'The mixed-policy fixture did not exclude the active-base introduction.'
-        }
-        $arrMixedPolicyFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base @($strMixedPolicyActiveBase, $strMixedPolicyInactiveBase) `
-                -Head $strMixedPolicyHead)
-        if ($arrMixedPolicyFailures.Count -ne 0) {
-            throw (
-                'A valid mixed-policy best-base range was rejected: ' +
-                ($arrMixedPolicyFailures -join '; ')
-            )
-        }
-        $strCrissCrossLeft = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strMergeBaseCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:00:00Z') `
-            -Message 'criss-cross left'
-        $strCrissCrossSharedMutation = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAdvancedTrustBaseTree -Parents @($strMergeBaseCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:01:00Z') `
-            -Message 'criss-cross shared-history trust mutation'
-        $strCrissCrossRight = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strCrissCrossSharedMutation) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:01:30Z') `
-            -Message 'criss-cross shared-history trust restore'
-        $strCrissCrossMergeLeft = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents @($strCrissCrossLeft, $strCrissCrossRight) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:02:00Z') `
-            -Message 'criss-cross merge left'
-        $strCrissCrossMergeRight = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents @($strCrissCrossRight, $strCrissCrossLeft) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:03:00Z') `
-            -Message 'criss-cross merge right'
-        $arrExpectedCrissCrossBases = @(
-            $strCrissCrossLeft,
-            $strCrissCrossRight
-        ) | Sort-Object
-        $objCrissCrossOpenedContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'pull_request_target' `
-            -PullRequestAction 'opened' `
-            -BaseRevision $strCrissCrossMergeLeft `
-            -HeadRevision $strCrissCrossMergeRight `
-            -IsNewRefRange $false -PreviousHeadRevision '' `
-            -EventHeadRevision '' -EventHeadDistinct ''
-        if ($objCrissCrossOpenedContext.HistoryBaseRevision -cne '' -or
-            $objCrissCrossOpenedContext.FreshnessBaseRevision -cne '' -or
-            (@($objCrissCrossOpenedContext.HistoryBaseRevisions) -join ',') -cne
-                ($arrExpectedCrissCrossBases -join ',') -or
-            (@($objCrissCrossOpenedContext.FreshnessBaseRevisions) -join ',') -cne
-                ($arrExpectedCrissCrossBases -join ',')) {
-            throw 'A valid opened criss-cross range did not retain every best merge base.'
-        }
-        $arrCrissCrossSharedHistoryTrustFailures = @(
-            Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $arrExpectedCrissCrossBases `
-                -HeadRevision $strCrissCrossMergeRight `
-                -RepositoryRelativePath @('.gitattributes')
-        )
-        if ($arrCrissCrossSharedHistoryTrustFailures.Count -ne 0) {
-            throw 'A mutation excluded by another best base was attributed to the topic.'
-        }
-        $arrCrissCrossSharedHistoryTouchedPaths = @(Read-GitRangeTouchedPath `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $arrExpectedCrissCrossBases `
-                -HeadRevision $strCrissCrossMergeRight `
-                -IsNewRefRange $false `
-                -RepositoryRelativePathspec ':(top)**' `
-                -MaximumBytes $intGitPathListMaximumBytes)
-        if ($arrCrissCrossSharedHistoryTouchedPaths -ccontains '.gitattributes') {
-            throw 'The combined best-base path walk included excluded shared history.'
-        }
-        $strCrissCrossTopicTrustCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAdvancedTrustBaseTree `
-            -Parents @($strCrissCrossMergeRight) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:03:30Z') `
-            -Message 'criss-cross topic trust mutation'
-        $arrCrissCrossTopicTrustFailures = @(Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $arrExpectedCrissCrossBases `
-                -HeadRevision $strCrissCrossTopicTrustCommit `
-                -RepositoryRelativePath @('.gitattributes'))
-        if ($arrCrissCrossTopicTrustFailures.Count -ne 1) {
-            throw 'A topic-owned mutation after all best bases did not fail closed.'
-        }
-        $strCrissCrossCurrentHead = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strCrissCrossMergeRight) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:04:00Z') `
-            -Message 'criss-cross synchronize current head'
-        $objCrissCrossSynchronizeContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'pull_request_target' `
-            -PullRequestAction 'synchronize' `
-            -BaseRevision $strCrissCrossMergeLeft `
-            -HeadRevision $strCrissCrossCurrentHead `
-            -IsNewRefRange $false `
-            -PreviousHeadRevision $strCrissCrossMergeRight `
-            -EventHeadRevision '' -EventHeadDistinct ''
-        if ((@($objCrissCrossSynchronizeContext.HistoryBaseRevisions) -join ',') -cne
-                ($arrExpectedCrissCrossBases -join ',') -or
-            $objCrissCrossSynchronizeContext.FreshnessBaseRevision -cne
-                $strCrissCrossMergeRight -or
-            $objCrissCrossSynchronizeContext.PreviousTopicBaseRevision -cne '' -or
-            $objCrissCrossSynchronizeContext.CurrentTopicBaseRevision -cne '') {
-            throw 'A valid synchronize criss-cross range used an incomplete base contract.'
-        }
-        $listExcessiveMergeBases = [Collections.Generic.List[string]]::new()
-        for ($intBaseIndex = 0; $intBaseIndex -lt 65; $intBaseIndex++) {
-            $listExcessiveMergeBases.Add(
-                (& $scriptBlockCreateMergeFixtureCommit `
-                    -Tree $strMergeBaseTree -Parents @($strMergeBaseCommit) `
-                    -Timestamp ([DateTimeOffset]::Parse(
-                            $strMergeHistoricalDate + 'T14:00:00Z'
-                        ).AddSeconds($intBaseIndex).ToString('o')) `
-                    -Message "excessive merge base $intBaseIndex")
-            )
-        }
-        $arrExcessiveMergeBases = $listExcessiveMergeBases.ToArray()
-        $strExcessiveMergeLeft = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents $arrExcessiveMergeBases `
-            -Timestamp ($strMergeHistoricalDate + 'T14:02:00Z') `
-            -Message 'excessive merge-base left'
-        [array]::Reverse($arrExcessiveMergeBases)
-        $strExcessiveMergeRight = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents $arrExcessiveMergeBases `
-            -Timestamp ($strMergeHistoricalDate + 'T14:03:00Z') `
-            -Message 'excessive merge-base right'
-        $boolExcessiveMergeBasesRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -EventName 'pull_request_target' -PullRequestAction 'opened' `
-                    -BaseRevision $strExcessiveMergeLeft `
-                    -HeadRevision $strExcessiveMergeRight `
-                    -IsNewRefRange $false -PreviousHeadRevision '' `
-                    -EventHeadRevision '' -EventHeadDistinct '')
-        }
-        catch {
-            $boolExcessiveMergeBasesRejected = $_.Exception.Message.Contains(
-                'must have 1 through 64 available merge bases',
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolExcessiveMergeBasesRejected) {
-            throw 'A pull request with more than 64 best merge bases did not fail closed.'
-        }
-        $strInheritedMergeCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeTopicTree `
-            -Parents @($strAdvancedBaseCommit, $strMergeTopicCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture inherited result'
-        $arrInheritedMergeFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strAdvancedBaseCommit -Head $strInheritedMergeCommit `
-                -RequireCommitDate $true)
-        if ($arrInheritedMergeFailures.Count -ne 0) {
-            throw (
-                'A merge that inherited governed content from its non-first parent failed: ' +
-                ($arrInheritedMergeFailures -join '; ')
-            )
-        }
-        $objCreatedMergeContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'push' -PullRequestAction '' `
-            -BaseRevision ('0' * 40) -HeadRevision $strInheritedMergeCommit `
-            -IsNewRefRange $true -PreviousHeadRevision '' `
-            -EventHeadRevision $strInheritedMergeCommit -EventHeadDistinct 'true' `
-            -NewRefCommitCount '1' `
-            -NewRefCommitEvidenceJson (ConvertTo-Json -Compress `
-                -InputObject @($strInheritedMergeCommit))
-        $arrCreatedMergeBoundaries = @(
-            $objCreatedMergeContext.FreshnessBaseRevisions
-        )
-        if ($objCreatedMergeContext.FreshnessBaseRevision -cne '' -or
-            $arrCreatedMergeBoundaries.Count -ne 2 -or
-            $arrCreatedMergeBoundaries -cnotcontains $strAdvancedBaseCommit -or
-            $arrCreatedMergeBoundaries -cnotcontains $strMergeTopicCommit) {
-            throw 'A valid created-ref merge did not retain both authenticated boundaries.'
-        }
-        $strReorderedMergeEvidence = ConvertTo-Json -Compress -InputObject @(
-            $strInheritedMergeCommit,
-            $strMergeTopicCommit,
-            $strAdvancedBaseCommit
-        )
-        $objReorderedMergeContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'push' -PullRequestAction '' `
-            -BaseRevision ('0' * 40) -HeadRevision $strInheritedMergeCommit `
-            -IsNewRefRange $true -PreviousHeadRevision '' `
-            -EventHeadRevision $strInheritedMergeCommit -EventHeadDistinct 'true' `
-            -NewRefCommitCount '3' `
-            -NewRefCommitEvidenceJson $strReorderedMergeEvidence
-        if ($objReorderedMergeContext.FreshnessBaseRevision -cne
-                $strMergeBaseCommit -or
-            @($objReorderedMergeContext.FreshnessBaseRevisions).Count -ne 1 -or
-            $objReorderedMergeContext.FreshnessBaseRevisions[0] -cne
-                $strMergeBaseCommit) {
-            throw 'Reordered exact created-ref DAG evidence was rejected or misbounded.'
-        }
-        $strFutureTopicCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeTopicTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp '2099-12-31T12:00:00Z' `
-            -Message 'merge fixture future topic'
-        $arrFutureTopicFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strMergeBaseCommit -Head $strFutureTopicCommit)
-        if (-not ($arrFutureTopicFailures -join '; ').Contains(
-                "Metadata range commit $strFutureTopicCommit timestamp",
-                [StringComparison]::Ordinal
-            )) {
-            throw 'An ordinary future commit timestamp did not fail closed.'
-        }
-        $strUniqueMergeContent = $strMergeTopicContent.Replace(
-            $strMergeHistoricalDate.Replace('-', '') + '.1',
-            $strMergeHistoricalDate.Replace('-', '') + '.2'
-        ) +
-            [Environment]::NewLine + 'Merge-authored content with stale metadata.'
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strUniqueMergeContent,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strUniqueMergeTree = ([string] (& git -C $strMergeFixtureRoot write-tree)).Trim()
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not create the unique merge-transition tree.'
-        }
-        $strUniqueMergeCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strUniqueMergeTree `
-            -Parents @($strAdvancedBaseCommit, $strMergeTopicCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture unique result'
-        $arrUniqueMergeFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strAdvancedBaseCommit -Head $strUniqueMergeCommit `
-                -RequireCommitDate $true)
-        if ($arrUniqueMergeFailures.Count -eq 0 -or
-            -not ($arrUniqueMergeFailures -join '; ').Contains(
-                "Last Updated must be $strMergeCurrentDate",
-                [StringComparison]::Ordinal
-            )) {
-            throw 'Merge-authored stale metadata did not fail the commit-date rule.'
-        }
-        $arrUniqueFreshnessFailures = @(Get-CurrentInputMetadataFreshnessFailure `
-                -Name 'AGENTS.md' `
-                -CurrentContent $strUniqueMergeContent `
-                -BaseContent $strMergeBaseContent `
-                -TrustedEventUtcDate $strMergeCurrentDate)
-        if (-not ($arrUniqueFreshnessFailures -join '; ').Contains(
-                "Last Updated must be $strMergeCurrentDate",
-                [StringComparison]::Ordinal
-            )) {
-            throw 'Trusted current-input freshness accepted stale merge metadata.'
-        }
-
-        $strNewerParentContent = $strAgentsContent +
-            [Environment]::NewLine + 'Newer first-parent merge fixture.'
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strNewerParentContent,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strNewerParentTree = ([string] (& git -C $strMergeFixtureRoot write-tree)).Trim()
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not create the newer merge-parent tree.'
-        }
-        $strNewerParentCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strNewerParentTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture newer parent'
-        $strRegressingMergeCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeTopicTree `
-            -Parents @($strNewerParentCommit, $strMergeTopicCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture regressing inherited result'
-        $arrRegressingMergeFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strNewerParentCommit -Head $strRegressingMergeCommit `
-                -RequireCommitDate $true)
-        if ($arrRegressingMergeFailures.Count -eq 0 -or
-            -not ($arrRegressingMergeFailures -join '; ').Contains(
-                'Version date must not move backward',
-                [StringComparison]::Ordinal
-            )) {
-            throw 'An inherited merge metadata rollback did not fail closed.'
-        }
-        $strBackwardBaseCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strNewerParentTree -Parents @($strRegressingMergeCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'backward push base fixture'
-        $arrBackwardRangeCommits = @(& git -C $strMergeFixtureRoot rev-list `
-                "$strBackwardBaseCommit..$strRegressingMergeCommit")
-        $arrBackwardEndpointPaths = @(& git -C $strMergeFixtureRoot diff `
-                --name-only $strBackwardBaseCommit $strRegressingMergeCommit --)
-        $arrBackwardHeadFailures = @(Get-GovernedDocumentCommitTransitionFailure `
-                -Name 'AGENTS.md' -RepositoryRootPath $strMergeFixtureRoot `
-                -RepositoryRelativePath 'AGENTS.md' `
-                -MaximumBytes $intAgentsMaximumInputBytes `
-                -CommitRevision $strRegressingMergeCommit `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes 1024 -PolicyMarker $strMetadataRangePolicyMarker `
-                -RequireExpectedUtcDateForRenderedChange $true)
-        if ($arrBackwardRangeCommits.Count -ne 0 -or
-            $arrBackwardEndpointPaths.Count -ne 1 -or
-            $arrBackwardEndpointPaths[0] -cne 'AGENTS.md' -or
-            -not (Test-BackwardCommitMove -RepositoryRootPath $strMergeFixtureRoot `
-                    -BaseRevision $strBackwardBaseCommit `
-                    -HeadRevision $strRegressingMergeCommit) -or
-            (Test-BackwardCommitMove -RepositoryRootPath $strMergeFixtureRoot `
-                    -BaseRevision $strRegressingMergeCommit `
-                    -HeadRevision $strBackwardBaseCommit) -or
-            -not ($arrBackwardHeadFailures -join '; ').Contains(
-                'Version date must not move backward',
-                [StringComparison]::Ordinal
-            )) {
-            throw 'A reused backward target did not receive exact direct transition validation.'
-        }
-        $listExcessParents = [Collections.Generic.List[string]]::new()
-        foreach ($intFixtureParent in 1..($intMetadataMaximumParents + 1)) {
-            $listExcessParents.Add((& $scriptBlockCreateMergeFixtureCommit `
-                        -Tree $strMergeBaseTree `
-                        -Parents @($strMergeBaseCommit) `
-                        -Timestamp ($strMergeHistoricalDate + 'T12:00:00Z') `
-                        -Message "merge fixture excess parent $intFixtureParent"))
-        }
-        $strExcessParentMerge = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents $listExcessParents.ToArray() `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture excessive parent count'
-        $boolExcessParentCountRejected = $false
-        try {
-            [void](& $scriptBlockGetMergeRangeFailure `
-                    -Base $strMergeBaseCommit -Head $strExcessParentMerge)
-        }
-        catch {
-            $boolExcessParentCountRejected = $_.Exception.Message.Contains(
-                "maximum is $intMetadataMaximumParents",
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolExcessParentCountRejected) {
-            throw 'An excessive metadata merge-parent count did not fail closed.'
-        }
-        $boolExcessEvidenceParentCountRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -EventName 'push' -PullRequestAction '' `
-                    -BaseRevision ('0' * 40) -HeadRevision $strExcessParentMerge `
-                    -IsNewRefRange $true -PreviousHeadRevision '' `
-                    -EventHeadRevision $strExcessParentMerge `
-                    -EventHeadDistinct 'true' -NewRefCommitCount '1' `
-                    -NewRefCommitEvidenceJson (ConvertTo-Json -Compress `
-                        -InputObject @($strExcessParentMerge)))
-        }
-        catch {
-            $boolExcessEvidenceParentCountRejected = $_.Exception.Message.Contains(
-                "the maximum is $intMetadataMaximumParents",
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolExcessEvidenceParentCountRejected) {
-            throw 'Excessive created-ref merge-parent evidence did not fail closed.'
-        }
-    }
-    finally {
-        if ($boolHadAuthorDate) {
-            $env:GIT_AUTHOR_DATE = $strOriginalAuthorDate
-        }
-        else {
-            Remove-Item -LiteralPath Env:GIT_AUTHOR_DATE -ErrorAction SilentlyContinue
-        }
-        if ($boolHadCommitterDate) {
-            $env:GIT_COMMITTER_DATE = $strOriginalCommitterDate
-        }
-        else {
-            Remove-Item -LiteralPath Env:GIT_COMMITTER_DATE -ErrorAction SilentlyContinue
-        }
-        if ([System.IO.Directory]::Exists($strMergeFixtureRoot) -and
-            $strMergeFixtureRoot.StartsWith(
-                $strSystemTempRoot,
-                [StringComparison]::OrdinalIgnoreCase
-            )) {
-            Remove-Item -LiteralPath $strMergeFixtureRoot -Recurse -Force
-        }
-    }
-
-    $strRevisionMismatchFixture = [string] (
-        & git -C $strRepositoryRootPath rev-parse --verify HEAD^1
-    )
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Could not resolve the revision-mismatch self-test fixture.'
-    }
-    $boolRevisionMismatchRejected = $false
-    try {
-        [void](Get-GovernedDocumentRangeTransitionFailure `
-                -Name 'AGENTS.md' `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -RepositoryRelativePath 'AGENTS.md' `
-                -MaximumBytes $intAgentsMaximumInputBytes `
-                -BaseRevision $strNewRefTestHead `
-                -HeadRevision $strNewRefTestHead `
-                -InputRevision $strRevisionMismatchFixture.Trim() `
-                -IsNewRefRange $false `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-                -PolicyMarker $strMetadataRangePolicyMarker)
-    }
-    catch {
-        $boolRevisionMismatchRejected = $_.Exception.Message.Contains(
-            'does not match the validation revision',
-            [StringComparison]::Ordinal
-        )
-    }
-    if (-not $boolRevisionMismatchRejected) {
-        throw 'A mismatched explicit validation revision did not fail closed.'
+    if ([string]::IsNullOrEmpty($strMergeCurrentTimestamp) -or
+        [string]::IsNullOrEmpty($strMergeBaseContent) -or
+        [string]::IsNullOrEmpty($strRationaleFixturePrePolicy)) {
+        throw 'The shared merge fixture scaffold did not produce content.'
     }
 
     $strAgentWorkflowContent = [IO.File]::ReadAllText(
         [IO.Path]::Combine($PSScriptRoot, 'agent-instructions.yml')
     )
     $strValidatorSourceContent = [IO.File]::ReadAllText($PSCommandPath)
-    if ($strValidatorSourceContent -notmatch
-        '\(\$EventName -ceq ''push'' -and -not \$RangeIsNewRef\)' -or
-        $strValidatorSourceContent -notmatch
-        '\$boolCommitDateOnlyEvent = \$EventName -ceq ''pull_request_target''') {
-        throw 'Commit-date range freshness selectors are incomplete.'
+    $arrLegacyCompatibilityVariableName = @(
+        'script:strLegacyMetadataRangeCompatibilityMarker',
+        'script:strLegacyStyleGuideRationaleCompatibilityMarker',
+        'script:strLegacyOperationalLintGuideCompatibilityMarker'
+    )
+    $arrLegacyCompatibilityMarker = @(
+        $script:strLegacyMetadataRangeCompatibilityMarker,
+        $script:strLegacyStyleGuideRationaleCompatibilityMarker,
+        $script:strLegacyOperationalLintGuideCompatibilityMarker
+    )
+    $arrExpectedLegacyCompatibilityMarker = @(
+        'metadata-range-transition-policy-v1',
+        'style-guide-rationale-metadata-policy-v1',
+        'operational-lint-guide-metadata-policy-v1'
+    )
+    if ([string]::Join("`n", $arrLegacyCompatibilityMarker) -cne
+        [string]::Join("`n", $arrExpectedLegacyCompatibilityMarker)) {
+        throw 'The inert trusted-bootstrap compatibility inventory changed.'
     }
-    if (@($objValidatorAst.FindAll({
+    for ($intLegacyIndex = 0;
+        $intLegacyIndex -lt $arrLegacyCompatibilityVariableName.Count;
+        $intLegacyIndex++) {
+        $strLegacyVariableLiteral = [char] 36 +
+            $arrLegacyCompatibilityVariableName[$intLegacyIndex]
+        if ([regex]::Matches(
+                $strValidatorSourceContent,
+                [regex]::Escape($strLegacyVariableLiteral)
+            ).Count -ne 2) {
+            throw 'Active policy reads an inert trusted-bootstrap compatibility constant.'
+        }
+        $strUnqualifiedLegacyLiteral = [char] 36 +
+            $arrLegacyCompatibilityVariableName[$intLegacyIndex].Substring(7)
+        if ([regex]::Matches(
+                $strValidatorSourceContent,
+                '(?<![\w:])' + [regex]::Escape($strUnqualifiedLegacyLiteral)
+            ).Count -ne 0) {
+            throw 'An unqualified legacy compatibility constant remains.'
+        }
+        $strMutatedLegacySource = $strValidatorSourceContent.Replace(
+            $arrExpectedLegacyCompatibilityMarker[$intLegacyIndex],
+            $arrExpectedLegacyCompatibilityMarker[$intLegacyIndex] + '-mutated'
+        )
+        if ($strMutatedLegacySource -ceq $strValidatorSourceContent -or
+            $strMutatedLegacySource.Contains(
+                "    '$($arrExpectedLegacyCompatibilityMarker[$intLegacyIndex])'",
+                [StringComparison]::Ordinal
+            )) {
+            throw 'A legacy compatibility inventory mutation was not detected.'
+        }
+    }
+    $arrLegacyCompatibilityAssignments = @($objValidatorAst.FindAll({
                 param($objNode)
-                $objNode -is [Management.Automation.Language.VariableExpressionAst] -and
-                $objNode.VariablePath.UserPath -ceq 'strTrustedEventUtcDate'
-            }, $true)).Count -ne 0) {
-        throw 'A push-event endpoint equality clock remains active.'
+                $objNode -is
+                    [Management.Automation.Language.AssignmentStatementAst] -and
+                $objNode.Left -is
+                    [Management.Automation.Language.VariableExpressionAst] -and
+                $arrLegacyCompatibilityVariableName -ccontains
+                    $objNode.Left.VariablePath.UserPath
+            }, $true))
+    $strForbiddenLegacySuppressionRule =
+        'PSUseDeclaredVarsMore' + 'ThanAssignments'
+    if ($arrLegacyCompatibilityAssignments.Count -ne 3 -or
+        $strValidatorSourceContent.Contains(
+            $strForbiddenLegacySuppressionRule,
+            [StringComparison]::Ordinal
+        )) {
+        throw 'The scoped inert compatibility declaration inventory is invalid.'
+    }
+    foreach ($strRemovedTransitionIdentity in @(
+            ('PreviousHead' + 'Revision'), ('NewRefCommit' + 'Count'),
+            ('NewRefCommitEvidence' + 'Json'),
+            ('Test-HistoricalPolicy' + 'Marker'),
+            ('Get-MetadataEventRevision' + 'Context')
+        )) {
+        if ($strValidatorSourceContent.Contains(
+                $strRemovedTransitionIdentity,
+                [StringComparison]::Ordinal
+            )) {
+            throw "Transition-only validator identity remains: $strRemovedTransitionIdentity"
+        }
     }
     foreach ($objNestedLintDocumentation in @(
             [pscustomobject]@{
@@ -11874,7 +8811,18 @@ if ($SelfTest) {
                 'PUSH_DELETED: ${{ github.event.deleted }}',
                 'refs/remotes/event/push-base',
                 'refs/remotes/event/pr-head',
-                'refs/remotes/event/pr-previous-head',
+                'id: created-push-boundary',
+                'git ls-remote --refs --heads --tags origin',
+                'refs/remotes/event/created-other-%04d',
+                'cmp --silent "${raw_refs}" "${raw_refs_after}"',
+                'AGENT_INSTRUCTION_DESTINATION_REF:',
+                'AGENT_INSTRUCTION_PUSH_COMMIT_EVIDENCE:',
+                '-OtherRefEvidenceJson',
+                'id: trust-root-authorization',
+                '-AuthorizationApplicabilityOnly',
+                '-TrustedMaintenanceAuthorizationValidated:',
+                'permissions:',
+                '  contents: read',
                 '      - edited',
                 "github.event.action != 'edited' ||",
                 "github.event.changes.base.ref.from != ''",
@@ -11882,18 +8830,14 @@ if ($SelfTest) {
                 '-PullRequestBaseChanged $env:AGENT_INSTRUCTION_PULL_REQUEST_BASE_CHANGED',
                 'test "${fetched_base}" = "${PUSH_BASE_SHA}"',
                 'test "${fetched_head}" = "${PR_HEAD_SHA}"',
-                'test "${fetched_previous_head}" = "${PR_PREVIOUS_HEAD_SHA}"',
-                'github.event.action == ''synchronize'' && github.event.before',
-                'AGENT_INSTRUCTION_EVENT_HEAD_REVISION:',
-                'github.event.head_commit.id',
-                'AGENT_INSTRUCTION_EVENT_HEAD_DISTINCT:',
-                'toJSON(github.event.head_commit.distinct)',
-                '-EventHeadRevision $env:AGENT_INSTRUCTION_EVENT_HEAD_REVISION',
-                '-EventHeadDistinct $env:AGENT_INSTRUCTION_EVENT_HEAD_DISTINCT',
-                'github.event.size',
-                'toJSON(github.event.commits.*.id)',
-                '-NewRefCommitCount $env:AGENT_INSTRUCTION_NEW_REF_COMMIT_COUNT',
-                '-NewRefCommitEvidenceJson $env:AGENT_INSTRUCTION_NEW_REF_COMMITS_JSON',
+                'AGENT_INSTRUCTION_PUBLISHED_BASELINE:',
+                'AGENT_INSTRUCTION_PUBLISHED_FINAL:',
+                'AGENT_INSTRUCTION_PUBLISHED_BASELINE_ABSENT:',
+                'AGENT_INSTRUCTION_PUBLISHED_FINAL_DELETED:',
+                '-PublishedBaselineRevision $env:AGENT_INSTRUCTION_PUBLISHED_BASELINE',
+                '-PublishedFinalRevision $env:AGENT_INSTRUCTION_PUBLISHED_FINAL',
+                'github.event.repository.pushed_at',
+                'github.event.pull_request.updated_at',
                 'persist-credentials: false',
                 'ref: ${{ github.sha }}'
             )) {
@@ -11910,27 +8854,26 @@ if ($SelfTest) {
             $Content -cmatch '"\+[^" ]+:') {
             $listFailures.Add('Event-data fetches must not force a destination ref.')
         }
-        if ($Content -cmatch
-            '(?s)AGENT_INSTRUCTION_EVENT_HEAD_REVISION:.{0,300}github\.event\.commits\.\*\.id') {
-            $listFailures.Add(
-                'The bounded push commits array must not decide head introduction.'
-            )
-        }
-        if ($Content.Contains(
-                'github.event.pull_request.updated_at',
-                [StringComparison]::Ordinal
+        foreach ($strForbiddenTransitionLiteral in @(
+                'PR_PREVIOUS_HEAD_SHA', 'refs/remotes/event/pr-previous-head',
+                'AGENT_INSTRUCTION_NEW_REF_COMMITS_JSON'
             )) {
-            $listFailures.Add(
-                'Pull request metadata freshness must use commit dates.'
-            )
+            if ($Content.Contains(
+                    $strForbiddenTransitionLiteral,
+                    [StringComparison]::Ordinal
+                )) {
+                $listFailures.Add(
+                    "Workflow retains transition-only input: $strForbiddenTransitionLiteral"
+                )
+            }
         }
         $intExpensiveGateCount = [regex]::Matches(
             $Content,
             "steps\.push-applicability\.outputs\.required == 'true'"
         ).Count
-        if ($intExpensiveGateCount -ne 5) {
+        if ($intExpensiveGateCount -ne 6) {
             $listFailures.Add(
-                'All five expensive validation steps require the applicability gate.'
+                'All six expensive validation steps require the applicability gate.'
             )
         }
 
@@ -11987,20 +8930,12 @@ if ($SelfTest) {
             Expected = 'push must not use a paths or paths-ignore filter.'
         },
         [pscustomobject]@{
-            Name = 'forcing previous-head fetch'
+            Name = 'forcing pull request head fetch'
             Content = $strAgentWorkflowContent.Replace(
-                '"${PR_PREVIOUS_HEAD_SHA}:refs/remotes/event/pr-previous-head"',
-                '"+${PR_PREVIOUS_HEAD_SHA}:refs/remotes/event/pr-previous-head"'
+                '"${PR_HEAD_SHA}:refs/remotes/event/pr-head"',
+                '"+${PR_HEAD_SHA}:refs/remotes/event/pr-head"'
             )
             Expected = 'Event-data fetches must not force a destination ref.'
-        },
-        [pscustomobject]@{
-            Name = 'missing previous-head identity proof'
-            Content = $strAgentWorkflowContent.Replace(
-                'test "${fetched_previous_head}" = "${PR_PREVIOUS_HEAD_SHA}"',
-                'test -n "${fetched_previous_head}"'
-            )
-            Expected = 'Workflow contract literal is missing: test'
         },
         [pscustomobject]@{
             Name = 'persisted checkout credential'
@@ -12011,20 +8946,12 @@ if ($SelfTest) {
             Expected = 'Workflow contract literal is missing: persist-credentials: false'
         },
         [pscustomobject]@{
-            Name = 'bounded push commit-list head evidence'
-            Content = $strAgentWorkflowContent.Replace(
-                'github.event.head_commit.id',
-                'github.event.commits.*.id'
-            )
-            Expected = 'The bounded push commits array must not decide head introduction.'
-        },
-        [pscustomobject]@{
             Name = 'ungated expensive steps'
             Content = $strAgentWorkflowContent.Replace(
                 "steps.push-applicability.outputs.required == 'true'",
                 "steps.push-applicability.outputs.required != 'false'"
             )
-            Expected = 'All five expensive validation steps require the applicability gate.'
+            Expected = 'All six expensive validation steps require the applicability gate.'
         },
         [pscustomobject]@{
             Name = 'missing edited trigger'
@@ -12051,13 +8978,12 @@ if ($SelfTest) {
             Expected = 'Workflow contract literal is missing: -PullRequestBaseChanged'
         },
         [pscustomobject]@{
-            Name = 'mutable pull request activity timestamp'
-            Content = $strAgentWorkflowContent -replace (
-                "github.event_name == 'push' &&\r?\n\s+" +
-                'github.event.repository.pushed_at'
-            ),
-                'github.event.pull_request.updated_at'
-            Expected = 'Pull request metadata freshness must use commit dates.'
+            Name = 'missing pull request final-state timestamp'
+            Content = $strAgentWorkflowContent.Replace(
+                'github.event.pull_request.updated_at',
+                'github.event.pull_request.created_at'
+            )
+            Expected = 'Workflow contract literal is missing: github.event.pull_request.updated_at'
         }
     )
     foreach ($objWorkflowMutation in $arrWorkflowMutations) {
@@ -12079,25 +9005,36 @@ if ($SelfTest) {
         }
     }
 
-    $arrUnchangedFailures = @(Get-TrustRootRangeMutationFailure `
+    $arrUnchangedFailures = @(
+        Get-TrustRootRangeMutationFailure `
             -RepositoryRootPath $strRepositoryRootPath `
             -BaseRevision $strNewRefTestHead `
             -HeadRevision $strNewRefTestHead `
-            -RepositoryRelativePath $script:arrTrustRootPaths)
-    if ($arrUnchangedFailures.Count -ne 0) {
-        throw 'An unchanged trusted validation range did not pass.'
+            -RepositoryRelativePath $script:arrTrustRootPaths |
+            Sort-Object -Unique
+    )
+    if ($arrUnchangedFailures -isnot [array] -or
+        $arrUnchangedFailures.Count -ne 0) {
+        throw 'The zero-result trust-root array regression did not pass.'
     }
     $strTrustRootBase = [string] (
         & git -C $strRepositoryRootPath rev-list --max-parents=0 HEAD |
             Select-Object -First 1
     )
-    $arrTrustRootFailures = @(Get-TrustRootRangeMutationFailure `
+    $arrTrustRootFailures = @(
+        Get-TrustRootRangeMutationFailure `
             -RepositoryRootPath $strRepositoryRootPath `
             -BaseRevision $strTrustRootBase.Trim() `
             -HeadRevision $strNewRefTestHead `
-            -RepositoryRelativePath $script:arrTrustRootPaths)
+            -RepositoryRelativePath $script:arrTrustRootPaths |
+            Sort-Object -Unique
+    )
     if ($LASTEXITCODE -ne 0) {
         throw 'The trusted validation mutation query leaked a nonzero native status.'
+    }
+    if ($arrTrustRootFailures -isnot [array] -or
+        $arrTrustRootFailures.Count -le 1) {
+        throw 'The many-result trust-root array regression did not pass.'
     }
     $arrHistoricallyChangedTrustPaths = @(
         & git -C $strRepositoryRootPath diff --name-only --no-renames `
@@ -12120,15 +9057,19 @@ if ($SelfTest) {
     if ($arrTrustRootFailures.Count -ne $arrHistoricallyChangedTrustPaths.Count) {
         throw 'The trusted validation mutation test returned an unexpected failure count.'
     }
-    $arrAttributeOnlyFailures = @(Get-TrustRootRangeMutationFailure `
+    $arrAttributeOnlyFailures = @(
+        Get-TrustRootRangeMutationFailure `
             -RepositoryRootPath $strRepositoryRootPath `
             -BaseRevision $strTrustRootBase.Trim() `
             -HeadRevision $strNewRefTestHead `
-            -RepositoryRelativePath @('.gitattributes'))
-    if ($arrAttributeOnlyFailures.Count -ne 1 -or
+            -RepositoryRelativePath @('.gitattributes') |
+            Sort-Object -Unique
+    )
+    if ($arrAttributeOnlyFailures -isnot [array] -or
+        $arrAttributeOnlyFailures.Count -ne 1 -or
         -not ($arrAttributeOnlyFailures -match
             [regex]::Escape('changes trusted validation path .gitattributes.'))) {
-        throw 'An attribute-only trust-root query did not fail closed.'
+        throw 'The one-result trust-root array regression did not fail closed.'
     }
 
     $strMetadataNormalizationBase = @(

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -5323,200 +5323,6 @@ function Get-PublishedEndpointMetadataFailure {
     }
 }
 
-function Read-GitIntroducedCommitRevision {
-    # .SYNOPSIS
-    # Reads a bounded authenticated introduced commit set.
-    # .DESCRIPTION
-    # Returns commits reachable from one exact head and not reachable from any
-    # authenticated base. The result fails closed above the configured cap.
-    # .PARAMETER RepositoryRootPath
-    # The absolute path of the trusted Git repository.
-    # .PARAMETER HeadRevision
-    # The exact authenticated head commit.
-    # .PARAMETER BaseRevision
-    # One through 64 authenticated commits that bound the introduced history.
-    # .EXAMPLE
-    # Read-GitIntroducedCommitRevision @hashtableArguments
-    #
-    # # Returns commits reachable from the head and outside every base.
-    # .INPUTS
-    # None. No pipeline input.
-    # .OUTPUTS
-    # [string] Zero or more commit IDs.
-    # .NOTES
-    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
-    # Parameters, return shape, and positional contract can change without notice.
-    # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260831.0.
-    [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory)][string] $RepositoryRootPath,
-        [Parameter(Mandatory)][string] $HeadRevision,
-        [Parameter(Mandatory)][AllowEmptyCollection()][string[]] $BaseRevision
-    )
-
-    $arrBases = @($BaseRevision)
-    if ($arrBases.Count -lt 1 -or
-        $arrBases.Count -gt $intMetadataMaximumBoundaries) {
-        throw 'Introduced history requires 1 through 64 authenticated bases.'
-    }
-    $arrArguments = @(
-        '-C', $RepositoryRootPath, 'rev-list', '--topo-order',
-        "--max-count=$($intMaximumIntroducedCommitCount + 1)",
-        $HeadRevision, '--not'
-    ) + $arrBases
-    $arrCommits = @(
-        & git @arrArguments 2>$null |
-            ForEach-Object { ([string] $_).Trim() }
-    )
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Could not enumerate authenticated introduced history.'
-    }
-    if ($arrCommits.Count -gt $intMaximumIntroducedCommitCount) {
-        throw "Authenticated introduced history exceeds $intMaximumIntroducedCommitCount commits."
-    }
-    return @($arrCommits)
-}
-
-function Get-GovernedMetadataHistoryFailure {
-    # .SYNOPSIS
-    # Validates every introduced commit transition for one governed document.
-    # .DESCRIPTION
-    # Reads Git blobs as inert data and applies metadata policy to each changed
-    # parent edge. Candidate scripts or workflows are never invoked.
-    # .PARAMETER Name
-    # The trusted document name for diagnostics.
-    # .PARAMETER RepositoryRootPath
-    # The absolute path of the trusted Git repository.
-    # .PARAMETER RepositoryRelativePath
-    # The exact governed document path.
-    # .PARAMETER MaximumBytes
-    # The maximum permitted document byte count.
-    # .PARAMETER CommitRevision
-    # The bounded introduced commit set to validate.
-    # .PARAMETER RequiresVersion
-    # True when the document must contain Version metadata.
-    # .PARAMETER RequiredDocument
-    # True when deletion of the document is prohibited.
-    # .EXAMPLE
-    # Get-GovernedMetadataHistoryFailure @hashtableArguments
-    #
-    # # Returns one diagnostic for each invalid commit transition.
-    # .INPUTS
-    # None. No pipeline input.
-    # .OUTPUTS
-    # [string] Zero or more validation diagnostics.
-    # .NOTES
-    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
-    # Parameters, return shape, and positional contract can change without notice.
-    # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260831.0.
-    [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory)][string] $Name,
-        [Parameter(Mandatory)][string] $RepositoryRootPath,
-        [Parameter(Mandatory)][string] $RepositoryRelativePath,
-        [Parameter(Mandatory)][ValidateRange(1, 2147483646)][int] $MaximumBytes,
-        [Parameter(Mandatory)][AllowEmptyCollection()][string[]] $CommitRevision,
-        [Parameter(Mandatory)][bool] $RequiresVersion,
-        [Parameter(Mandatory)][bool] $RequiredDocument
-    )
-
-    foreach ($strCommit in @($CommitRevision)) {
-        $strCommitAndParents = [string] (& git -C $RepositoryRootPath `
-                rev-list --parents -n 1 $strCommit 2>$null)
-        if ($LASTEXITCODE -ne 0) {
-            throw "Could not inspect metadata transition commit $strCommit."
-        }
-        $arrCommitAndParents = @($strCommitAndParents.Trim() -split '\s+')
-        if ($arrCommitAndParents.Count -lt 1 -or
-            $arrCommitAndParents.Count -gt ($intMetadataMaximumBoundaries + 1) -or
-            $arrCommitAndParents[0] -cne $strCommit) {
-            throw "Git returned invalid metadata parents for $strCommit."
-        }
-        $arrParents = @($arrCommitAndParents | Select-Object -Skip 1)
-        if ($arrParents.Count -eq 0) {
-            $arrParents = @('')
-        }
-        foreach ($strParent in $arrParents) {
-            & git -C $RepositoryRootPath cat-file -e `
-                "$strCommit`:$RepositoryRelativePath" 2>$null
-            $boolCurrentExists = $LASTEXITCODE -eq 0
-            $boolParentExists = $false
-            if (-not [string]::IsNullOrEmpty($strParent)) {
-                & git -C $RepositoryRootPath cat-file -e `
-                    "$strParent`:$RepositoryRelativePath" 2>$null
-                $boolParentExists = $LASTEXITCODE -eq 0
-            }
-            if (-not $boolCurrentExists -and -not $boolParentExists) {
-                continue
-            }
-            $strCurrentBlob = if ($boolCurrentExists) {
-                [string] (& git -C $RepositoryRootPath rev-parse --verify `
-                        "$strCommit`:$RepositoryRelativePath" 2>$null)
-            } else { '' }
-            if ($boolCurrentExists -and $LASTEXITCODE -ne 0) {
-                throw "Could not resolve $Name at $strCommit."
-            }
-            $strParentBlob = if ($boolParentExists) {
-                [string] (& git -C $RepositoryRootPath rev-parse --verify `
-                        "$strParent`:$RepositoryRelativePath" 2>$null)
-            } else { '' }
-            if ($boolParentExists -and $LASTEXITCODE -ne 0) {
-                throw "Could not resolve the parent of $Name at $strCommit."
-            }
-            if ($strCurrentBlob.Trim() -ceq $strParentBlob.Trim()) {
-                continue
-            }
-            if (-not $boolCurrentExists) {
-                if ($RequiredDocument) {
-                    Write-Output "$Name is required and must not be deleted by $strCommit."
-                }
-                continue
-            }
-            $strCurrentContent = Read-GitRevisionText `
-                -RepositoryRootPath $RepositoryRootPath `
-                -Revision $strCommit `
-                -RepositoryRelativePath $RepositoryRelativePath `
-                -MaximumBytes $MaximumBytes `
-                -RequireRegularFile
-            $strParentContent = if ($boolParentExists) {
-                Read-GitRevisionText `
-                    -RepositoryRootPath $RepositoryRootPath `
-                    -Revision $strParent `
-                    -RepositoryRelativePath $RepositoryRelativePath `
-                    -MaximumBytes $MaximumBytes `
-                    -RequireRegularFile
-            } else { $null }
-            $strCommitEpoch = [string] (& git -C $RepositoryRootPath show `
-                    -s --format=%ct $strCommit 2>$null)
-            if ($LASTEXITCODE -ne 0 -or $strCommitEpoch.Trim() -cnotmatch '^\d+$') {
-                throw "Could not read the trusted commit date for $strCommit."
-            }
-            $strCommitUtcDate = (
-                ConvertFrom-TrustedEventTimestamp -Timestamp $strCommitEpoch.Trim()
-            ).ToString('yyyy-MM-dd')
-            if ($RequiresVersion) {
-                Get-PublishedEndpointMetadataFailure `
-                    -Name $Name `
-                    -CurrentContent $strCurrentContent `
-                    -ParentContent $strParentContent `
-                    -ExpectedUtcDate $strCommitUtcDate `
-                    -IsNewDocumentTransition (-not $boolParentExists)
-            }
-            else {
-                Get-PublishedEndpointLastUpdatedFailure `
-                    -Name $Name `
-                    -CurrentContent $strCurrentContent `
-                    -BaseContent $strParentContent `
-                    -TrustedEventUtcDate $strCommitUtcDate
-            }
-        }
-    }
-}
-
 function Get-TrustRootRangeMutationFailure {
     # .SYNOPSIS
     # Finds trust-root changes in endpoints and intervening commits.
@@ -6615,13 +6421,9 @@ elseif (-not [string]::IsNullOrEmpty($DestinationRef) -or
     throw 'Created-push evidence is valid only when the destination ref is new.'
 }
 $arrPublishedGraphBases = @()
-$arrPublishedIntroducedCommits = @()
 if ($boolPublishedEndpointsRequested) {
     if ($PublishedBaselineAbsent) {
         $arrPublishedGraphBases = @($objCreatedRefContext.BoundaryRevisions)
-        $arrPublishedIntroducedCommits = @(
-            $objCreatedRefContext.IntroducedCommitRevisions
-        )
     }
     else {
         $arrPublishedGraphBases = if ($EventName -ceq 'pull_request_target') {
@@ -6631,10 +6433,6 @@ if ($boolPublishedEndpointsRequested) {
                     -RightRevision $PublishedFinalRevision)
         }
         else { @($PublishedBaselineRevision) }
-        $arrPublishedIntroducedCommits = @(Read-GitIntroducedCommitRevision `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -HeadRevision $PublishedFinalRevision `
-                -BaseRevision $arrPublishedGraphBases)
     }
 }
 
@@ -7272,17 +7070,6 @@ foreach ($objDocumentContext in $listGovernedDocumentContexts) {
                 -RequireCurrentMaximumDateForRenderedChange `
                     $objDocumentContext.IsWorktreeTransition)
     }
-    if ($boolPublishedEndpointsRequested -and
-        $arrPublishedIntroducedCommits.Count -gt 0) {
-        $arrRepositoryFailures += @(Get-GovernedMetadataHistoryFailure `
-                -Name $objDocumentContext.Path `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -RepositoryRelativePath $objDocumentContext.Path `
-                -MaximumBytes $objDocumentContext.MaximumBytes `
-                -CommitRevision $arrPublishedIntroducedCommits `
-                -RequiresVersion $objDocumentContext.RequiresVersion `
-                -RequiredDocument $objDocumentContext.RequiredDocument)
-    }
 }
 if ($arrRepositoryFailures.Count -gt 0) {
     throw "Agent-instruction contract failed:`n- $($arrRepositoryFailures -join "`n- ")"
@@ -7315,8 +7102,8 @@ if ($SelfTest) {
         param($objNode)
         $objNode -is [Management.Automation.Language.FunctionDefinitionAst]
     }, $true))
-    if ($arrValidatorFunctionAsts.Count -ne 57) {
-        throw 'The validator function-help inventory must contain exactly 57 functions.'
+    if ($arrValidatorFunctionAsts.Count -ne 55) {
+        throw 'The validator function-help inventory must contain exactly 55 functions.'
     }
     foreach ($objFunctionAst in $arrValidatorFunctionAsts) {
         $objHelp = $objFunctionAst.GetHelpContent()
@@ -9311,7 +9098,9 @@ if ($SelfTest) {
             ('PreviousHead' + 'Revision'), ('NewRefCommit' + 'Count'),
             ('NewRefCommitEvidence' + 'Json'),
             ('Test-HistoricalPolicy' + 'Marker'),
-            ('Get-MetadataEventRevision' + 'Context')
+            ('Get-MetadataEventRevision' + 'Context'),
+            ('Read-GitIntroducedCommit' + 'Revision'),
+            ('Get-GovernedMetadataHistory' + 'Failure')
         )) {
         if ($strValidatorSourceContent.Contains(
                 $strRemovedTransitionIdentity,

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -2,7 +2,7 @@
 # Validates governed agent instructions and optional authenticated Git ranges.
 # .NOTES
 # Positional parameters are not supported.
-# Version: 1.7.20260902.6
+# Version: 1.7.20260902.7
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([string])]
@@ -2161,7 +2161,7 @@ function Get-MarkdownParseContext {
     # .DESCRIPTION
     # Uses the repository-locked markdown-it package to identify code-block ranges,
     # prose blocks with operative code spans and link destinations, top-level
-    # blocks, top-level list items, and level-two headings.
+    # blocks, table rows and cells, top-level list items, and level-two headings.
     # It validates all parser output before returning it.
     #
     # .PARAMETER Content
@@ -2185,7 +2185,7 @@ function Get-MarkdownParseContext {
     # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
     # Parameters, return shape, and positional contract can change without notice.
     # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
+    # Version: 1.0.20260902.0.
     [CmdletBinding(PositionalBinding = $false)]
     [OutputType([pscustomobject])]
     param(
@@ -2228,6 +2228,7 @@ function Get-MarkdownParseContext {
         '  const deletionStack = [];'
         '  const htmlContainerStack = [];'
         '  const output = [];'
+        '  const renderedOutput = [];'
         '  const code = [];'
         '  const links = [];'
         '  for (const child of children) {'
@@ -2259,16 +2260,26 @@ function Get-MarkdownParseContext {
         '      if (typeof href !== "string") throw new Error("Invalid Markdown link destination.");'
         '      links.push(href);'
         '    }'
-        '    if (child.type === "text" || child.type === "text_special") output.push(child.content);'
-        '    else if (child.type === "softbreak" || child.type === "hardbreak") output.push("\n");'
-        '    else if (child.type === "code_inline") code.push(child.content);'
+        '    if (child.type === "text" || child.type === "text_special") {'
+        '      output.push(child.content);'
+        '      renderedOutput.push(child.content);'
+        '    } else if (child.type === "softbreak" || child.type === "hardbreak") {'
+        '      output.push("\n");'
+        '      renderedOutput.push("\n");'
+        '    } else if (child.type === "code_inline") {'
+        '      code.push(child.content);'
+        '      renderedOutput.push(child.content);'
+        '    }'
         '  }'
         '  if (deletionStack.length > 0) throw new Error("Unclosed deletion container.");'
         '  if (htmlContainerStack.length > 0) throw new Error("Unclosed inline HTML container.");'
-        '  return { text: output.join(""), code, links };'
+        '  return { text: output.join(""), renderedText: renderedOutput.join(""), code, links };'
         '};'
         'const codeBlockRanges = tokens.filter((token) => token.type === "fence" || token.type === "code_block").map((token) => token.map);'
-        'const proseBlocks = tokens.filter((token) => token.type === "inline" && Array.isArray(token.map) && Array.isArray(token.children)).map((token) => ({ range: token.map, ...getOperativeInlineContext(token.children) }));'
+        'const proseBlocks = tokens.filter((token) => token.type === "inline" && Array.isArray(token.map) && Array.isArray(token.children)).map((token) => {'
+        '  const context = getOperativeInlineContext(token.children);'
+        '  return { range: token.map, text: context.text, code: context.code, links: context.links };'
+        '});'
         'const topLevelBlocks = tokens.flatMap((token, index) => {'
         '  if (token.level !== 0 || !Array.isArray(token.map) || (token.nesting !== 0 && token.nesting !== 1)) return [];'
         '  let text = null;'
@@ -2292,7 +2303,25 @@ function Get-MarkdownParseContext {
         '  const inlineToken = tokens[index + 1];'
         '  return [{ range: token.map, text: inlineToken?.type === "inline" ? inlineToken.content : null }];'
         '});'
-        'process.stdout.write(JSON.stringify({ codeBlockRanges, proseBlocks, topLevelBlocks, topLevelListItems, levelTwoHeadings }));'
+        'const tableRows = tokens.flatMap((token, index) => {'
+        '  if (token.type !== "tr_open" || token.tag !== "tr" || token.nesting !== 1 || !Array.isArray(token.map)) return [];'
+        '  const closeIndex = tokens.findIndex((candidate, candidateIndex) => candidateIndex > index && candidate.type === "tr_close" && candidate.tag === "tr" && candidate.nesting === -1 && candidate.level === token.level);'
+        '  if (closeIndex < 0) throw new Error("Unclosed Markdown table row.");'
+        '  const cells = [];'
+        '  for (let cellIndex = index + 1; cellIndex < closeIndex; cellIndex += 1) {'
+        '    const cellToken = tokens[cellIndex];'
+        '    if (cellToken.type !== "th_open" && cellToken.type !== "td_open") continue;'
+        '    if ((cellToken.tag !== "th" && cellToken.tag !== "td") || cellToken.nesting !== 1) throw new Error("Invalid Markdown table cell.");'
+        '    const inlineToken = tokens[cellIndex + 1];'
+        '    const closeToken = tokens[cellIndex + 2];'
+        '    if (inlineToken?.type !== "inline" || !Array.isArray(inlineToken.children) || closeToken?.type !== `${cellToken.tag}_close` || closeToken.tag !== cellToken.tag || closeToken.nesting !== -1) throw new Error("Invalid Markdown table-cell container.");'
+        '    const context = getOperativeInlineContext(inlineToken.children);'
+        '    cells.push({ tag: cellToken.tag, text: context.renderedText, code: context.code, links: context.links });'
+        '  }'
+        '  if (cells.length === 0) throw new Error("Markdown table row has no cells.");'
+        '  return [{ range: token.map, cells }];'
+        '});'
+        'process.stdout.write(JSON.stringify({ codeBlockRanges, proseBlocks, tableRows, topLevelBlocks, topLevelListItems, levelTwoHeadings }));'
     ) -join "`n"
 
     $objStartInfo = [System.Diagnostics.ProcessStartInfo]::new()
@@ -2328,6 +2357,7 @@ function Get-MarkdownParseContext {
     if ($null -eq $objRawContext -or
         $null -eq $objRawContext.codeBlockRanges -or
         $null -eq $objRawContext.proseBlocks -or
+        $null -eq $objRawContext.tableRows -or
         $null -eq $objRawContext.topLevelBlocks -or
         $null -eq $objRawContext.topLevelListItems -or
         $null -eq $objRawContext.levelTwoHeadings) {
@@ -2389,6 +2419,58 @@ function Get-MarkdownParseContext {
                 Code = [string[]]@($objRawProseBlock.code)
                 Links = [string[]]@($objRawProseBlock.links)
             })
+    }
+
+    $listTableRows = [Collections.Generic.List[pscustomobject]]::new()
+    $intPreviousTableRowEnd = 0
+    foreach ($objRawTableRow in @($objRawContext.tableRows)) {
+        if ($null -eq $objRawTableRow -or
+            $objRawTableRow.range -isnot [array] -or
+            $objRawTableRow.range.Count -ne 2 -or
+            $objRawTableRow.cells -isnot [array] -or
+            $objRawTableRow.cells.Count -eq 0) {
+            throw 'The locked Markdown parser returned a malformed table row.'
+        }
+
+        $intStart = [int64] 0
+        $intEnd = [int64] 0
+        if (-not [int64]::TryParse([string]$objRawTableRow.range[0], [ref]$intStart) -or
+            -not [int64]::TryParse([string]$objRawTableRow.range[1], [ref]$intEnd) -or
+            $intStart -lt $intPreviousTableRowEnd -or
+            $intStart -lt 0 -or
+            $intEnd -le $intStart -or
+            $intEnd -gt $LineCount) {
+            throw 'The locked Markdown parser returned an invalid table-row range.'
+        }
+
+        $listCells = [Collections.Generic.List[pscustomobject]]::new()
+        foreach ($objRawCell in @($objRawTableRow.cells)) {
+            if ($null -eq $objRawCell -or
+                $objRawCell.tag -isnot [string] -or
+                @('th', 'td') -cnotcontains $objRawCell.tag -or
+                $objRawCell.text -isnot [string] -or
+                $objRawCell.code -isnot [array] -or
+                @($objRawCell.code | Where-Object { $_ -isnot [string] }).Count -ne 0 -or
+                $objRawCell.links -isnot [array] -or
+                @($objRawCell.links | Where-Object { $_ -isnot [string] }).Count -ne 0) {
+                throw 'The locked Markdown parser returned a malformed table cell.'
+            }
+            $listCells.Add([pscustomobject]@{
+                    Tag = [string]$objRawCell.tag
+                    Start = [int]$intStart
+                    End = [int]$intEnd
+                    Text = [string]$objRawCell.text
+                    Code = [string[]]@($objRawCell.code)
+                    Links = [string[]]@($objRawCell.links)
+                })
+        }
+
+        $listTableRows.Add([pscustomobject]@{
+                Start = [int]$intStart
+                End = [int]$intEnd
+                Cells = [pscustomobject[]]$listCells.ToArray()
+            })
+        $intPreviousTableRowEnd = [int]$intEnd
     }
 
     $listTopLevelBlocks = [Collections.Generic.List[pscustomobject]]::new()
@@ -2501,6 +2583,7 @@ function Get-MarkdownParseContext {
     return [pscustomobject]@{
         CodeBlockRanges = [pscustomobject[]]$listRanges.ToArray()
         ProseBlocks = [pscustomobject[]]$listProseBlocks.ToArray()
+        TableRows = [pscustomobject[]]$listTableRows.ToArray()
         TopLevelBlocks = [pscustomobject[]]$listTopLevelBlocks.ToArray()
         TopLevelListItems = [pscustomobject[]]$listTopLevelListItems.ToArray()
         LevelTwoHeadings = [pscustomobject[]]$listLevelTwoHeadings.ToArray()
@@ -2529,7 +2612,7 @@ function Assert-MarkdownParserExactContext {
     # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
     # Parameters, return shape, and positional contract can change without notice.
     # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
+    # Version: 1.0.20260902.0.
     [CmdletBinding(PositionalBinding = $false)]
     [OutputType([void])]
     param()
@@ -2544,6 +2627,7 @@ function Assert-MarkdownParserExactContext {
     $strExpected = '{"CodeBlockRanges":[],"ProseBlocks":[' +
         '{"Start":0,"End":1,"Text":"Transport","Code":[],"Links":[]},' +
         '{"Start":2,"End":3,"Text":"Paragraph .","Code":["code"],"Links":[]}],' +
+        '"TableRows":[],' +
         '"TopLevelBlocks":[' +
         '{"Type":"heading_open","Tag":"h2","Start":0,"End":1,"Text":"Transport"},' +
         '{"Type":"paragraph_open","Tag":"p","Start":2,"End":3,"Text":"Paragraph ."}],' +
@@ -2551,6 +2635,28 @@ function Assert-MarkdownParserExactContext {
         '{"Start":0,"End":1,"Text":"Transport"}]}'
     if ($strActual -cne $strExpected) {
         throw "Self-test 'ordinary exact Markdown parser context' changed output."
+    }
+
+    $strTableMarkdown = @(
+        '| **Decision** `Status` | Value |'
+        '| :--- | ---: |'
+        '| Field | *Accepted* |'
+    ) -join "`n"
+    $objTableContext = Get-MarkdownParseContext `
+        -Content $strTableMarkdown -LineCount 3
+    if ($objTableContext.TableRows.Count -ne 2 -or
+        $objTableContext.TableRows[0].Start -ne 0 -or
+        $objTableContext.TableRows[0].End -ne 1 -or
+        $objTableContext.TableRows[0].Cells.Count -ne 2 -or
+        $objTableContext.TableRows[0].Cells[0].Tag -cne 'th' -or
+        $objTableContext.TableRows[0].Cells[0].Text -cne 'Decision Status' -or
+        $objTableContext.TableRows[0].Cells[0].Code.Count -ne 1 -or
+        $objTableContext.TableRows[0].Cells[0].Code[0] -cne 'Status' -or
+        $objTableContext.TableRows[1].Start -ne 2 -or
+        $objTableContext.TableRows[1].End -ne 3 -or
+        $objTableContext.TableRows[1].Cells[1].Tag -cne 'td' -or
+        $objTableContext.TableRows[1].Cells[1].Text -cne 'Accepted') {
+        throw "Self-test 'exact Markdown table context' changed output."
     }
 }
 
@@ -2580,7 +2686,7 @@ function Get-OperativeMarkdownContext {
     # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
     # Parameters, return shape, and positional contract can change without notice.
     # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
+    # Version: 1.0.20260902.0.
     [CmdletBinding(PositionalBinding = $false)]
     [OutputType([pscustomobject])]
     param(
@@ -2617,6 +2723,7 @@ function Get-OperativeMarkdownContext {
         SourceLines = [string[]]$arrLines
         CodeBlockLines = [bool[]]$arrCodeBlockLines
         ProseBlocks = [pscustomobject[]]$objParseContext.ProseBlocks
+        TableRows = [pscustomobject[]]$objParseContext.TableRows
         TopLevelListItems = [pscustomobject[]]$objParseContext.TopLevelListItems
         LevelTwoHeadings = [pscustomobject[]]$objParseContext.LevelTwoHeadings
     }
@@ -5054,6 +5161,37 @@ function Get-DecisionRecordLifecycleFailure {
             "$Name must not contain a separate operative Status field outside Metadata."
         )
     }
+    if (@($objMarkdownContext.TableRows |
+            Where-Object {
+                $boolOutsideMetadata =
+                    $_.Start -le $objMetadataHeading.Start -or
+                    $_.Start -ge $intMetadataSectionEnd
+                $boolHasStatusField = $false
+                if ($boolOutsideMetadata) {
+                    for ($intCell = 0; $intCell -lt $_.Cells.Count - 1; $intCell++) {
+                        $strLabel = [regex]::Replace(
+                            $_.Cells[$intCell].Text.Trim(),
+                            '\s+',
+                            ' '
+                        )
+                        $strValue = [regex]::Replace(
+                            $_.Cells[$intCell + 1].Text.Trim(),
+                            '\s+',
+                            ' '
+                        )
+                        if ($strLabel -match '(?i)^(?:Decision\s+)?Status$' -and
+                            -not [string]::IsNullOrWhiteSpace($strValue)) {
+                            $boolHasStatusField = $true
+                            break
+                        }
+                    }
+                }
+                $boolHasStatusField
+            }).Count -ne 0) {
+        Write-Output (
+            "$Name must not contain a separate operative Status field outside Metadata."
+        )
+    }
 }
 
 function Get-DocumentMetadataContext {
@@ -7422,9 +7560,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strValidatorSource,
-            '(?m)^# Version: 1\.7\.20260902\.6$'
+            '(?m)^# Version: 1\.7\.20260902\.7$'
         ).Count -ne 1) {
-        throw 'The validator script version is not 1.7.20260902.6.'
+        throw 'The validator script version is not 1.7.20260902.7.'
     }
     $boolSavedWindowsPython = $script:useWindowsPythonLauncher
     $arrSavedPythonNames = $script:pythonPathNames
@@ -7636,6 +7774,97 @@ if ($SelfTest) {
         ('docs/decisions/0001-legacy.md must not contain a separate operative ' +
             'Status field outside Metadata.')) {
         throw 'A Decision Status field escaped lifecycle validation.'
+    }
+    $arrTableStatusFailureFixtures = @(
+        [pscustomobject]@{
+            Name = 'header Status field'
+            Content = $strCompliantDecisionRecord.Replace(
+                "## Context`n",
+                "## Context`n| STATUS | Accepted |`n| --- | --- |`n"
+            )
+        },
+        [pscustomobject]@{
+            Name = 'body Decision Status field with alignment and inline formatting'
+            Content = $strCompliantDecisionRecord.Replace(
+                "## Context`n",
+                (@(
+                        '## Context'
+                        '| Field | Value |'
+                        '| :--- | ---: |'
+                        '| **decision** `status` | *Accepted* |'
+                    ) -join "`n") + "`n"
+            )
+        }
+    )
+    foreach ($objTableStatusFixture in $arrTableStatusFailureFixtures) {
+        if (@(Get-DecisionRecordLifecycleFailure `
+                -Name 'docs/decisions/0001-legacy.md' `
+                -CurrentContent $objTableStatusFixture.Content `
+                -BaselineContent $strLegacyDecisionRecord) -cnotcontains
+            ('docs/decisions/0001-legacy.md must not contain a separate operative ' +
+                'Status field outside Metadata.')) {
+            throw "$($objTableStatusFixture.Name) escaped lifecycle validation."
+        }
+    }
+    $arrTableStatusAcceptedFixtures = @(
+        [pscustomobject]@{
+            Name = 'fenced table example'
+            Content = $strCompliantDecisionRecord.Replace(
+                'Changed legacy context.',
+                (@(
+                        'Changed legacy context.'
+                        '```markdown'
+                        '| Status | Accepted |'
+                        '| --- | --- |'
+                        '```'
+                    ) -join "`n")
+            )
+        },
+        [pscustomobject]@{
+            Name = 'commented table example'
+            Content = $strCompliantDecisionRecord.Replace(
+                'Changed legacy context.',
+                (@(
+                        'Changed legacy context.'
+                        '<!--'
+                        '| Status | Accepted |'
+                        '| --- | --- |'
+                        '-->'
+                    ) -join "`n")
+            )
+        },
+        [pscustomobject]@{
+            Name = 'unrelated table'
+            Content = $strCompliantDecisionRecord.Replace(
+                'Changed legacy context.',
+                (@(
+                        'Changed legacy context.'
+                        '| State | Owner |'
+                        '| --- | --- |'
+                        '| Accepted | Maintainers |'
+                    ) -join "`n")
+            )
+        },
+        [pscustomobject]@{
+            Name = 'empty Status table value'
+            Content = $strCompliantDecisionRecord.Replace(
+                'Changed legacy context.',
+                (@(
+                        'Changed legacy context.'
+                        '| Field | Value |'
+                        '| --- | --- |'
+                        '| Status | |'
+                    ) -join "`n")
+            )
+        }
+    )
+    foreach ($objTableStatusFixture in $arrTableStatusAcceptedFixtures) {
+        if (@(Get-DecisionRecordLifecycleFailure `
+                -Name 'docs/decisions/0001-legacy.md' `
+                -CurrentContent $objTableStatusFixture.Content `
+                -BaselineContent $strLegacyDecisionRecord).Count -ne 0) {
+            throw "$($objTableStatusFixture.Name) caused a false lifecycle finding."
+        }
     }
     $strDecisionStatusProseRecord = $strCompliantDecisionRecord.Replace(
         'Changed legacy context.',

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -8981,6 +8981,15 @@ if ($SelfTest) {
                 'refs/remotes/event/pr-head',
                 'id: created-push-boundary',
                 'git ls-remote --refs --heads --tags origin',
+                'sorted_refs="$(mktemp)"',
+                "if ! node -e '",
+                'const { TextDecoder } = require("util");',
+                'new TextDecoder("utf-8", { fatal: true })',
+                'seenRefs.has(fields[1])',
+                'const compareOrdinal = (left, right) =>',
+                'left < right ? -1 : left > right ? 1 : 0;',
+                'mapfile -t remote_rows <"${sorted_refs}"',
+                'Remote ref evidence parsing or ordinal sorting failed.',
                 'refs/remotes/event/created-other-%04d',
                 'cmp --silent "${raw_refs}" "${raw_refs_after}"',
                 'AGENT_INSTRUCTION_DESTINATION_REF:',
@@ -9022,6 +9031,14 @@ if ($SelfTest) {
         if ($Content -cmatch '(?m)(^|\s)--force(\s|$)' -or
             $Content -cmatch '"\+[^" ]+:') {
             $listFailures.Add('Event-data fetches must not force a destination ref.')
+        }
+        if ($Content.Contains(
+                'mapfile -t remote_rows < <(sort "${raw_refs}")',
+                [StringComparison]::Ordinal
+            )) {
+            $listFailures.Add(
+                'Remote ref evidence must be parsed and sorted by ordinal ref name.'
+            )
         }
         foreach ($strForbiddenTransitionLiteral in @(
                 'PR_PREVIOUS_HEAD_SHA', 'refs/remotes/event/pr-previous-head',
@@ -9093,6 +9110,35 @@ if ($SelfTest) {
             'Agent workflow contract failed: ' +
             ($arrAgentWorkflowFailures -join '; ')
         )
+    }
+    $arrShaFirstConflictRows = [object[]] @(
+        [pscustomobject]@{
+            Object = '0000000000000000000000000000000000000001'
+            Ref = 'refs/heads/z-sha-first'
+        },
+        [pscustomobject]@{
+            Object = 'ffffffffffffffffffffffffffffffffffffffff'
+            Ref = 'refs/heads/a-name-first'
+        }
+    )
+    $arrShaSortedConflictRows = @(
+        $arrShaFirstConflictRows | Sort-Object -Property Object
+    )
+    $arrOrdinalSortedConflictRows = [object[]] @($arrShaFirstConflictRows)
+    [Array]::Sort(
+        $arrOrdinalSortedConflictRows,
+        [Comparison[object]] {
+            param($objLeft, $objRight)
+            return [string]::CompareOrdinal(
+                [string] $objLeft.Ref,
+                [string] $objRight.Ref
+            )
+        }
+    )
+    if ($arrShaSortedConflictRows[0].Ref -cne 'refs/heads/z-sha-first' -or
+        $arrOrdinalSortedConflictRows[0].Ref -cne 'refs/heads/a-name-first' -or
+        $arrOrdinalSortedConflictRows[1].Ref -cne 'refs/heads/z-sha-first') {
+        throw 'The SHA-first versus ordinal-ref adversarial fixture did not pass.'
     }
     $arrWorkflowMutations = @(
         [pscustomobject]@{
@@ -9174,6 +9220,39 @@ if ($SelfTest) {
                 'toJson(github.event.size)'
             )
             Expected = 'Workflow contract literal is missing: toJson(github.event.commits)'
+        },
+        [pscustomobject]@{
+            Name = 'restored SHA-first whole-row sort'
+            Content = $strAgentWorkflowContent.Replace(
+                'mapfile -t remote_rows <"${sorted_refs}"',
+                'mapfile -t remote_rows < <(sort "${raw_refs}")'
+            )
+            Expected =
+                'Remote ref evidence must be parsed and sorted by ordinal ref name.'
+        },
+        [pscustomobject]@{
+            Name = 'non-ordinal ref comparator'
+            Content = $strAgentWorkflowContent.Replace(
+                'left < right ? -1 : left > right ? 1 : 0;',
+                'left.localeCompare(right);'
+            )
+            Expected = 'Workflow contract literal is missing: left < right'
+        },
+        [pscustomobject]@{
+            Name = 'missing duplicate ref rejection'
+            Content = $strAgentWorkflowContent.Replace(
+                'seenRefs.has(fields[1])',
+                'false'
+            )
+            Expected = 'Workflow contract literal is missing: seenRefs.has(fields[1])'
+        },
+        [pscustomobject]@{
+            Name = 'fail-open ref sorter invocation'
+            Content = $strAgentWorkflowContent.Replace(
+                "if ! node -e '",
+                "if node -e '"
+            )
+            Expected = "Workflow contract literal is missing: if ! node -e '"
         }
     )
     foreach ($objWorkflowMutation in $arrWorkflowMutations) {

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -9280,7 +9280,25 @@ if ($SelfTest) {
                 'refs/remotes/event/push-base',
                 'refs/remotes/event/pr-head',
                 'id: created-push-boundary',
+                'PUSH_COMMIT_EVIDENCE: ${{ toJson(github.event.commits) }}',
                 'git ls-remote --refs --heads --tags origin',
+                'const evidence = process.env.PUSH_COMMIT_EVIDENCE;',
+                'Buffer.byteLength(evidence, "utf8") > 1048576',
+                'commits = JSON.parse(evidence);',
+                '!Array.isArray(commits) || commits.length > 2048',
+                '!/^[0-9a-f]{40}$/.test(entry.id)',
+                'seenCommitIds.has(entry.id)',
+                'if (ids.length > 0 &&',
+                'ids[ids.length - 1] !== process.env.PUSH_AFTER_SHA',
+                '(ids.length > 0 ? "\n" : ""), "utf8");',
+                'mapfile -t push_commit_ids <"${push_commit_ids_file}"',
+                'fetch_depth=$((push_commit_count + 1))',
+                'test "${fetch_depth}" -le 2049',
+                "destination_local_ref='refs/remotes/event/created-destination'",
+                '--no-write-fetch-head --no-recurse-submodules origin',
+                '"${PUSH_REF}:${destination_local_ref}"',
+                'test "${fetched_destination}" = "${PUSH_AFTER_SHA}"',
+                'git cat-file -e "${push_commit_id}^{commit}"',
                 'sorted_refs="$(mktemp)"',
                 "if ! node -e '",
                 'const { TextDecoder } = require("util");',
@@ -9547,6 +9565,86 @@ if ($SelfTest) {
             Expected = 'Workflow contract literal is missing: seenRefs.has(fields[1])'
         },
         [pscustomobject]@{
+            Name = 'missing push commit byte bound'
+            Content = $strAgentWorkflowContent.Replace(
+                'Buffer.byteLength(evidence, "utf8") > 1048576',
+                'false'
+            )
+            Expected = 'Workflow contract literal is missing: Buffer.byteLength'
+        },
+        [pscustomobject]@{
+            Name = 'missing push commit array and count bound'
+            Content = $strAgentWorkflowContent.Replace(
+                '!Array.isArray(commits) || commits.length > 2048',
+                'false'
+            )
+            Expected = 'Workflow contract literal is missing: !Array.isArray(commits)'
+        },
+        [pscustomobject]@{
+            Name = 'missing push commit ID validation'
+            Content = $strAgentWorkflowContent.Replace(
+                '!/^[0-9a-f]{40}$/.test(entry.id)',
+                'false'
+            )
+            Expected = 'Workflow contract literal is missing: !/^[0-9a-f]{40}$/'
+        },
+        [pscustomobject]@{
+            Name = 'missing duplicate push commit rejection'
+            Content = $strAgentWorkflowContent.Replace(
+                'seenCommitIds.has(entry.id)',
+                'false'
+            )
+            Expected = 'Workflow contract literal is missing: seenCommitIds.has(entry.id)'
+        },
+        [pscustomobject]@{
+            Name = 'empty push commit array rejected by producer'
+            Content = $strAgentWorkflowContent.Replace(
+                'if (ids.length > 0 &&',
+                'if (ids.length === 0 ||'
+            )
+            Expected = 'Workflow contract literal is missing: if (ids.length > 0 &&'
+        },
+        [pscustomobject]@{
+            Name = 'empty push commit array serialized as one blank record'
+            Content = $strAgentWorkflowContent.Replace(
+                '(ids.length > 0 ? "\n" : ""), "utf8");',
+                '"\n", "utf8");'
+            )
+            Expected = 'Workflow contract literal is missing: (ids.length > 0 ?'
+        },
+        [pscustomobject]@{
+            Name = 'missing push commit head agreement'
+            Content = $strAgentWorkflowContent.Replace(
+                'ids[ids.length - 1] !== process.env.PUSH_AFTER_SHA',
+                'false'
+            )
+            Expected = 'Workflow contract literal is missing: ids[ids.length - 1]'
+        },
+        [pscustomobject]@{
+            Name = 'unbounded destination history fetch'
+            Content = $strAgentWorkflowContent.Replace(
+                'fetch_depth=$((push_commit_count + 1))',
+                'fetch_depth=2147483647'
+            )
+            Expected = 'Workflow contract literal is missing: fetch_depth=$((push_commit_count + 1))'
+        },
+        [pscustomobject]@{
+            Name = 'forcing created destination fetch'
+            Content = $strAgentWorkflowContent.Replace(
+                '"${PUSH_REF}:${destination_local_ref}"',
+                '"+${PUSH_REF}:${destination_local_ref}"'
+            )
+            Expected = 'Event-data fetches must not force a destination ref.'
+        },
+        [pscustomobject]@{
+            Name = 'missing payload commit availability proof'
+            Content = $strAgentWorkflowContent.Replace(
+                'git cat-file -e "${push_commit_id}^{commit}"',
+                'git cat-file -t "${push_commit_id}^{commit}"'
+            )
+            Expected = 'Workflow contract literal is missing: git cat-file -e'
+        },
+        [pscustomobject]@{
             Name = 'fail-open ref sorter invocation'
             Content = $strAgentWorkflowContent.Replace(
                 "if ! node -e '",
@@ -9574,71 +9672,212 @@ if ($SelfTest) {
         }
     }
 
-    $arrUnchangedFailures = @(
-        Get-TrustRootRangeMutationFailure `
-            -RepositoryRootPath $strRepositoryRootPath `
-            -BaseRevision $strNewRefTestHead `
-            -HeadRevision $strNewRefTestHead `
-            -RepositoryRelativePath $script:arrTrustRootPaths |
-            Sort-Object -Unique
+    $strArrayFixtureSystemTempRoot =
+        [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+    $strArrayFixtureRoot = [IO.Path]::Combine(
+        $strArrayFixtureSystemTempRoot,
+        'agent-instruction-trust-array-' + [Guid]::NewGuid().ToString('N')
     )
-    if ($arrUnchangedFailures -isnot [array] -or
-        $arrUnchangedFailures.Count -ne 0) {
-        throw 'The zero-result trust-root array regression did not pass.'
-    }
-    $strTrustRootBase = [string] (
-        & git -C $strRepositoryRootPath rev-list --max-parents=0 HEAD |
-            Select-Object -First 1
+    $strArrayFixtureRepository =
+        [IO.Path]::Combine($strArrayFixtureRoot, 'source')
+    $strArrayFixtureDisabledHooks =
+        [IO.Path]::Combine($strArrayFixtureRoot, 'disabled-hooks')
+    [string[]] $arrArrayFixturePaths = @(
+        '.gitattributes',
+        '.github/workflows/Test-AgentInstructions.SelfTest.ps1',
+        '.github/workflows/Test-TrustRootAuthorization.ps1'
     )
-    $arrTrustRootFailures = @(
-        Get-TrustRootRangeMutationFailure `
-            -RepositoryRootPath $strRepositoryRootPath `
-            -BaseRevision $strTrustRootBase.Trim() `
-            -HeadRevision $strNewRefTestHead `
-            -RepositoryRelativePath $script:arrTrustRootPaths |
-            Sort-Object -Unique
-    )
-    if ($LASTEXITCODE -ne 0) {
-        throw 'The trusted validation mutation query leaked a nonzero native status.'
-    }
-    if ($arrTrustRootFailures -isnot [array] -or
-        $arrTrustRootFailures.Count -le 1) {
-        throw 'The many-result trust-root array regression did not pass.'
-    }
-    $arrHistoricallyChangedTrustPaths = @(
-        & git -C $strRepositoryRootPath diff --name-only --no-renames `
-            --no-ext-diff --no-textconv $strTrustRootBase.Trim() `
-            $strNewRefTestHead -- $script:arrTrustRootPaths
-    )
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Could not inventory changed historical trust roots.'
-    }
-    if ($arrHistoricallyChangedTrustPaths -cnotcontains
-        '.github/workflows/Test-AgentInstructions.SelfTest.ps1') {
-        throw 'The extracted self-test lacks historical trust-root mutation evidence.'
-    }
-    foreach ($strTrustPath in $arrHistoricallyChangedTrustPaths) {
-        if (-not ($arrTrustRootFailures -match
-                [regex]::Escape("changes trusted validation path $strTrustPath."))) {
-            throw "A changed trusted validation path did not fail closed: $strTrustPath"
+    $boolArrayFixtureOriginalAuthorization =
+        $script:boolTrustedMaintenanceAuthorizationValidated
+    [void][IO.Directory]::CreateDirectory($strArrayFixtureRepository)
+    try {
+        $objArrayFixtureUtf8 = [Text.UTF8Encoding]::new($false)
+        foreach ($strArrayFixturePath in $arrArrayFixturePaths) {
+            $strArrayFixtureFile = [IO.Path]::Combine(
+                $strArrayFixtureRepository,
+                $strArrayFixturePath.Replace(
+                    '/',
+                    [IO.Path]::DirectorySeparatorChar
+                )
+            )
+            [void][IO.Directory]::CreateDirectory(
+                [IO.Path]::GetDirectoryName($strArrayFixtureFile)
+            )
+            [IO.File]::WriteAllText(
+                $strArrayFixtureFile,
+                $(if ($strArrayFixturePath -ceq '.gitattributes') {
+                        "* text=auto`n"
+                    } else { "baseline $strArrayFixturePath`n" }),
+                $objArrayFixtureUtf8
+            )
+        }
+        & git -C $strArrayFixtureRepository init --quiet --initial-branch=main
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not initialize the trust-root array fixture.'
+        }
+        & git -C $strArrayFixtureRepository add -- $arrArrayFixturePaths
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not stage the trust-root array baseline.'
+        }
+        & git -C $strArrayFixtureRepository `
+            -c 'user.name=Agent instruction self-test' `
+            -c 'user.email=agent-instruction-self-test@example.invalid' `
+            -c 'commit.gpgSign=false' `
+            -c "core.hooksPath=$strArrayFixtureDisabledHooks" `
+            commit --quiet --no-gpg-sign -m 'trust-root array baseline'
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not commit the trust-root array baseline.'
+        }
+        $strArrayFixtureBase = ([string] (& git -C $strArrayFixtureRepository `
+                    rev-parse --verify 'HEAD^{commit}')).Trim()
+
+        [IO.File]::WriteAllText(
+            [IO.Path]::Combine($strArrayFixtureRepository, '.gitattributes'),
+            "one-path mutation`n",
+            $objArrayFixtureUtf8
+        )
+        & git -C $strArrayFixtureRepository add -- '.gitattributes'
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not stage the one-path trust-root mutation.'
+        }
+        & git -C $strArrayFixtureRepository `
+            -c 'user.name=Agent instruction self-test' `
+            -c 'user.email=agent-instruction-self-test@example.invalid' `
+            -c 'commit.gpgSign=false' `
+            -c "core.hooksPath=$strArrayFixtureDisabledHooks" `
+            commit --quiet --no-gpg-sign -m 'one trust-root mutation'
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not commit the one-path trust-root mutation.'
+        }
+        $strArrayFixtureOne = ([string] (& git -C $strArrayFixtureRepository `
+                    rev-parse --verify 'HEAD^{commit}')).Trim()
+
+        foreach ($strArrayFixturePath in $arrArrayFixturePaths) {
+            $strArrayFixtureFile = [IO.Path]::Combine(
+                $strArrayFixtureRepository,
+                $strArrayFixturePath.Replace(
+                    '/',
+                    [IO.Path]::DirectorySeparatorChar
+                )
+            )
+            [IO.File]::WriteAllText(
+                $strArrayFixtureFile,
+                $(if ($strArrayFixturePath -ceq '.gitattributes') {
+                        "* -text`n"
+                    } else { "many-path mutation $strArrayFixturePath`n" }),
+                $objArrayFixtureUtf8
+            )
+        }
+        & git -C $strArrayFixtureRepository add -- $arrArrayFixturePaths
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not stage the many-path trust-root mutation.'
+        }
+        & git -C $strArrayFixtureRepository `
+            -c 'user.name=Agent instruction self-test' `
+            -c 'user.email=agent-instruction-self-test@example.invalid' `
+            -c 'commit.gpgSign=false' `
+            -c "core.hooksPath=$strArrayFixtureDisabledHooks" `
+            commit --quiet --no-gpg-sign -m 'many trust-root mutations'
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not commit the many-path trust-root mutation.'
+        }
+        $strArrayFixtureMany = ([string] (& git -C $strArrayFixtureRepository `
+                    rev-parse --verify 'HEAD^{commit}')).Trim()
+        foreach ($strArrayFixtureRevision in @(
+                $strArrayFixtureBase,
+                $strArrayFixtureOne,
+                $strArrayFixtureMany
+            )) {
+            if ($strArrayFixtureRevision -cnotmatch
+                '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
+                throw 'Could not resolve a trust-root array fixture commit.'
+            }
+        }
+
+        $arrUnchangedFailures = @(
+            Get-TrustRootRangeMutationFailure `
+                -RepositoryRootPath $strArrayFixtureRepository `
+                -BaseRevision $strArrayFixtureOne `
+                -HeadRevision $strArrayFixtureOne `
+                -RepositoryRelativePath $arrArrayFixturePaths |
+                Sort-Object -Unique
+        )
+        if ($arrUnchangedFailures -isnot [array] -or
+            $arrUnchangedFailures.Count -ne 0) {
+            throw 'The zero-result trust-root array regression did not pass.'
+        }
+
+        $strTrustRootFailureSuffix =
+            ' Update this trust root only through an authorized trusted-base maintenance path.'
+        [string[]] $arrExpectedOneFailures = @(
+            'Pull request changes trusted validation path .gitattributes.' +
+                $strTrustRootFailureSuffix
+        )
+        $arrAttributeOnlyFailures = @(
+            Get-TrustRootRangeMutationFailure `
+                -RepositoryRootPath $strArrayFixtureRepository `
+                -BaseRevision $strArrayFixtureBase `
+                -HeadRevision $strArrayFixtureOne `
+                -RepositoryRelativePath $arrArrayFixturePaths |
+                Sort-Object -Unique
+        )
+        if ($arrAttributeOnlyFailures -isnot [array] -or
+            $arrAttributeOnlyFailures.Count -ne 1 -or
+            $arrAttributeOnlyFailures[0] -cne $arrExpectedOneFailures[0]) {
+            throw 'The one-result trust-root array regression did not fail closed.'
+        }
+
+        [string[]] $arrExpectedManyFailures = @(
+            (
+                'Pull request changes trusted validation path .gitattributes.' +
+                    $strTrustRootFailureSuffix
+            ),
+            (
+                'Pull request changes trusted validation path ' +
+                    '.github/workflows/Test-AgentInstructions.SelfTest.ps1.' +
+                    $strTrustRootFailureSuffix
+            ),
+            (
+                'Pull request changes trusted validation path ' +
+                    '.github/workflows/Test-TrustRootAuthorization.ps1.' +
+                    $strTrustRootFailureSuffix
+            )
+        )
+        $arrTrustRootFailures = @(
+            Get-TrustRootRangeMutationFailure `
+                -RepositoryRootPath $strArrayFixtureRepository `
+                -BaseRevision $strArrayFixtureOne `
+                -HeadRevision $strArrayFixtureMany `
+                -RepositoryRelativePath $arrArrayFixturePaths |
+                Sort-Object -Unique
+        )
+        if ($LASTEXITCODE -ne 0 -or $arrTrustRootFailures -isnot [array] -or
+            $arrTrustRootFailures.Count -ne $arrExpectedManyFailures.Count) {
+            throw 'The many-result trust-root array regression did not pass.'
+        }
+        for ($intArrayFailureIndex = 0;
+            $intArrayFailureIndex -lt $arrExpectedManyFailures.Count;
+            $intArrayFailureIndex++) {
+            if ($arrTrustRootFailures[$intArrayFailureIndex] -cne
+                $arrExpectedManyFailures[$intArrayFailureIndex]) {
+                throw 'The many-result trust-root array path set is not exact.'
+            }
+        }
+        if ($arrTrustRootFailures -cnotcontains
+            $arrExpectedManyFailures[1]) {
+            throw 'The extracted self-test lacks hermetic trust-root mutation evidence.'
         }
     }
-    if ($arrTrustRootFailures.Count -ne $arrHistoricallyChangedTrustPaths.Count) {
-        throw 'The trusted validation mutation test returned an unexpected failure count.'
-    }
-    $arrAttributeOnlyFailures = @(
-        Get-TrustRootRangeMutationFailure `
-            -RepositoryRootPath $strRepositoryRootPath `
-            -BaseRevision $strTrustRootBase.Trim() `
-            -HeadRevision $strNewRefTestHead `
-            -RepositoryRelativePath @('.gitattributes') |
-            Sort-Object -Unique
-    )
-    if ($arrAttributeOnlyFailures -isnot [array] -or
-        $arrAttributeOnlyFailures.Count -ne 1 -or
-        -not ($arrAttributeOnlyFailures -match
-            [regex]::Escape('changes trusted validation path .gitattributes.'))) {
-        throw 'The one-result trust-root array regression did not fail closed.'
+    finally {
+        $script:boolTrustedMaintenanceAuthorizationValidated =
+            $boolArrayFixtureOriginalAuthorization
+        if ([IO.Directory]::Exists($strArrayFixtureRoot) -and
+            $strArrayFixtureRoot.StartsWith(
+                $strArrayFixtureSystemTempRoot,
+                [StringComparison]::OrdinalIgnoreCase
+            )) {
+            Remove-Item -LiteralPath $strArrayFixtureRoot -Recurse -Force
+        }
     }
 
     $strMetadataNormalizationBase = @(

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -2,7 +2,7 @@
 # Validates governed agent instructions and optional authenticated Git ranges.
 # .NOTES
 # Positional parameters are not supported.
-# Version: 1.7.20260902.2
+# Version: 1.7.20260902.3
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([string])]
@@ -917,9 +917,9 @@ function Read-GitPublishedEndpointChangedPath {
     # Reads bounded paths changed between the published baseline and final state.
     #
     # .DESCRIPTION
-    # Uses authenticated endpoint trees. A created ref uses its graph-derived
-    # introduced set and outside-parent boundaries. Only a genuine root uses
-    # the complete final tree.
+    # Uses authenticated endpoint trees. A created ref with one authenticated
+    # outside-parent boundary compares that boundary tree with the final tree.
+    # Only a genuine root uses the complete final tree.
     #
     # .PARAMETER RepositoryRootPath
     # The absolute path of the trusted Git repository.
@@ -957,7 +957,7 @@ function Read-GitPublishedEndpointChangedPath {
     # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
     # Parameters, return shape, and positional contract can change without notice.
     # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
+    # Version: 1.0.20260902.0.
     [CmdletBinding(PositionalBinding = $false)]
     [OutputType([string])]
     param(
@@ -986,12 +986,15 @@ function Read-GitPublishedEndpointChangedPath {
         @('-C', $RepositoryRootPath, 'ls-tree', '-r', '-z', '--name-only',
             $FinalRevision)
     }
-    elseif ($BaselineAbsent) {
+    elseif ($BaselineAbsent -and $arrBoundaries.Count -eq 1) {
         @(
-            '-C', $RepositoryRootPath, 'log', '--format=', '--name-only', '-z',
-            '-m', '--no-renames', '--no-ext-diff', '--no-textconv',
-            $FinalRevision, '--not'
-        ) + $arrBoundaries + @('--', ':(top)**')
+            '-C', $RepositoryRootPath, 'diff', '--name-only', '-z',
+            '--no-renames', '--no-ext-diff', '--no-textconv',
+            $arrBoundaries[0], $FinalRevision, '--', ':(top)**'
+        )
+    }
+    elseif ($BaselineAbsent) {
+        throw 'A created ref with introduced commits must have one boundary.'
     }
     else {
         @('-C', $RepositoryRootPath, 'diff', '--name-only', '-z',
@@ -1014,8 +1017,7 @@ function Read-GitPublishedEndpointChangedPath {
     if ($objResult.ExitCode -ne 0) {
         throw 'Could not enumerate paths changed between published endpoints.'
     }
-    $arrPaths = @(ConvertFrom-GitPathListData -Bytes $objResult.Bytes `
-            -AllowDuplicatePath:$BaselineAbsent)
+    $arrPaths = @(ConvertFrom-GitPathListData -Bytes $objResult.Bytes)
     return @($arrPaths | Sort-Object -Unique)
 }
 
@@ -7379,9 +7381,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strValidatorSource,
-            '(?m)^# Version: 1\.7\.20260902\.2$'
+            '(?m)^# Version: 1\.7\.20260902\.3$'
         ).Count -ne 1) {
-        throw 'The validator script version is not 1.7.20260902.2.'
+        throw 'The validator script version is not 1.7.20260902.3.'
     }
     $boolSavedWindowsPython = $script:useWindowsPythonLauncher
     $arrSavedPythonNames = $script:pythonPathNames
@@ -7795,9 +7797,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strExtractedSelfTestSource,
-            '(?m)^# Version: 1\.2\.20260902\.1$'
+            '(?m)^# Version: 1\.2\.20260902\.2$'
         ).Count -ne 1) {
-        throw 'The extracted self-test lacks version 1.2.20260902.1.'
+        throw 'The extracted self-test lacks version 1.2.20260902.2.'
     }
     $strExtractedSelfTestRevision = if (
         [string]::IsNullOrEmpty($strValidatedInputRevision)

--- a/.github/workflows/Test-AgentInstructions.ps1
+++ b/.github/workflows/Test-AgentInstructions.ps1
@@ -2,27 +2,22 @@
 # Validates governed agent instructions and optional authenticated Git ranges.
 # .NOTES
 # Positional parameters are not supported.
-# Version: 1.7.20260830.7
+# Version: 1.7.20260831.0
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([string])]
 param(
     [Parameter()][switch] $SelfTest,
     [Parameter()][AllowEmptyString()][string] $InputRevision = '',
-    [Parameter()][AllowEmptyString()][string] $RangeBaseRevision = '',
-    [Parameter()][AllowEmptyString()][string] $RangeHeadRevision = '',
-    [Parameter()][switch] $RangeIsNewRef,
-    [Parameter()][switch] $RangeIsDeletedRef,
+    [Parameter()][AllowEmptyString()][string] $PublishedBaselineRevision = '',
+    [Parameter()][AllowEmptyString()][string] $PublishedFinalRevision = '',
+    [Parameter()][switch] $PublishedBaselineAbsent,
+    [Parameter()][switch] $PublishedFinalDeleted,
     [Parameter()][switch] $PushApplicabilityOnly,
     [Parameter()][AllowEmptyString()][string] $TrustedEventTimestamp = '',
     [Parameter()][AllowEmptyString()][string] $EventName = '',
     [Parameter()][AllowEmptyString()][string] $PullRequestAction = '',
-    [Parameter()][AllowEmptyString()][string] $PreviousHeadRevision = '',
-    [Parameter()][AllowEmptyString()][string] $PullRequestBaseChanged = '',
-    [Parameter()][AllowEmptyString()][string] $EventHeadRevision = '',
-    [Parameter()][AllowEmptyString()][string] $EventHeadDistinct = '',
-    [Parameter()][AllowEmptyString()][string] $NewRefCommitCount = '',
-    [Parameter()][AllowEmptyString()][string] $NewRefCommitEvidenceJson = ''
+    [Parameter()][AllowEmptyString()][string] $PullRequestBaseChanged = ''
 )
 
 Set-StrictMode -Version Latest
@@ -35,15 +30,7 @@ $intDocsInstructionsMaximumInputBytes = 131072
 $intInstructionDocumentMaximumInputBytes = 131072
 $intStyleGuideRationaleMaximumInputBytes = 196608
 $intValidatorMaximumInputBytes = 573440
-$intHistoricalPolicyMarkerMaximumBytes = 573440
 $intGitPathListMaximumBytes = 1048576
-$intMetadataMaximumParents = 64
-$intNewRefMaximumCommitEvidence = 2048
-$strMetadataRangePolicyMarker = 'metadata-range-transition-policy-v1'
-$strLintGuideMetadataPolicyMarker =
-    'operational-lint-guide-metadata-policy-v1'
-$strStyleGuideRationaleMetadataPolicyMarker =
-    'style-guide-rationale-metadata-policy-v1'
 $strPythonPrerequisite =
     'Python 3.12 is required to validate .codex/config.toml. On Windows, ' +
     'install the Python launcher for `py -3.12`; otherwise, expose ' +
@@ -214,8 +201,7 @@ $script:arrProhibitedDocumentationClaimLiterals = @(
     'comment block at the top of `CONTRIBUTING.md`'
 )
 $script:arrDocumentationClaimOwnerPaths = @(
-    '.github/instructions/docs.instructions.md',
-    '.github/workflows/Test-AgentInstructions.ps1'
+    '.github/instructions/docs.instructions.md'
 )
 $script:strClaudeImportFailure =
     'CLAUDE.md must not contain active @path imports.'
@@ -891,47 +877,39 @@ function Read-GitTrackedPath {
     return ConvertFrom-GitPathListData -Bytes $objProcessResult.Bytes
 }
 
-function Read-GitRangeTouchedPath {
+function Read-GitPublishedEndpointChangedPath {
     # .SYNOPSIS
-    # Reads bounded path-touch history from a Git revision range.
+    # Reads bounded paths changed between the published baseline and final state.
     #
     # .DESCRIPTION
-    # Reads every path touched by the authenticated commit history in a revision range.
+    # Uses only the two authenticated endpoint trees. An absent baseline treats
+    # every path in the final tree as introduced.
     #
     # .PARAMETER RepositoryRootPath
     # The absolute path of the trusted Git repository.
     #
-    # .PARAMETER BaseRevision
-    # The authenticated base Git object IDs to exclude from the topic range.
+    # .PARAMETER BaselineRevision
+    # The authenticated published baseline commit, or the zero object ID.
     #
-    # .PARAMETER HeadRevision
-    # The authenticated head Git object ID.
+    # .PARAMETER FinalRevision
+    # The authenticated published final commit.
     #
-    # .PARAMETER IsNewRefRange
-    # Indicates whether the range represents a newly created ref.
-    #
-    # .PARAMETER NewRefBoundaryRevision
-    # The authenticated boundary revision for a new ref.
-    #
-    # .PARAMETER NewRefHasIntroducedCommit
-    # Indicates whether the new ref introduces a commit outside the boundary.
-    #
-    # .PARAMETER RepositoryRelativePathspec
-    # The exact repository-relative Git pathspec to inspect.
+    # .PARAMETER BaselineAbsent
+    # Indicates that the publication created a ref with no baseline tree.
     #
     # .PARAMETER MaximumBytes
-    # The maximum permitted output size in bytes.
+    # The maximum permitted Git path-list output size.
     #
     # .EXAMPLE
-    # Read-GitRangeTouchedPath @hashtableArguments
+    # Read-GitPublishedEndpointChangedPath @hashtableArguments
     #
-    # # Runs with validated named arguments.
+    # # Returns the paths whose final state differs from the baseline.
     #
     # .INPUTS
     # None. No pipeline input.
     #
     # .OUTPUTS
-    # [System.String] Zero or more validated values or diagnostics described in the function description.
+    # [string] Zero or more changed repository-relative paths.
     #
     # .NOTES
     # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
@@ -941,118 +919,39 @@ function Read-GitRangeTouchedPath {
     [CmdletBinding(PositionalBinding = $false)]
     [OutputType([string])]
     param(
-        [Parameter(Mandatory)]
-        [string] $RepositoryRootPath,
-
-        [Parameter(Mandatory)]
-        [AllowEmptyCollection()]
-        [AllowEmptyString()]
-        [string[]] $BaseRevision,
-
-        [Parameter(Mandatory)]
-        [string] $HeadRevision,
-
-        [Parameter(Mandatory)]
-        [bool] $IsNewRefRange,
-
-        [Parameter()]
-        [AllowEmptyCollection()]
-        [string[]] $NewRefBoundaryRevision = @(),
-
-        [Parameter()]
-        [bool] $NewRefHasIntroducedCommit = $false,
-
-        [Parameter(Mandatory)]
-        [string] $RepositoryRelativePathspec,
-
-        [Parameter(Mandatory)]
-        [ValidateRange(1, 2147483646)]
-        [int] $MaximumBytes
+        [Parameter(Mandatory)][string] $RepositoryRootPath,
+        [Parameter(Mandatory)][AllowEmptyString()][string] $BaselineRevision,
+        [Parameter(Mandatory)][string] $FinalRevision,
+        [Parameter(Mandatory)][bool] $BaselineAbsent,
+        [Parameter(Mandatory)][ValidateRange(1, 2147483646)][int] $MaximumBytes
     )
 
-    $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
-    $strZeroObjectIdPattern = '^(?:0{40}|0{64})$'
-    if ($HeadRevision -notmatch $strObjectIdPattern -or
-        $HeadRevision -match $strZeroObjectIdPattern) {
-        throw 'The touched-path range head is invalid.'
-    }
-    if ($RepositoryRelativePathspec.StartsWith('-', [StringComparison]::Ordinal) -or
-        [IO.Path]::IsPathRooted($RepositoryRelativePathspec) -or
-        $RepositoryRelativePathspec -match '(^|/)\.\.?(/|$)' -or
-        $RepositoryRelativePathspec.Contains('\', [StringComparison]::Ordinal)) {
-        throw 'The touched-path range pathspec is invalid.'
-    }
-
-    $arrBaseRevisions = @($BaseRevision)
-    $arrRevisionArguments = @()
-    if ($IsNewRefRange) {
-        if ($arrBaseRevisions.Count -ne 1 -or
-            $arrBaseRevisions[0] -notmatch $strZeroObjectIdPattern) {
-            throw 'A new-ref touched-path range requires an all-zero base.'
-        }
-        if (-not $NewRefHasIntroducedCommit) {
-            if ($NewRefBoundaryRevision.Count -ne 0) {
-                throw 'A new-ref range without introduced commits must not have boundaries.'
-            }
-            return [string[]] @()
-        }
-        $arrRevisionArguments += $HeadRevision
-        if ($NewRefBoundaryRevision.Count -gt 0) {
-            $arrRevisionArguments += '--not'
-            foreach ($strBoundaryRevision in $NewRefBoundaryRevision) {
-                if ($strBoundaryRevision -notmatch $strObjectIdPattern -or
-                    $strBoundaryRevision -match $strZeroObjectIdPattern) {
-                    throw 'The new-ref touched-path boundary is invalid.'
-                }
-                $arrRevisionArguments += $strBoundaryRevision
-            }
-        }
+    $arrArguments = if ($BaselineAbsent) {
+        @('-C', $RepositoryRootPath, 'ls-tree', '-r', '-z', '--name-only',
+            $FinalRevision)
     }
     else {
-        if ($arrBaseRevisions.Count -lt 1 -or $arrBaseRevisions.Count -gt 64 -or
-            @($arrBaseRevisions | Sort-Object -Unique).Count -ne
-                $arrBaseRevisions.Count) {
-            throw 'An existing touched-path range requires 1 through 64 unique bases.'
-        }
-        foreach ($strBaseRevision in $arrBaseRevisions) {
-            if ($strBaseRevision -notmatch $strObjectIdPattern -or
-                $strBaseRevision -match $strZeroObjectIdPattern) {
-                throw 'An existing touched-path range contains an invalid base.'
-            }
-        }
-        $arrRevisionArguments += @($HeadRevision, '--not') + $arrBaseRevisions
+        @('-C', $RepositoryRootPath, 'diff', '--name-only', '-z',
+            '--no-renames', '--no-ext-diff', '--no-textconv',
+            $BaselineRevision, $FinalRevision, '--', ':(top)**')
     }
-
     $objStartInfo = [Diagnostics.ProcessStartInfo]::new('git')
     $objStartInfo.UseShellExecute = $false
     $objStartInfo.CreateNoWindow = $true
     $objStartInfo.RedirectStandardOutput = $true
     $objStartInfo.RedirectStandardError = $true
-    foreach ($strArgument in @(
-            '-C', $RepositoryRootPath, 'log', '--format=', '--name-only', '-z',
-            '-m', '--no-renames', '--no-ext-diff', '--no-textconv'
-        ) + $arrRevisionArguments + @('--', $RepositoryRelativePathspec)) {
+    foreach ($strArgument in $arrArguments) {
         $objStartInfo.ArgumentList.Add($strArgument)
     }
-    $objGitProcess = [Diagnostics.Process]::new()
-    $objGitProcess.StartInfo = $objStartInfo
-    $objProcessResult = Read-BoundedProcessData `
-        -Process $objGitProcess `
-        -MaximumBytes $MaximumBytes `
-        -TimeoutMilliseconds 10000 `
-        -DisplayName 'Git authenticated range touched-path enumeration'
-    if ($objProcessResult.ExitCode -ne 0) {
-        throw 'Could not enumerate paths touched by the authenticated range.'
+    $objProcess = [Diagnostics.Process]::new()
+    $objProcess.StartInfo = $objStartInfo
+    $objResult = Read-BoundedProcessData -Process $objProcess `
+        -MaximumBytes $MaximumBytes -TimeoutMilliseconds 10000 `
+        -DisplayName 'Git published-endpoint path enumeration'
+    if ($objResult.ExitCode -ne 0) {
+        throw 'Could not enumerate paths changed between published endpoints.'
     }
-
-    $setTouchedPaths = [Collections.Generic.HashSet[string]]::new(
-        [StringComparer]::Ordinal
-    )
-    foreach ($strTouchedPath in @(ConvertFrom-GitPathListData `
-                -Bytes $objProcessResult.Bytes -AllowDuplicatePath)) {
-        [void]$setTouchedPaths.Add($strTouchedPath)
-    }
-    return @($setTouchedPaths | Sort-Object)
+    return ConvertFrom-GitPathListData -Bytes $objResult.Bytes
 }
 
 function Read-RepositoryInputData {
@@ -1357,78 +1256,13 @@ function Read-GitRevisionText {
         -DisplayName "$Revision`:$RepositoryRelativePath"
 }
 
-function Test-HistoricalPolicyMarker {
+function Get-PublishedBaselineDocumentContext {
     # .SYNOPSIS
-    # Tests whether a revision file contains an ordinal literal.
+    # Gets the local HEAD baseline for one governed worktree document.
     #
     # .DESCRIPTION
-    # Reads one historical policy file and tests for an exact ordinal marker.
-    #
-    # .PARAMETER RepositoryRootPath
-    # The absolute path of the trusted Git repository.
-    #
-    # .PARAMETER Revision
-    # The exact Git revision to inspect.
-    #
-    # .PARAMETER RepositoryRelativePath
-    # The canonical repository-relative path to inspect.
-    #
-    # .PARAMETER Literal
-    # The exact ordinal marker to find.
-    #
-    # .EXAMPLE
-    # Test-HistoricalPolicyMarker @hashtableArguments
-    #
-    # # Runs with validated named arguments.
-    #
-    # .INPUTS
-    # None. No pipeline input.
-    #
-    # .OUTPUTS
-    # [System.Boolean] True when the condition in the synopsis is satisfied; otherwise false.
-    #
-    # .NOTES
-    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
-    # Parameters, return shape, and positional contract can change without notice.
-    # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
-    [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([bool])]
-    param(
-        [Parameter(Mandatory)]
-        [string] $RepositoryRootPath,
-
-        [Parameter(Mandatory)]
-        [string] $Revision,
-
-        [Parameter(Mandatory)]
-        [string] $RepositoryRelativePath,
-
-        [Parameter(Mandatory)]
-        [string] $Literal
-    )
-
-    & git -C $RepositoryRootPath cat-file -e `
-        "$Revision`:$RepositoryRelativePath" 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        return $false
-    }
-
-    $strRevisionContent = Read-GitRevisionText `
-        -RepositoryRootPath $RepositoryRootPath `
-        -Revision $Revision `
-        -RepositoryRelativePath $RepositoryRelativePath `
-        -MaximumBytes $intHistoricalPolicyMarkerMaximumBytes `
-        -RequireRegularFile
-    return $strRevisionContent.Contains($Literal, [StringComparison]::Ordinal)
-}
-
-function Get-GovernedDocumentParentContext {
-    # .SYNOPSIS
-    # Gets the worktree or first-parent comparison for one governed document.
-    #
-    # .DESCRIPTION
-    # Resolves the current governed document and its comparison parent from the worktree or an exact revision.
+    # Reads the published local baseline from HEAD and reports whether the
+    # worktree content differs from it.
     #
     # .PARAMETER RepositoryRootPath
     # The absolute path of the trusted Git repository.
@@ -1439,11 +1273,8 @@ function Get-GovernedDocumentParentContext {
     # .PARAMETER MaximumBytes
     # The maximum permitted output size in bytes.
     #
-    # .PARAMETER Revision
-    # The exact Git revision to inspect.
-    #
     # .EXAMPLE
-    # Get-GovernedDocumentParentContext @hashtableArguments
+    # Get-PublishedBaselineDocumentContext @hashtableArguments
     #
     # # Runs with validated named arguments.
     #
@@ -1469,52 +1300,8 @@ function Get-GovernedDocumentParentContext {
 
         [Parameter(Mandatory)]
         [ValidateRange(1, 2147483646)]
-        [int] $MaximumBytes,
-
-        [Parameter()]
-        [AllowEmptyString()]
-        [string] $Revision = ''
+        [int] $MaximumBytes
     )
-
-    if (-not [string]::IsNullOrEmpty($Revision)) {
-        if ($Revision -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-            throw "The governed-document input revision is invalid: $Revision"
-        }
-        $arrCommitAndParents = @(([string](& git -C $RepositoryRootPath rev-list --parents `
-                    -n 1 $Revision)).Trim() -split '\s+')
-        if ($LASTEXITCODE -ne 0 -or $arrCommitAndParents[0] -ine $Revision) {
-            throw "Could not read parents of input commit $Revision."
-        }
-        if ($arrCommitAndParents.Count -eq 1) {
-            return [pscustomobject]@{ParentContent = $null; ExpectedUtcDate = ''
-                ParentRevision = $null; IsWorktreeTransition = $false}
-        }
-        $strParentRevision = "$Revision`^1"
-        & git -C $RepositoryRootPath cat-file -e `
-            "$strParentRevision`^{commit}" 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            throw "The governed-document input commit has no first parent: $Revision"
-        }
-        & git -C $RepositoryRootPath cat-file -e `
-            "$strParentRevision`:$RepositoryRelativePath" 2>$null
-        $strParentContent = if ($LASTEXITCODE -eq 0) {
-            Read-GitRevisionText `
-                -RepositoryRootPath $RepositoryRootPath `
-                -Revision $strParentRevision `
-                -RepositoryRelativePath $RepositoryRelativePath `
-                -MaximumBytes $MaximumBytes `
-                -RequireRegularFile
-        }
-        else {
-            $null
-        }
-        return [pscustomobject]@{
-            ParentContent = $strParentContent
-            ExpectedUtcDate = ''
-            ParentRevision = $strParentRevision
-            IsWorktreeTransition = $false
-        }
-    }
 
     & git -C $RepositoryRootPath diff --quiet HEAD -- $RepositoryRelativePath
     $intDiffExitCode = $LASTEXITCODE
@@ -1522,14 +1309,10 @@ function Get-GovernedDocumentParentContext {
         throw "Could not compare $RepositoryRelativePath with HEAD."
     }
 
-    if ($intDiffExitCode -eq 1) {
-        $strParentRevision = 'HEAD'
-        $strExpectedUtcDate = [DateTimeOffset]::UtcNow.ToString('yyyy-MM-dd')
-    }
-    else {
-        $strParentRevision = 'HEAD^'
-        $strExpectedUtcDate = ''
-    }
+    $strParentRevision = 'HEAD'
+    $strExpectedUtcDate = if ($intDiffExitCode -eq 1) {
+        [DateTimeOffset]::UtcNow.ToString('yyyy-MM-dd')
+    } else { '' }
 
     & git -C $RepositoryRootPath cat-file -e `
         "$strParentRevision`:$RepositoryRelativePath" 2>$null
@@ -3324,7 +3107,7 @@ function Get-CurrentInputMetadataFreshnessFailure {
     }
 }
 
-function Get-LastUpdatedMetadataFreshnessFailure {
+function Get-PublishedEndpointLastUpdatedFailure {
     # .SYNOPSIS
     # Validates metadata and freshness without a Version field.
     #
@@ -3353,7 +3136,7 @@ function Get-LastUpdatedMetadataFreshnessFailure {
     # Requires changed rendered content to use the latest allowed current date.
     #
     # .EXAMPLE
-    # Get-LastUpdatedMetadataFreshnessFailure @hashtableArguments
+    # Get-PublishedEndpointLastUpdatedFailure @hashtableArguments
     #
     # # Runs with validated named arguments.
     #
@@ -3470,106 +3253,6 @@ function Get-LastUpdatedMetadataFreshnessFailure {
             'after a historical rendered-content change.'
         )
     }
-}
-
-function Test-TopicOwnedGitPathDeltaEqual {
-    # .SYNOPSIS
-    # Compares one authenticated path delta across two topic-head ranges.
-    #
-    # .DESCRIPTION
-    # Compares one path delta across previous and current topic-head ranges.
-    #
-    # .PARAMETER RepositoryRootPath
-    # The absolute path of the trusted Git repository.
-    #
-    # .PARAMETER PreviousBaseRevision
-    # The previous authenticated base Git object ID.
-    #
-    # .PARAMETER PreviousHeadRevision
-    # The previous authenticated head Git object ID.
-    #
-    # .PARAMETER CurrentBaseRevision
-    # The current authenticated base Git object ID.
-    #
-    # .PARAMETER CurrentHeadRevision
-    # The current authenticated head Git object ID.
-    #
-    # .PARAMETER RepositoryRelativePath
-    # The canonical repository-relative path to inspect.
-    #
-    # .EXAMPLE
-    # Test-TopicOwnedGitPathDeltaEqual @hashtableArguments
-    #
-    # # Runs with validated named arguments.
-    #
-    # .INPUTS
-    # None. No pipeline input.
-    #
-    # .OUTPUTS
-    # [System.Boolean] True when the condition in the synopsis is satisfied; otherwise false.
-    #
-    # .NOTES
-    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
-    # Parameters, return shape, and positional contract can change without notice.
-    # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
-    [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([bool])]
-    param(
-        [Parameter(Mandatory)][string] $RepositoryRootPath,
-        [Parameter(Mandatory)][string] $PreviousBaseRevision,
-        [Parameter(Mandatory)][string] $PreviousHeadRevision,
-        [Parameter(Mandatory)][string] $CurrentBaseRevision,
-        [Parameter(Mandatory)][string] $CurrentHeadRevision,
-        [Parameter(Mandatory)][string] $RepositoryRelativePath
-    )
-
-    $arrPreviousDelta = @(& git -C $RepositoryRootPath diff --unified=0 --no-renames `
-            --no-ext-diff --no-textconv $PreviousBaseRevision `
-            $PreviousHeadRevision -- $RepositoryRelativePath)
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Could not read the authenticated previous topic-owned path delta.'
-    }
-    $arrCurrentDelta = @(& git -C $RepositoryRootPath diff --unified=0 --no-renames `
-            --no-ext-diff --no-textconv $CurrentBaseRevision `
-            $CurrentHeadRevision -- $RepositoryRelativePath)
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Could not read the authenticated current topic-owned path delta.'
-    }
-    $scriptBlockGetPatchIdentity = {
-        param(
-            [string[]] $DeltaLines,
-            [string] $RangeDescription
-        )
-
-        if ($DeltaLines.Count -eq 0) {
-            return ''
-        }
-        $arrPatchIdentityOutput = @(
-            $DeltaLines | & git -C $RepositoryRootPath patch-id --verbatim
-        )
-        if ($LASTEXITCODE -ne 0) {
-            throw "Could not fingerprint the authenticated $RangeDescription delta."
-        }
-        $arrPatchIdentityOutput = @(
-            $arrPatchIdentityOutput | Where-Object {
-                -not [string]::IsNullOrWhiteSpace([string]$_)
-            }
-        )
-        if ($arrPatchIdentityOutput.Count -ne 1 -or
-            ([string]$arrPatchIdentityOutput[0]).Trim() -cnotmatch
-                '^(?<PatchId>[0-9a-f]{40}|[0-9a-f]{64})\s+[0-9a-f]+$') {
-            throw "The authenticated $RangeDescription delta has no unique patch identity."
-        }
-        return $Matches['PatchId']
-    }
-    $strPreviousPatchIdentity = & $scriptBlockGetPatchIdentity `
-        -DeltaLines $arrPreviousDelta -RangeDescription 'previous topic-owned path'
-    $strCurrentPatchIdentity = & $scriptBlockGetPatchIdentity `
-        -DeltaLines $arrCurrentDelta -RangeDescription 'current topic-owned path'
-    return (
-        $strPreviousPatchIdentity -ceq $strCurrentPatchIdentity
-    )
 }
 
 function Get-MarkdownParserBootstrapFailure {
@@ -3734,12 +3417,13 @@ function Test-ProhibitedClaudeLocalPath {
     return $RepositoryRelativePath -imatch '^(?:[^/]+/)*CLAUDE\.local\.md$'
 }
 
-function Get-MetadataEventRevisionContext {
+function Assert-PublishedEndpointContext {
     # .SYNOPSIS
-    # Resolves history and current-event comparison bases from trusted payload data.
+    # Authenticates the published baseline and final Git endpoints.
     #
     # .DESCRIPTION
-    # Authenticates event revisions and derives the exact historical and current comparison ranges used for metadata freshness validation.
+    # Validates event-specific flags, exact object IDs, object availability, and
+    # pull-request base-change evidence without inspecting topic commit history.
     #
     # .PARAMETER RepositoryRootPath
     # The absolute path of the trusted Git repository.
@@ -3748,45 +3432,30 @@ function Get-MetadataEventRevisionContext {
     # The authenticated GitHub event name.
     #
     # .PARAMETER PullRequestAction
-    # The authenticated pull-request action.
+    # The authenticated pull-request action, or empty for push.
     #
-    # .PARAMETER BaseRevision
-    # The authenticated base Git object ID.
+    # .PARAMETER BaselineRevision
+    # The authenticated published baseline commit, or zero for ref creation.
     #
-    # .PARAMETER HeadRevision
-    # The authenticated head Git object ID.
+    # .PARAMETER FinalRevision
+    # The authenticated published final commit.
     #
-    # .PARAMETER IsNewRefRange
-    # Indicates whether the range represents a newly created ref.
-    #
-    # .PARAMETER PreviousHeadRevision
-    # The previous authenticated head Git object ID.
+    # .PARAMETER BaselineAbsent
+    # Indicates that the publication created a ref with no baseline tree.
     #
     # .PARAMETER PullRequestBaseChanged
-    # Indicates whether the pull-request base changed in this event.
-    #
-    # .PARAMETER EventHeadRevision
-    # The head revision authenticated by the event payload.
-    #
-    # .PARAMETER EventHeadDistinct
-    # Indicates whether the event head differs from the current head.
-    #
-    # .PARAMETER NewRefCommitCount
-    # The authenticated number of introduced commits for a new ref.
-    #
-    # .PARAMETER NewRefCommitEvidenceJson
-    # The authenticated JSON evidence for introduced new-ref commits.
+    # Exact authenticated evidence for an edited pull-request base change.
     #
     # .EXAMPLE
-    # Get-MetadataEventRevisionContext @hashtableArguments
+    # Assert-PublishedEndpointContext @hashtableArguments
     #
-    # # Runs with validated named arguments.
+    # # Throws unless the endpoint pair and event fields are authenticated.
     #
     # .INPUTS
     # None. No pipeline input.
     #
     # .OUTPUTS
-    # [System.Management.Automation.PSCustomObject] One validated context object described in the function description.
+    # None. The function throws on invalid endpoint context.
     #
     # .NOTES
     # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
@@ -3794,395 +3463,65 @@ function Get-MetadataEventRevisionContext {
     # Positional parameters are disabled; internal callers use named arguments.
     # Version: 1.0.20260830.0.
     [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([pscustomobject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory)][string] $RepositoryRootPath,
         [Parameter(Mandatory)][string] $EventName,
         [Parameter(Mandatory)][AllowEmptyString()][string] $PullRequestAction,
-        [Parameter(Mandatory)][string] $BaseRevision,
-        [Parameter(Mandatory)][string] $HeadRevision,
-        [Parameter(Mandatory)][bool] $IsNewRefRange,
-        [Parameter(Mandatory)][AllowEmptyString()][string] $PreviousHeadRevision,
-        [Parameter()][AllowEmptyString()][string] $PullRequestBaseChanged = '',
-        [Parameter(Mandatory)][AllowEmptyString()][string] $EventHeadRevision,
-        [Parameter(Mandatory)][AllowEmptyString()][string] $EventHeadDistinct,
-        [Parameter()][AllowEmptyString()][string] $NewRefCommitCount = '',
-        [Parameter()][AllowEmptyString()][string] $NewRefCommitEvidenceJson = ''
+        [Parameter(Mandatory)][AllowEmptyString()][string] $BaselineRevision,
+        [Parameter(Mandatory)][string] $FinalRevision,
+        [Parameter(Mandatory)][bool] $BaselineAbsent,
+        [Parameter(Mandatory)][AllowEmptyString()][string] $PullRequestBaseChanged
     )
 
     $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
     $strZeroObjectIdPattern = '^(?:0{40}|0{64})$'
-    if ($HeadRevision -notmatch $strObjectIdPattern -or
-        $HeadRevision -match $strZeroObjectIdPattern) {
-        throw 'The metadata event head is invalid.'
+    if ($EventName -cnotin @('push', 'pull_request_target')) {
+        throw "Unsupported metadata publication event: $EventName"
     }
-    & git -C $RepositoryRootPath cat-file -e "$HeadRevision`^{commit}" 2>$null
+    if ($FinalRevision -notmatch $strObjectIdPattern -or
+        $FinalRevision -match $strZeroObjectIdPattern) {
+        throw 'The published final revision must be a nonzero Git object ID.'
+    }
+    & git -C $RepositoryRootPath cat-file -e "$FinalRevision`^{commit}" 2>$null
     if ($LASTEXITCODE -ne 0) {
-        throw 'The metadata event head is unavailable.'
+        throw "The published final commit is unavailable: $FinalRevision"
     }
 
-    if ($EventName -ceq 'push') {
-        if (-not [string]::IsNullOrEmpty($PullRequestAction) -or
-            -not [string]::IsNullOrEmpty($PullRequestBaseChanged) -or
-            -not [string]::IsNullOrEmpty($PreviousHeadRevision)) {
-            throw 'A push metadata event must not supply pull request fields.'
+    if ($BaselineAbsent) {
+        if ($EventName -cne 'push' -or
+            $BaselineRevision -notmatch $strZeroObjectIdPattern) {
+            throw 'Only a created push may use an absent published baseline.'
         }
-        if ($EventHeadRevision -notmatch $strObjectIdPattern -or
-            $EventHeadRevision -match $strZeroObjectIdPattern) {
-            throw 'A push metadata event requires a valid expanded head revision.'
+    }
+    else {
+        if ($BaselineRevision -notmatch $strObjectIdPattern -or
+            $BaselineRevision -match $strZeroObjectIdPattern) {
+            throw 'The published baseline revision must be a nonzero Git object ID.'
         }
-        if (-not [string]::Equals(
-                $EventHeadRevision,
-                $HeadRevision,
-                [StringComparison]::OrdinalIgnoreCase
-            )) {
-            throw 'The expanded push head revision must match the event after revision.'
-        }
-        if ($EventHeadDistinct -cnotin @('true', 'false')) {
-            throw 'The expanded push head distinct value must be true or false.'
-        }
-        $boolHeadIntroducedByPush = $EventHeadDistinct -ceq 'true'
-        if ($IsNewRefRange) {
-            if ($BaseRevision -notmatch $strZeroObjectIdPattern) {
-                throw 'A new-ref push metadata event requires an all-zero base.'
-            }
-            $intNewRefCommitCount = 0
-            if ($NewRefCommitCount -cnotmatch '^(?:0|[1-9][0-9]*)$' -or
-                -not [int]::TryParse($NewRefCommitCount, [ref]$intNewRefCommitCount)) {
-                throw 'A new-ref push requires a valid authenticated commit count.'
-            }
-            if ($intNewRefCommitCount -gt $intNewRefMaximumCommitEvidence) {
-                throw (
-                    'The authenticated new-ref commit count exceeds the maximum of ' +
-                    "$intNewRefMaximumCommitEvidence."
-                )
-            }
-            try {
-                $objNewRefCommitEvidence = ConvertFrom-Json `
-                    -InputObject $NewRefCommitEvidenceJson -NoEnumerate
-                if ($objNewRefCommitEvidence -isnot [System.Array]) {
-                    throw 'The evidence value is not an array.'
-                }
-                $arrNewRefCommitEvidence = @($objNewRefCommitEvidence)
-            }
-            catch {
-                throw 'The authenticated new-ref commit evidence is malformed.'
-            }
-            if ($arrNewRefCommitEvidence.Count -gt $intNewRefCommitCount) {
-                throw 'The authenticated new-ref commit evidence exceeds its declared count.'
-            }
-            $arrSuppliedEvidence = @($arrNewRefCommitEvidence)
-            if ($arrNewRefCommitEvidence.Count -lt $intNewRefCommitCount) {
-                $arrOtherRefTips = @(@(& git -C $RepositoryRootPath for-each-ref `
-                        '--format=%(objectname)' refs 2>$null) | Where-Object {
-                    -not [string]::Equals(([string]$_).Trim(), $HeadRevision,
-                        [StringComparison]::OrdinalIgnoreCase)
-                })
-                if ($LASTEXITCODE -ne 0) {
-                    throw 'Could not identify refs for new-ref evidence recovery.'
-                }
-                $arrRevisionArguments = @('-C', $RepositoryRootPath, 'rev-list',
-                    '--topo-order', "--max-count=$intNewRefCommitCount", $HeadRevision)
-                if ($arrOtherRefTips.Count -gt 0) {
-                    $arrRevisionArguments += @('--not') + $arrOtherRefTips
-                }
-                $arrRecoveredEvidence = @(& git @arrRevisionArguments 2>$null)
-                if ($LASTEXITCODE -ne 0 -or
-                    $arrRecoveredEvidence.Count -ne $intNewRefCommitCount) {
-                    throw 'The authenticated new-ref commit evidence is incomplete.'
-                }
-                $arrNewRefCommitEvidence = $arrRecoveredEvidence
-            }
-            if (-not $boolHeadIntroducedByPush) {
-                if ($intNewRefCommitCount -ne 0) {
-                    throw 'A non-distinct new-ref push must report zero introduced commits.'
-                }
-            }
-            elseif ($intNewRefCommitCount -eq 0) {
-                throw 'Distinct new-ref push requires an introduced commit.'
-            }
-            $setEvidenceCommits = [Collections.Generic.HashSet[string]]::new(
-                [StringComparer]::OrdinalIgnoreCase
-            )
-            $dictionaryEvidenceParents =
-                [Collections.Generic.Dictionary[string, string[]]]::new(
-                    [StringComparer]::OrdinalIgnoreCase
-                )
-            foreach ($objEvidenceCommit in $arrNewRefCommitEvidence) {
-                $strEvidenceCommit = [string]$objEvidenceCommit
-                if ($strEvidenceCommit -notmatch $strObjectIdPattern -or
-                    $strEvidenceCommit -match $strZeroObjectIdPattern) {
-                    throw 'The authenticated new-ref commit evidence contains an invalid commit.'
-                }
-                if (-not $setEvidenceCommits.Add($strEvidenceCommit)) {
-                    throw 'The authenticated new-ref commit evidence contains a duplicate commit.'
-                }
-                & git -C $RepositoryRootPath cat-file -e `
-                    "$strEvidenceCommit`^{commit}" 2>$null
-                if ($LASTEXITCODE -ne 0) {
-                    throw 'The authenticated new-ref commit evidence is unavailable.'
-                }
-                $strCommitAndParents = [string](& git -C $RepositoryRootPath `
-                        rev-list --parents -n 1 $strEvidenceCommit 2>$null)
-                if ($LASTEXITCODE -ne 0) {
-                    throw 'The authenticated new-ref commit evidence is unavailable.'
-                }
-                $arrCommitAndParents = @($strCommitAndParents.Trim() -split '\s+')
-                if ($arrCommitAndParents.Count -eq 0 -or
-                    $arrCommitAndParents[0] -notmatch $strObjectIdPattern -or
-                    -not [string]::Equals(
-                        $arrCommitAndParents[0],
-                        $strEvidenceCommit,
-                        [StringComparison]::OrdinalIgnoreCase
-                    )) {
-                    throw 'Git returned a mismatched new-ref evidence identity.'
-                }
-                $intEvidenceParentCount = $arrCommitAndParents.Count - 1
-                if ($intEvidenceParentCount -gt $intMetadataMaximumParents) {
-                    throw (
-                        "Authenticated new-ref commit $strEvidenceCommit has " +
-                        "$intEvidenceParentCount parents; the maximum is " +
-                        "$intMetadataMaximumParents."
-                    )
-                }
-                $listEvidenceParents = [Collections.Generic.List[string]]::new()
-                for ($intParentIndex = 1;
-                    $intParentIndex -lt $arrCommitAndParents.Count;
-                    $intParentIndex++) {
-                    $strEvidenceParent = [string]$arrCommitAndParents[$intParentIndex]
-                    if ($strEvidenceParent -notmatch $strObjectIdPattern -or
-                        $strEvidenceParent -match $strZeroObjectIdPattern) {
-                        throw 'Git returned an invalid new-ref evidence parent.'
-                    }
-                    & git -C $RepositoryRootPath cat-file -e `
-                        "$strEvidenceParent`^{commit}" 2>$null
-                    if ($LASTEXITCODE -ne 0) {
-                        throw 'Git returned an unavailable new-ref evidence parent.'
-                    }
-                    $listEvidenceParents.Add($strEvidenceParent)
-                }
-                $dictionaryEvidenceParents.Add(
-                    $strEvidenceCommit,
-                    $listEvidenceParents.ToArray()
-                )
-            }
-            $setSuppliedEvidence = [Collections.Generic.HashSet[string]]::new(
-                [StringComparer]::OrdinalIgnoreCase)
-            foreach ($objSuppliedEvidence in $arrSuppliedEvidence) {
-                $strSuppliedEvidence = [string]$objSuppliedEvidence
-                if ($strSuppliedEvidence -notmatch $strObjectIdPattern -or
-                    $strSuppliedEvidence -match $strZeroObjectIdPattern) {
-                    throw 'The authenticated new-ref commit evidence contains an invalid commit.'
-                }
-                if (-not $setSuppliedEvidence.Add($strSuppliedEvidence)) {
-                    throw 'The authenticated new-ref commit evidence contains a duplicate commit.'
-                }
-                if (-not $setEvidenceCommits.Contains($strSuppliedEvidence)) {
-                    throw 'The authenticated new-ref commit evidence contradicts Git history.'
-                }
-            }
-            if ($boolHeadIntroducedByPush -and
-                -not $setEvidenceCommits.Contains($HeadRevision)) {
-                throw 'The authenticated new-ref commit evidence does not contain the event head.'
-            }
-            $setReachableEvidence = [Collections.Generic.HashSet[string]]::new(
-                [StringComparer]::OrdinalIgnoreCase
-            )
-            $setBoundaryParents = [Collections.Generic.HashSet[string]]::new(
-                [StringComparer]::OrdinalIgnoreCase
-            )
-            if ($boolHeadIntroducedByPush) {
-                $stackEvidenceCommits = [Collections.Generic.Stack[string]]::new()
-                $stackEvidenceCommits.Push($HeadRevision)
-                while ($stackEvidenceCommits.Count -gt 0) {
-                    $strReachableCommit = $stackEvidenceCommits.Pop()
-                    if (-not $setReachableEvidence.Add($strReachableCommit)) {
-                        continue
-                    }
-                    foreach ($strReachableParent in
-                        $dictionaryEvidenceParents[$strReachableCommit]) {
-                        if ($setEvidenceCommits.Contains($strReachableParent)) {
-                            $stackEvidenceCommits.Push($strReachableParent)
-                        }
-                        else {
-                            [void]$setBoundaryParents.Add($strReachableParent)
-                        }
-                    }
-                }
-                if ($setReachableEvidence.Count -ne $setEvidenceCommits.Count) {
-                    throw 'The authenticated new-ref commit evidence contains a disconnected commit.'
-                }
-            }
-            $arrFreshnessBases = @($setBoundaryParents | Sort-Object)
-            return [pscustomobject]@{
-                HistoryBaseRevision = $BaseRevision
-                HistoryBaseRevisions = @($BaseRevision)
-                FreshnessBaseRevision = if ($arrFreshnessBases.Count -eq 1) {
-                    $arrFreshnessBases[0]
-                } else { '' }
-                FreshnessBaseRevisions = $arrFreshnessBases
-                EvaluateFreshness = $boolHeadIntroducedByPush
-                PreviousTopicBaseRevision = ''
-                PreviousTopicHeadRevision = ''
-                CurrentTopicBaseRevision = ''
-                CurrentTopicHeadRevision = ''
-                NewRefBoundaryRevisions = $arrFreshnessBases
-                NewRefIntroducedCommitRevisions = @(
-                    $setEvidenceCommits | Sort-Object
-                )
-            }
-        }
-        if (-not [string]::IsNullOrEmpty($NewRefCommitCount) -or
-            -not [string]::IsNullOrEmpty($NewRefCommitEvidenceJson)) {
-            throw 'An existing-ref push must not supply new-ref commit evidence.'
-        }
-        if ($BaseRevision -notmatch $strObjectIdPattern -or
-            $BaseRevision -match $strZeroObjectIdPattern) {
-            throw 'An existing-ref push metadata event requires a valid base.'
-        }
-        & git -C $RepositoryRootPath cat-file -e `
-            "$BaseRevision`^{commit}" 2>$null
+        & git -C $RepositoryRootPath cat-file -e "$BaselineRevision`^{commit}" 2>$null
         if ($LASTEXITCODE -ne 0) {
-            throw 'The existing-ref push base is unavailable.'
-        }
-        return [pscustomobject]@{
-            HistoryBaseRevision = $BaseRevision
-            HistoryBaseRevisions = @($BaseRevision)
-            FreshnessBaseRevision = if ($boolHeadIntroducedByPush) {
-                $BaseRevision
-            }
-            else {
-                ''
-            }
-            FreshnessBaseRevisions = if ($boolHeadIntroducedByPush) {
-                @($BaseRevision)
-            } else { @() }
-            EvaluateFreshness = $boolHeadIntroducedByPush
-            PreviousTopicBaseRevision = ''
-            PreviousTopicHeadRevision = ''
-            CurrentTopicBaseRevision = ''
-            CurrentTopicHeadRevision = ''
+            throw "The published baseline commit is unavailable: $BaselineRevision"
         }
     }
 
-    if ($EventName -cne 'pull_request_target') {
-        throw "Unsupported metadata event name: $EventName"
-    }
-    if ($IsNewRefRange -or
-        -not [string]::IsNullOrEmpty($EventHeadRevision) -or
-        -not [string]::IsNullOrEmpty($EventHeadDistinct) -or
-        -not [string]::IsNullOrEmpty($NewRefCommitCount) -or
-        -not [string]::IsNullOrEmpty($NewRefCommitEvidenceJson)) {
-        throw 'A pull request metadata event must not use push-only fields.'
-    }
-    if ($PullRequestAction -cnotin @('opened', 'reopened', 'synchronize', 'edited')) {
-        throw "Unsupported pull request metadata action: $PullRequestAction"
-    }
-    if ($PullRequestAction -ceq 'edited') {
-        if ($PullRequestBaseChanged -cne 'true') {
-            throw 'An edited pull request event requires trusted base-change proof.'
+    if ($EventName -ceq 'pull_request_target') {
+        if ($BaselineAbsent -or
+            $PullRequestAction -cnotin @('opened', 'reopened', 'synchronize', 'edited')) {
+            throw 'Pull request publication endpoints are incomplete.'
+        }
+        if ($PullRequestAction -ceq 'edited') {
+            if ($PullRequestBaseChanged -cne 'true') {
+                throw 'An edited pull request requires an authenticated base change.'
+            }
+        }
+        elseif (-not [string]::IsNullOrEmpty($PullRequestBaseChanged)) {
+            throw 'Pull request base-change evidence is only valid for edited events.'
         }
     }
-    elseif (-not [string]::IsNullOrEmpty($PullRequestBaseChanged)) {
-        throw 'Only an edited pull request event may supply base-change proof.'
-    }
-    if ($BaseRevision -notmatch $strObjectIdPattern -or
-        $BaseRevision -match $strZeroObjectIdPattern) {
-        throw 'A pull request metadata event requires a valid base tip.'
-    }
-    & git -C $RepositoryRootPath cat-file -e "$BaseRevision`^{commit}" 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        throw 'The pull request base tip is unavailable.'
-    }
-    $arrMergeBases = @(
-        & git -C $RepositoryRootPath merge-base --all `
-            $BaseRevision $HeadRevision 2>$null |
-            ForEach-Object { ([string]$_).Trim() } |
-            Sort-Object -Unique
-    )
-    if ($LASTEXITCODE -ne 0 -or $arrMergeBases.Count -lt 1 -or
-        $arrMergeBases.Count -gt $intMetadataMaximumParents -or
-        @($arrMergeBases | Where-Object {
-                $_ -notmatch $strObjectIdPattern -or $_ -match $strZeroObjectIdPattern
-            }).Count -ne 0) {
-        throw 'The pull request metadata range must have 1 through 64 available merge bases.'
-    }
-    foreach ($strMergeBase in $arrMergeBases) {
-        & git -C $RepositoryRootPath cat-file -e "$strMergeBase`^{commit}" 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            throw 'The pull request metadata range contains an unavailable merge base.'
-        }
-    }
-    $strHistoryBase = if ($arrMergeBases.Count -eq 1) {
-        $arrMergeBases[0]
-    } else { '' }
-
-    if ($PullRequestAction -cne 'synchronize') {
-        if (-not [string]::IsNullOrEmpty($PreviousHeadRevision)) {
-            throw 'A nonsynchronize pull request must not supply a previous head.'
-        }
-        return [pscustomobject]@{
-            HistoryBaseRevision = $strHistoryBase
-            HistoryBaseRevisions = $arrMergeBases
-            FreshnessBaseRevision = $strHistoryBase
-            FreshnessBaseRevisions = $arrMergeBases
-            EvaluateFreshness = $true
-            PreviousTopicBaseRevision = ''
-            PreviousTopicHeadRevision = ''
-            CurrentTopicBaseRevision = ''
-            CurrentTopicHeadRevision = ''
-        }
-    }
-    if ($PreviousHeadRevision -notmatch $strObjectIdPattern -or
-        $PreviousHeadRevision -match $strZeroObjectIdPattern -or
-        [string]::Equals(
-            $PreviousHeadRevision,
-            $HeadRevision,
-            [StringComparison]::OrdinalIgnoreCase
-        )) {
-        throw 'A synchronize event requires a distinct valid previous topic head.'
-    }
-    & git -C $RepositoryRootPath cat-file -e `
-        "$PreviousHeadRevision`^{commit}" 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        throw 'The synchronize previous topic head is unavailable.'
-    }
-    $arrPreviousMergeBases = @(
-        & git -C $RepositoryRootPath merge-base --all `
-            $BaseRevision $PreviousHeadRevision 2>$null |
-            ForEach-Object { ([string]$_).Trim() } |
-            Sort-Object -Unique
-    )
-    if ($LASTEXITCODE -ne 0 -or $arrPreviousMergeBases.Count -lt 1 -or
-        $arrPreviousMergeBases.Count -gt $intMetadataMaximumParents -or
-        @($arrPreviousMergeBases | Where-Object {
-                $_ -notmatch $strObjectIdPattern -or $_ -match $strZeroObjectIdPattern
-            }).Count -ne 0) {
-        throw 'The synchronize previous topic range must have 1 through 64 available merge bases.'
-    }
-    foreach ($strPreviousMergeBase in $arrPreviousMergeBases) {
-        & git -C $RepositoryRootPath cat-file -e `
-            "$strPreviousMergeBase`^{commit}" 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            throw 'The synchronize previous topic range contains an unavailable merge base.'
-        }
-    }
-    $boolSingleTopicBase = $arrMergeBases.Count -eq 1 -and
-        $arrPreviousMergeBases.Count -eq 1
-    return [pscustomobject]@{
-        HistoryBaseRevision = $strHistoryBase
-        HistoryBaseRevisions = $arrMergeBases
-        FreshnessBaseRevision = $PreviousHeadRevision
-        FreshnessBaseRevisions = @($PreviousHeadRevision)
-        EvaluateFreshness = $true
-        PreviousTopicBaseRevision = if ($boolSingleTopicBase) {
-            $arrPreviousMergeBases[0]
-        } else { '' }
-        PreviousTopicHeadRevision = $PreviousHeadRevision
-        CurrentTopicBaseRevision = if ($boolSingleTopicBase) {
-            $arrMergeBases[0]
-        } else { '' }
-        CurrentTopicHeadRevision = $HeadRevision
+    elseif (-not [string]::IsNullOrEmpty($PullRequestAction) -or
+        -not [string]::IsNullOrEmpty($PullRequestBaseChanged)) {
+        throw 'Push publication endpoints received pull request fields.'
     }
 }
 
@@ -5058,7 +4397,8 @@ function Get-DocumentMetadataContext {
     $arrRequiredFields = @(
         [pscustomobject]@{
             Name = 'Status'
-            Pattern = '^- \*\*Status:\*\* (?<Value>Draft|Active|Deprecated)$'
+            Pattern = '^- \*\*Status:\*\* ' +
+                '(?<Value>Draft|Proposed|Active|Accepted|Superseded|Deprecated)$'
         },
         [pscustomobject]@{
             Name = 'Owner'
@@ -5129,6 +4469,8 @@ function Get-DocumentMetadataContext {
 
     return [pscustomobject]@{
         Failure = $null
+        Major = if ($RequiresVersion) {$objVersionMatch.Groups['Major'].Value} else {$null}
+        Minor = if ($RequiresVersion) {$objVersionMatch.Groups['Minor'].Value} else {$null}
         VersionDate = if ($RequiresVersion) {$objVersionMatch.Groups['Date'].Value} else {$null}
         UpdatedDate = $objUpdatedMatch.Groups['Date'].Value
         Revision = if ($RequiresVersion) {$objVersionMatch.Groups['Revision'].Value} else {$null}
@@ -5137,7 +4479,7 @@ function Get-DocumentMetadataContext {
     }
 }
 
-function Get-DocumentMetadataTransitionFailure {
+function Get-PublishedEndpointMetadataFailure {
     # .SYNOPSIS
     # Finds metadata failures in one document transition.
     #
@@ -5164,7 +4506,7 @@ function Get-DocumentMetadataTransitionFailure {
     # True to require the expected date after rendered changes.
     #
     # .EXAMPLE
-    # $arrFailure = @(Get-DocumentMetadataTransitionFailure `
+    # $arrFailure = @(Get-PublishedEndpointMetadataFailure `
     #     -Name 'AGENTS.md' -CurrentContent $strCurrent `
     #     -ParentContent $strParent -ExpectedUtcDate '2026-08-27' `
     #     -IsNewDocumentTransition $false)
@@ -5229,6 +4571,16 @@ function Get-DocumentMetadataTransitionFailure {
         return
     }
 
+    $intCurrentMajor = [int64] 0
+    $intCurrentMinor = [int64] 0
+    $intCurrentRevision = [int64] 0
+    if (-not [int64]::TryParse($objCurrentMetadata.Major, [ref] $intCurrentMajor) -or
+        -not [int64]::TryParse($objCurrentMetadata.Minor, [ref] $intCurrentMinor) -or
+        -not [int64]::TryParse($objCurrentMetadata.Revision, [ref] $intCurrentRevision)) {
+        Write-Output "$Name Version major, minor, and revision must fit in signed 64-bit integers."
+        return
+    }
+
     if ([string]::IsNullOrEmpty($ParentContent)) {
         if (-not $IsNewDocumentTransition) {
             return
@@ -5246,6 +4598,11 @@ function Get-DocumentMetadataTransitionFailure {
         if ($strCurrentUpdatedDate -cne $ExpectedUtcDate) {
             Write-Output (
                 "$Name Last Updated must be $ExpectedUtcDate after a rendered-content change."
+            )
+        }
+        if ($intCurrentRevision -ne 0) {
+            Write-Output (
+                "$Name Version revision must be exactly 0 when no published baseline exists."
             )
         }
         return
@@ -5275,17 +4632,16 @@ function Get-DocumentMetadataTransitionFailure {
         return
     }
 
-    $intCurrentRevision = [int64] 0
+    $intParentMajor = [int64] 0
+    $intParentMinor = [int64] 0
     $intParentRevision = [int64] 0
-    if (-not [int64]::TryParse(
-            $objCurrentMetadata.Revision,
-            [ref] $intCurrentRevision
-        ) -or
-        -not [int64]::TryParse(
-            $objParentMetadata.Revision,
-            [ref] $intParentRevision
-        )) {
-        Write-Output "$Name Version revision must fit in a signed 64-bit integer."
+    if (-not [int64]::TryParse($objParentMetadata.Major, [ref] $intParentMajor) -or
+        -not [int64]::TryParse($objParentMetadata.Minor, [ref] $intParentMinor) -or
+        -not [int64]::TryParse($objParentMetadata.Revision, [ref] $intParentRevision)) {
+        Write-Output (
+            "The published baseline $Name Version major, minor, and revision must fit " +
+            'in signed 64-bit integers.'
+        )
         return
     }
 
@@ -5293,23 +4649,27 @@ function Get-DocumentMetadataTransitionFailure {
         $strCurrentVersionDate,
         $strParentVersionDate
     )
+    $intHigherOrderComparison = if ($intCurrentMajor -ne $intParentMajor) {
+        $intCurrentMajor.CompareTo($intParentMajor)
+    }
+    elseif ($intCurrentMinor -ne $intParentMinor) {
+        $intCurrentMinor.CompareTo($intParentMinor)
+    }
+    else {
+        $intVersionDateComparison
+    }
     $strCurrentComparison = ConvertTo-MetadataComparisonText `
         -Content $CurrentContent -MetadataContext $objCurrentMetadata
     $strParentComparison = ConvertTo-MetadataComparisonText `
         -Content $ParentContent -MetadataContext $objParentMetadata
     $boolRenderedContentChanged = $strCurrentComparison -cne $strParentComparison
-    if ($intVersionDateComparison -lt 0) {
+    if ($intHigherOrderComparison -lt 0) {
         Write-Output (
-            "$Name Version date must not move backward from $strParentVersionDate to " +
-            "$strCurrentVersionDate."
+            "$Name Version major, minor, and date tuple must not move backward from " +
+            "$intParentMajor.$intParentMinor.$strParentVersionDate to " +
+            "$intCurrentMajor.$intCurrentMinor.$strCurrentVersionDate."
         )
-    }
-    elseif ($intVersionDateComparison -eq 0 -and
-        $intCurrentRevision -lt $intParentRevision) {
-        Write-Output (
-            "$Name Version revision must not decrease from $intParentRevision to " +
-            "$intCurrentRevision."
-        )
+        return
     }
 
     if (-not $boolRenderedContentChanged) {
@@ -5330,92 +4690,27 @@ function Get-DocumentMetadataTransitionFailure {
         }
     }
 
-    if ($intVersionDateComparison -eq 0) {
+    if ($intHigherOrderComparison -eq 0) {
         if ($intParentRevision -eq [int64]::MaxValue) {
-            Write-Output "The parent $Name Version revision cannot be incremented safely."
-        }
-        elseif ($intCurrentRevision -eq $intParentRevision) {
             Write-Output (
-                "$Name Version revision must be greater than $intParentRevision after a " +
-                'same-day content change.'
+                "The published baseline $Name Version revision cannot be incremented safely."
+            )
+            return
+        }
+        $intExpectedRevision = $intParentRevision + 1
+        if ($intCurrentRevision -ne $intExpectedRevision) {
+            Write-Output (
+                "$Name Version revision must be exactly $intExpectedRevision after a " +
+                'rendered-content change with an unchanged published-baseline major, ' +
+                'minor, and date tuple.'
             )
         }
     }
-}
-
-function Get-DocumentMetadataRangeTransitionFailure {
-    # .SYNOPSIS
-    # Finds metadata-policy failures across document transition records.
-    #
-    # .DESCRIPTION
-    # Evaluates direct-parent metadata transitions.
-    #
-    # .PARAMETER Name
-    # The governed document display name used in diagnostic output.
-    #
-    # .PARAMETER TransitionContext
-    # Ordered transition records. Each record supplies CurrentContent,
-    # ParentContent, ExpectedUtcDate, CurrentRevision, and ParentRevision. The
-    # optional RequireExpectedUtcDateForRenderedChange property defaults to true.
-    #
-    # .EXAMPLE
-    # $arrFailure = @(Get-DocumentMetadataRangeTransitionFailure `
-    #     -Name 'AGENTS.md' -TransitionContext $arrTransitions)
-    #
-    # # Returns no strings when every transition satisfies the metadata policy.
-    #
-    # .EXAMPLE
-    # Get-DocumentMetadataRangeTransitionFailure `
-    #     -Name 'AGENTS.md' -TransitionContext $arrTransitions
-    #
-    # # Writes one commit-prefixed string for every failed transition rule.
-    #
-    # .INPUTS
-    # None. You can't pipe objects to this function.
-    #
-    # .OUTPUTS
-    # [string] Zero or more diagnostics in the form Name transition
-    # ParentRevision..CurrentRevision followed by the transition failure. No
-    # output means every supplied transition passed.
-    #
-    # .NOTES
-    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
-    # Parameters, return shape, and positional contract can change without notice.
-    # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
-    [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory)]
-        [string] $Name,
-
-        [Parameter(Mandatory)]
-        [AllowEmptyCollection()]
-        [pscustomobject[]] $TransitionContext
-    )
-
-    foreach ($objTransition in $TransitionContext) {
-        $objDateRequirementProperty =
-            $objTransition.PSObject.Properties['RequireExpectedUtcDateForRenderedChange']
-        $boolRequireExpectedUtcDate = if ($null -eq $objDateRequirementProperty) {
-            $true
-        }
-        else {
-            [bool] $objDateRequirementProperty.Value
-        }
-        $arrTransitionFailures = @(Get-DocumentMetadataTransitionFailure `
-                -Name $Name `
-                -CurrentContent $objTransition.CurrentContent `
-                -ParentContent $objTransition.ParentContent `
-                -ExpectedUtcDate $objTransition.ExpectedUtcDate `
-                -IsNewDocumentTransition ($null -eq $objTransition.ParentContent) `
-                -RequireExpectedUtcDateForRenderedChange $boolRequireExpectedUtcDate)
-        foreach ($strFailure in $arrTransitionFailures) {
-            Write-Output (
-                "$Name transition $($objTransition.ParentRevision).." +
-                "$($objTransition.CurrentRevision): $strFailure"
-            )
-        }
+    elseif ($intCurrentRevision -ne 0) {
+        Write-Output (
+            "$Name Version revision must be exactly 0 when the major, minor, or date " +
+            'tuple differs from the published baseline.'
+        )
     }
 }
 
@@ -5519,709 +4814,6 @@ function Get-TrustRootRangeMutationFailure {
             "Pull request changes trusted validation path $strTrustPath. " +
             'Update this trust root only through an authorized trusted-base maintenance path.'
         )
-    }
-}
-
-function Get-GovernedDocumentCommitTransitionFailure {
-    # .SYNOPSIS
-    # Finds an invalid governed-document transition in one commit.
-    #
-    # .DESCRIPTION
-    # Validates one commit against each parent as a governed-document transition.
-    #
-    # .PARAMETER Name
-    # The fixture or document name to use in diagnostics.
-    #
-    # .PARAMETER RepositoryRootPath
-    # The absolute path of the trusted Git repository.
-    #
-    # .PARAMETER RepositoryRelativePath
-    # The canonical repository-relative path to inspect.
-    #
-    # .PARAMETER MaximumBytes
-    # The maximum permitted output size in bytes.
-    #
-    # .PARAMETER CommitRevision
-    # The exact commit whose parent transitions must be validated.
-    #
-    # .PARAMETER PolicyRepositoryRelativePath
-    # The repository-relative policy document path.
-    #
-    # .PARAMETER PolicyMaximumBytes
-    # The maximum permitted policy document size in bytes.
-    #
-    # .PARAMETER PolicyMarker
-    # The exact marker that activates the historical policy.
-    #
-    # .PARAMETER RequireExpectedUtcDateForRenderedChange
-    # Requires a rendered change to use the expected UTC date.
-    #
-    # .PARAMETER RequiresVersion
-    # Indicates whether the document header must contain Version metadata.
-    #
-    # .PARAMETER RequiredDocument
-    # Indicates whether deletion of the governed document is prohibited.
-    #
-    # .EXAMPLE
-    # Get-GovernedDocumentCommitTransitionFailure @hashtableArguments
-    #
-    # # Runs with validated named arguments.
-    #
-    # .INPUTS
-    # None. No pipeline input.
-    #
-    # .OUTPUTS
-    # [System.String] Zero or more validated values or diagnostics described in the function description.
-    #
-    # .NOTES
-    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
-    # Parameters, return shape, and positional contract can change without notice.
-    # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
-    [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory)]
-        [string] $Name,
-
-        [Parameter(Mandatory)]
-        [string] $RepositoryRootPath,
-
-        [Parameter(Mandatory)]
-        [string] $RepositoryRelativePath,
-
-        [Parameter(Mandatory)]
-        [ValidateRange(1, 2147483646)]
-        [int] $MaximumBytes,
-
-        [Parameter(Mandatory)]
-        [string] $CommitRevision,
-
-        [Parameter(Mandatory)]
-        [string] $PolicyRepositoryRelativePath,
-
-        [Parameter(Mandatory)]
-        [ValidateRange(1, 2147483646)]
-        [int] $PolicyMaximumBytes,
-
-        [Parameter(Mandatory)]
-        [string] $PolicyMarker,
-
-        [Parameter()]
-        [bool] $RequireExpectedUtcDateForRenderedChange = $false,
-
-        [Parameter()]
-        [bool] $RequiresVersion = $true,
-
-        [Parameter()]
-        [bool] $RequiredDocument = $false
-    )
-
-    $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
-    if ($CommitRevision -notmatch $strObjectIdPattern) {
-        throw "The governed direct-transition commit is invalid: $CommitRevision"
-    }
-    & git -C $RepositoryRootPath cat-file -e "$CommitRevision`^{commit}" 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        throw "The governed direct-transition commit is unavailable: $CommitRevision"
-    }
-    $strParentLine = [string] (
-        & git -C $RepositoryRootPath rev-list --parents -n 1 $CommitRevision
-    )
-    if ($LASTEXITCODE -ne 0) {
-        throw "Could not read the parents of metadata range commit $CommitRevision."
-    }
-    $arrCommitAndParents = @($strParentLine.Trim() -split '\s+')
-    if ($arrCommitAndParents.Count -eq 0 -or
-        $arrCommitAndParents[0] -notmatch $strObjectIdPattern -or
-        -not [string]::Equals(
-            $arrCommitAndParents[0],
-            $CommitRevision,
-            [StringComparison]::OrdinalIgnoreCase
-        )) {
-        throw "Git returned an invalid identity for metadata range commit $CommitRevision."
-    }
-    $intParentCount = $arrCommitAndParents.Count - 1
-    if ($intParentCount -gt $intMetadataMaximumParents) {
-        throw (
-            "Metadata range commit $CommitRevision has $intParentCount parents; " +
-            "the maximum is $intMetadataMaximumParents."
-        )
-    }
-    $listParentContexts = [Collections.Generic.List[pscustomobject]]::new()
-    $boolHasPolicyActiveParent = $false
-    for ($intParentIndex = 1;
-        $intParentIndex -lt $arrCommitAndParents.Count;
-        $intParentIndex++) {
-        $strParentRevision = [string]$arrCommitAndParents[$intParentIndex]
-        if ($strParentRevision -notmatch $strObjectIdPattern) {
-            throw "Git returned an invalid parent for metadata range commit $CommitRevision."
-        }
-        & git -C $RepositoryRootPath cat-file -e `
-            "$strParentRevision`^{commit}" 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            throw "Git returned an unavailable parent for metadata range commit $CommitRevision."
-        }
-        $boolParentHasPolicyMarker = Test-HistoricalPolicyMarker `
-            -RepositoryRootPath $RepositoryRootPath `
-            -Revision $strParentRevision `
-            -RepositoryRelativePath $PolicyRepositoryRelativePath `
-            -Literal $PolicyMarker
-        if ($boolParentHasPolicyMarker) {
-            $boolHasPolicyActiveParent = $true
-        }
-        $listParentContexts.Add([pscustomobject]@{
-                Revision = $strParentRevision
-                HasPolicyMarker = $boolParentHasPolicyMarker
-            })
-    }
-    $arrCurrentTreeEntries = @(& git -C $RepositoryRootPath ls-tree `
-            $CommitRevision -- $RepositoryRelativePath 2>&1)
-    if ($LASTEXITCODE -ne 0) {
-        throw (
-            "Could not inspect $RepositoryRelativePath for metadata range commit " +
-            "$CommitRevision."
-        )
-    }
-    $boolUseWorktreePolicy = $false
-    if ($CommitRevision -ceq $script:strCheckedOutRevision) {
-        & git -C $RepositoryRootPath diff --quiet --no-ext-diff --no-textconv `
-            $CommitRevision -- $PolicyRepositoryRelativePath
-        if ($LASTEXITCODE -eq 1) {
-            $boolUseWorktreePolicy = $true
-        } elseif ($LASTEXITCODE -ne 0) {
-            throw 'Could not compare the checked-out policy with its commit.'
-        }
-    }
-    if ($boolUseWorktreePolicy) {
-        $arrPolicyBytes = [byte[]] @(
-            Read-RepositoryInputData `
-                -Path (Join-Path $RepositoryRootPath $PolicyRepositoryRelativePath) `
-                -RepositoryRootPath $RepositoryRootPath `
-                -RepositoryRelativePath $PolicyRepositoryRelativePath `
-                -DisplayName $PolicyRepositoryRelativePath `
-                -MaximumBytes $PolicyMaximumBytes
-        )
-        $strPolicy = ConvertFrom-StrictUtf8Data `
-            -Bytes $arrPolicyBytes -DisplayName $PolicyRepositoryRelativePath
-        if (-not $strPolicy.Contains($PolicyMarker, [StringComparison]::Ordinal)) {
-            throw 'The checked-out policy is missing its governance marker.'
-        }
-    } elseif (-not (Test-HistoricalPolicyMarker `
-                -RepositoryRootPath $RepositoryRootPath `
-                -Revision $CommitRevision `
-                -RepositoryRelativePath $PolicyRepositoryRelativePath `
-                -Literal $PolicyMarker)) {
-        if ($boolHasPolicyActiveParent) {
-            Write-Output (
-                "$PolicyRepositoryRelativePath governance marker $PolicyMarker " +
-                "must not be removed at metadata range commit $CommitRevision."
-            )
-        }
-        if ($RequiredDocument -and $arrCurrentTreeEntries.Count -eq 0) {
-            Write-Output "Required governed document $RepositoryRelativePath must exist in $CommitRevision."
-        }
-        return
-    }
-
-    $listChangedParents = [Collections.Generic.List[pscustomobject]]::new()
-    $boolMatchesPolicyActiveParent = $false
-    foreach ($objParentContext in $listParentContexts) {
-        & git -C $RepositoryRootPath diff --quiet --no-ext-diff --no-textconv `
-            $objParentContext.Revision $CommitRevision -- $RepositoryRelativePath
-        $intDiffExitCode = $LASTEXITCODE
-        if ($intDiffExitCode -eq 0) {
-            if ($objParentContext.HasPolicyMarker) {
-                $boolMatchesPolicyActiveParent = $true
-            }
-            continue
-        }
-        if ($intDiffExitCode -ne 1) {
-            throw (
-                "Could not compare $RepositoryRelativePath for metadata range commit " +
-                "$CommitRevision."
-            )
-        }
-        $boolRestoresFirstParentBlob = $false
-        $strChangedParentFirstParent = [string] (
-            & git -C $RepositoryRootPath rev-parse --verify `
-                "$($objParentContext.Revision)`^1`^{commit}" 2>$null
-        )
-        if ($LASTEXITCODE -eq 0 -and
-            -not [string]::IsNullOrEmpty($strChangedParentFirstParent.Trim())) {
-            & git -C $RepositoryRootPath diff --quiet --no-ext-diff --no-textconv `
-                $strChangedParentFirstParent.Trim() $CommitRevision -- `
-                $RepositoryRelativePath
-            $intRestorationDiffExitCode = $LASTEXITCODE
-            if ($intRestorationDiffExitCode -eq 0) {
-                $boolRestoresFirstParentBlob = $true
-            }
-            elseif ($intRestorationDiffExitCode -ne 1) {
-                throw (
-                    "Could not verify exact restoration of $RepositoryRelativePath " +
-                    "for metadata range commit $CommitRevision."
-                )
-            }
-        }
-        $listChangedParents.Add([pscustomobject]@{
-                Revision = $objParentContext.Revision
-                HasPolicyMarker = $objParentContext.HasPolicyMarker
-                RestoresFirstParentBlob = $boolRestoresFirstParentBlob
-            })
-    }
-    if ($intParentCount -ne 0 -and $listChangedParents.Count -eq 0) {
-        return [string[]] @()
-    }
-
-    $strCommitTimestamp = [string] (
-        & git -C $RepositoryRootPath show -s --format=%cI $CommitRevision
-    )
-    if ($LASTEXITCODE -ne 0) {
-        throw "Could not read the timestamp of metadata range commit $CommitRevision."
-    }
-    $objCommitTimestamp = [DateTimeOffset]::MinValue
-    if (-not [DateTimeOffset]::TryParse(
-            $strCommitTimestamp.Trim(),
-            [ref] $objCommitTimestamp
-        )) {
-        throw "Metadata range commit $CommitRevision has an invalid timestamp."
-    }
-    if ($objCommitTimestamp -gt $script:objMaximumCommitUtcTimestamp) {
-        Write-Output (
-            "Metadata range commit $CommitRevision timestamp " +
-            "$($objCommitTimestamp.ToUniversalTime().ToString('o')) must not be later than " +
-            "trusted UTC $($script:objMaximumCommitUtcTimestamp.ToString('o'))."
-        )
-        return
-    }
-
-    if ($arrCurrentTreeEntries.Count -eq 0) {
-        if ($RequiredDocument) {
-            Write-Output "Required governed document $RepositoryRelativePath must exist in $CommitRevision."
-        }
-        return [string[]] @()
-    }
-
-    $strCurrentContent = Read-GitRevisionText `
-        -RepositoryRootPath $RepositoryRootPath `
-        -Revision $CommitRevision `
-        -RepositoryRelativePath $RepositoryRelativePath `
-        -MaximumBytes $MaximumBytes `
-        -RequireRegularFile
-    $listTransitions = [Collections.Generic.List[pscustomobject]]::new()
-    if ($intParentCount -eq 0) {
-        $listTransitions.Add([pscustomobject]@{
-                CurrentContent = $strCurrentContent
-                ParentContent = $null
-                ExpectedUtcDate = $objCommitTimestamp.UtcDateTime.ToString('yyyy-MM-dd')
-                CurrentRevision = $CommitRevision
-                ParentRevision = ''
-                AllowSameDateForExactRestoration = $false
-                RequireExpectedUtcDateForRenderedChange =
-                    $RequireExpectedUtcDateForRenderedChange
-            })
-    }
-    foreach ($objChangedParent in $listChangedParents) {
-        $strParentContent = if ($objChangedParent.HasPolicyMarker) {
-            & git -C $RepositoryRootPath cat-file -e `
-                "$($objChangedParent.Revision)`:$RepositoryRelativePath" 2>$null
-            if ($LASTEXITCODE -ne 0) {
-                $null
-            }
-            else {
-            Read-GitRevisionText `
-                -RepositoryRootPath $RepositoryRootPath `
-                    -Revision $objChangedParent.Revision `
-                -RepositoryRelativePath $RepositoryRelativePath `
-                -MaximumBytes $MaximumBytes `
-                -RequireRegularFile
-            }
-        }
-        else {
-            $null
-        }
-        $listTransitions.Add([pscustomobject]@{
-                CurrentContent = $strCurrentContent
-                ParentContent = $strParentContent
-                ExpectedUtcDate = $objCommitTimestamp.UtcDateTime.ToString('yyyy-MM-dd')
-                CurrentRevision = $CommitRevision
-                ParentRevision = $objChangedParent.Revision
-                AllowSameDateForExactRestoration =
-                    $objChangedParent.RestoresFirstParentBlob
-                RequireExpectedUtcDateForRenderedChange =
-                    $RequireExpectedUtcDateForRenderedChange -and
-                    $objChangedParent.HasPolicyMarker -and
-                    -not $boolMatchesPolicyActiveParent
-            })
-    }
-
-    if ($RequiresVersion) {
-        return Get-DocumentMetadataRangeTransitionFailure `
-            -Name $Name `
-            -TransitionContext $listTransitions.ToArray()
-    }
-    foreach ($objTransition in $listTransitions) {
-        Get-LastUpdatedMetadataFreshnessFailure `
-            -Name $Name `
-            -CurrentContent $objTransition.CurrentContent `
-            -BaseContent $objTransition.ParentContent `
-            -TrustedEventUtcDate $(if (
-                $objTransition.RequireExpectedUtcDateForRenderedChange) {
-                    $objTransition.ExpectedUtcDate
-                } else { '' }) `
-            -ModifyingCommitUtcDate $objTransition.ExpectedUtcDate `
-            -AllowSameDateForExactRestoration `
-                $objTransition.AllowSameDateForExactRestoration
-    }
-}
-
-function Get-GovernedDocumentRangeTransitionFailure {
-    # .SYNOPSIS
-    # Finds an invalid governed-document transition across a revision range.
-    #
-    # .DESCRIPTION
-    # Validates endpoint state and every touched commit in the authenticated range.
-    #
-    # .PARAMETER Name
-    # The fixture or document name to use in diagnostics.
-    #
-    # .PARAMETER RepositoryRootPath
-    # The absolute path of the trusted Git repository.
-    #
-    # .PARAMETER RepositoryRelativePath
-    # The canonical repository-relative path to inspect.
-    #
-    # .PARAMETER MaximumBytes
-    # The maximum permitted output size in bytes.
-    #
-    # .PARAMETER BaseRevision
-    # The authenticated base Git object IDs to exclude from the topic range.
-    #
-    # .PARAMETER HeadRevision
-    # The authenticated head Git object ID.
-    #
-    # .PARAMETER InputRevision
-    # The exact revision used to read current validation inputs.
-    #
-    # .PARAMETER IsNewRefRange
-    # Indicates whether the range represents a newly created ref.
-    #
-    # .PARAMETER PolicyRepositoryRelativePath
-    # The repository-relative policy document path.
-    #
-    # .PARAMETER PolicyMaximumBytes
-    # The maximum permitted policy document size in bytes.
-    #
-    # .PARAMETER PolicyMarker
-    # The exact marker that activates the historical policy.
-    #
-    # .PARAMETER RequireExpectedUtcDateForRenderedChange
-    # Requires a rendered change to use the expected UTC date.
-    #
-    # .PARAMETER CommitDateFreshnessRevision
-    # The revision whose trusted commit date bounds metadata freshness.
-    #
-    # .PARAMETER RequiresVersion
-    # Indicates whether the document header must contain Version metadata.
-    #
-    # .PARAMETER RequiredDocument
-    # Indicates whether deletion of the governed document is prohibited.
-    #
-    # .EXAMPLE
-    # Get-GovernedDocumentRangeTransitionFailure @hashtableArguments
-    #
-    # # Runs with validated named arguments.
-    #
-    # .INPUTS
-    # None. No pipeline input.
-    #
-    # .OUTPUTS
-    # [System.String] Zero or more validated values or diagnostics described in the function description.
-    #
-    # .NOTES
-    # PRIVATE/INTERNAL HELPER - This function is not part of the public API.
-    # Parameters, return shape, and positional contract can change without notice.
-    # Positional parameters are disabled; internal callers use named arguments.
-    # Version: 1.0.20260830.0.
-    [CmdletBinding(PositionalBinding = $false)]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory)]
-        [string] $Name,
-
-        [Parameter(Mandatory)]
-        [string] $RepositoryRootPath,
-
-        [Parameter(Mandatory)]
-        [string] $RepositoryRelativePath,
-
-        [Parameter(Mandatory)]
-        [ValidateRange(1, 2147483646)]
-        [int] $MaximumBytes,
-
-        [Parameter(Mandatory)]
-        [AllowEmptyCollection()]
-        [AllowEmptyString()]
-        [string[]] $BaseRevision,
-
-        [Parameter(Mandatory)]
-        [AllowEmptyString()]
-        [string] $HeadRevision,
-
-        [Parameter()]
-        [AllowEmptyString()]
-        [string] $InputRevision = '',
-
-        [Parameter(Mandatory)]
-        [bool] $IsNewRefRange,
-
-        [Parameter(Mandatory)]
-        [string] $PolicyRepositoryRelativePath,
-
-        [Parameter(Mandatory)]
-        [ValidateRange(1, 2147483646)]
-        [int] $PolicyMaximumBytes,
-
-        [Parameter(Mandatory)]
-        [string] $PolicyMarker,
-
-        [Parameter()]
-        [bool] $RequireExpectedUtcDateForRenderedChange = $false,
-
-        [Parameter()]
-        [AllowEmptyCollection()]
-        [string[]] $CommitDateFreshnessRevision = @(),
-
-        [Parameter()]
-        [bool] $RequiresVersion = $true,
-
-        [Parameter()]
-        [bool] $RequiredDocument = $false
-    )
-
-    $arrBaseRevisions = @($BaseRevision)
-    if ($arrBaseRevisions.Count -eq 1 -and
-        [string]::IsNullOrEmpty($arrBaseRevisions[0])) {
-        $arrBaseRevisions = @()
-    }
-    elseif (@($arrBaseRevisions | Where-Object {
-                [string]::IsNullOrEmpty($_)
-            }).Count -ne 0) {
-        throw 'The metadata event range contains an empty base revision.'
-    }
-    if ($arrBaseRevisions.Count -eq 0 -and
-        [string]::IsNullOrEmpty($HeadRevision)) {
-        if ($IsNewRefRange) {
-            throw 'A new-ref metadata event range must supply base and head revisions.'
-        }
-        return [string[]] @()
-    }
-    if ($arrBaseRevisions.Count -eq 0 -or
-        [string]::IsNullOrEmpty($HeadRevision)) {
-        throw 'The metadata event range must supply both base and head revisions.'
-    }
-
-    $strObjectIdPattern = '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
-    $strZeroObjectIdPattern = '^(?:0{40}|0{64})$'
-    $boolBaseIsZeroObjectId = $arrBaseRevisions.Count -eq 1 -and
-        $arrBaseRevisions[0] -match $strZeroObjectIdPattern
-    if ($IsNewRefRange -and -not $boolBaseIsZeroObjectId) {
-        throw 'A new-ref metadata event range requires an all-zero base revision.'
-    }
-    if (-not $IsNewRefRange -and $boolBaseIsZeroObjectId) {
-        throw 'An all-zero metadata event-range base requires the new-ref flag.'
-    }
-    if ($HeadRevision -match $strZeroObjectIdPattern) {
-        throw 'The metadata event-range head must not be an all-zero object ID.'
-    }
-
-    if ($arrBaseRevisions.Count -gt 64 -or
-        @($arrBaseRevisions | Sort-Object -Unique).Count -ne
-            $arrBaseRevisions.Count) {
-        throw 'The metadata event range requires at most 64 unique bases.'
-    }
-    foreach ($strRevision in @($arrBaseRevisions) + @($HeadRevision)) {
-        if ($strRevision -notmatch $strObjectIdPattern) {
-            throw "The metadata event range contains an invalid object ID: $strRevision"
-        }
-        if ($strRevision -eq $arrBaseRevisions[0] -and
-            $boolBaseIsZeroObjectId) {
-            continue
-        }
-        & git -C $RepositoryRootPath cat-file -e "$strRevision`^{commit}" 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            throw "The metadata event-range commit is unavailable: $strRevision"
-        }
-    }
-
-    $strValidationRevision = if ([string]::IsNullOrEmpty($InputRevision)) {
-        'HEAD'
-    }
-    else {
-        $InputRevision
-    }
-    $strCheckedOutHead = [string] (
-        & git -C $RepositoryRootPath rev-parse --verify `
-            "$strValidationRevision`^{commit}"
-    )
-    if ($LASTEXITCODE -ne 0 -or
-        -not [string]::Equals(
-            $strCheckedOutHead.Trim(),
-            $HeadRevision,
-            [StringComparison]::OrdinalIgnoreCase
-        )) {
-        throw "The metadata event-range head does not match the validation revision: $HeadRevision"
-    }
-    if ($arrBaseRevisions.Count -eq 1 -and [string]::Equals(
-            $arrBaseRevisions[0], $HeadRevision,
-            [StringComparison]::OrdinalIgnoreCase)) {
-        return [string[]] @()
-    }
-
-    $boolHeadHasPolicyMarker = Test-HistoricalPolicyMarker `
-        -RepositoryRootPath $RepositoryRootPath `
-        -Revision $HeadRevision `
-        -RepositoryRelativePath $PolicyRepositoryRelativePath `
-        -Literal $PolicyMarker
-    if (-not $boolHeadHasPolicyMarker) {
-        throw "The metadata event-range head does not contain policy marker $PolicyMarker."
-    }
-
-    $boolAnyBaseHasPolicyMarker = $false
-    if (-not $IsNewRefRange) {
-        $boolAnyBaseHasPolicyMarker = @(
-            $arrBaseRevisions | Where-Object {
-                Test-HistoricalPolicyMarker `
-                    -RepositoryRootPath $RepositoryRootPath `
-                    -Revision $_ `
-                    -RepositoryRelativePath $PolicyRepositoryRelativePath `
-                    -Literal $PolicyMarker
-            }
-        ).Count -gt 0
-    }
-    if (-not $boolAnyBaseHasPolicyMarker) {
-        if ($IsNewRefRange) {
-            $arrPolicyPathCommits = @(
-                & git -C $RepositoryRootPath log --reverse --topo-order `
-                    --format=%H "-S$PolicyMarker" $HeadRevision -- `
-                    $PolicyRepositoryRelativePath 2>&1
-            )
-        }
-        else {
-            $arrPolicyLogArguments = @(
-                '-C', $RepositoryRootPath, 'log', '--reverse', '--topo-order',
-                '--format=%H', "-S$PolicyMarker", $HeadRevision, '--not'
-            ) + $arrBaseRevisions + @('--', $PolicyRepositoryRelativePath)
-            $arrPolicyPathCommits = @(& git @arrPolicyLogArguments 2>&1)
-        }
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not enumerate metadata policy-marker changes.'
-        }
-
-        $strPolicyIntroductionCommit = ''
-        foreach ($strPolicyCommitValue in $arrPolicyPathCommits) {
-            $strPolicyCommit = ([string]$strPolicyCommitValue).Trim()
-            if ($strPolicyCommit -notmatch $strObjectIdPattern) {
-                throw "Git returned an invalid metadata policy commit: $strPolicyCommit"
-            }
-            if (Test-HistoricalPolicyMarker `
-                    -RepositoryRootPath $RepositoryRootPath `
-                    -Revision $strPolicyCommit `
-                    -RepositoryRelativePath $PolicyRepositoryRelativePath `
-                    -Literal $PolicyMarker) {
-                $strPolicyIntroductionCommit = $strPolicyCommit
-                break
-            }
-        }
-        if ([string]::IsNullOrEmpty($strPolicyIntroductionCommit)) {
-            throw "Could not locate the introduction of metadata policy marker $PolicyMarker."
-        }
-
-        $strPolicyParentLine = [string] (
-            & git -C $RepositoryRootPath rev-list --parents -n 1 `
-                $strPolicyIntroductionCommit
-        )
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not read the metadata policy-introduction parent.'
-        }
-        $arrPolicyCommitAndParents = @($strPolicyParentLine.Trim() -split ' ')
-        if ($arrPolicyCommitAndParents.Count -eq 1 -and $IsNewRefRange) {
-            $arrEffectiveBaseRevisions = @()
-        }
-        elseif ($arrPolicyCommitAndParents.Count -lt 2 -or
-            $arrPolicyCommitAndParents[1] -notmatch $strObjectIdPattern) {
-            throw 'The metadata policy-introduction commit must have a valid first parent.'
-        }
-        else {
-            $arrEffectiveBaseRevisions = @(
-                if ($IsNewRefRange) {
-                    $arrPolicyCommitAndParents[1]
-                }
-                else {
-                    @($arrBaseRevisions) + @($arrPolicyCommitAndParents[1]) |
-                        Sort-Object -Unique
-                }
-            )
-        }
-    }
-    else {
-        $arrEffectiveBaseRevisions = @($arrBaseRevisions)
-    }
-
-    if ($arrEffectiveBaseRevisions.Count -eq 0) {
-        $arrRangeCommits = @(
-            & git -C $RepositoryRootPath rev-list --reverse --topo-order `
-                $HeadRevision 2>&1
-        )
-    }
-    else {
-        $arrRangeArguments = @(
-            '-C', $RepositoryRootPath, 'rev-list', '--reverse', '--topo-order',
-            $HeadRevision, '--not'
-        ) + $arrEffectiveBaseRevisions
-        $arrRangeCommits = @(& git @arrRangeArguments 2>&1)
-    }
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Could not enumerate the metadata event range.'
-    }
-
-    $setRangeCommits = [Collections.Generic.HashSet[string]]::new(
-        [StringComparer]::OrdinalIgnoreCase
-    )
-    foreach ($strRangeCommitValue in $arrRangeCommits) {
-        [void]$setRangeCommits.Add(([string]$strRangeCommitValue).Trim())
-    }
-    $setCommitDateFreshnessRevisions =
-        [Collections.Generic.HashSet[string]]::new(
-            [StringComparer]::OrdinalIgnoreCase
-        )
-    foreach ($strFreshnessRevision in $CommitDateFreshnessRevision) {
-        if ($strFreshnessRevision -notmatch $strObjectIdPattern -or
-            -not $setRangeCommits.Contains($strFreshnessRevision)) {
-            throw 'A commit-date freshness revision is outside the metadata event range.'
-        }
-        [void]$setCommitDateFreshnessRevisions.Add($strFreshnessRevision)
-    }
-
-    foreach ($strRangeCommitValue in $arrRangeCommits) {
-        $strRangeCommit = ([string]$strRangeCommitValue).Trim()
-        $arrCommitFailures = @(Get-GovernedDocumentCommitTransitionFailure `
-            -Name $Name `
-            -RepositoryRootPath $RepositoryRootPath `
-            -RepositoryRelativePath $RepositoryRelativePath `
-            -MaximumBytes $MaximumBytes `
-            -CommitRevision $strRangeCommit `
-            -PolicyRepositoryRelativePath $PolicyRepositoryRelativePath `
-            -PolicyMaximumBytes $PolicyMaximumBytes `
-            -PolicyMarker $PolicyMarker `
-            -RequireExpectedUtcDateForRenderedChange `
-                ($RequireExpectedUtcDateForRenderedChange -or
-                    $setCommitDateFreshnessRevisions.Contains($strRangeCommit)) `
-            -RequiresVersion $RequiresVersion `
-            -RequiredDocument $RequiredDocument)
-        foreach ($strCommitFailure in $arrCommitFailures) {
-            Write-Output $strCommitFailure
-        }
     }
 }
 
@@ -6838,7 +5430,7 @@ function Get-AgentInstructionFailure {
     }
 
     foreach ($objDocument in $arrDocuments) {
-        $arrMetadataFailures = @(Get-DocumentMetadataTransitionFailure `
+        $arrMetadataFailures = @(Get-PublishedEndpointMetadataFailure `
                 -Name $objDocument.Name `
                 -CurrentContent $objDocument.RawContent `
                 -ParentContent $objDocument.ParentContent `
@@ -7069,24 +5661,19 @@ if ($PushApplicabilityOnly) {
         -not [string]::IsNullOrEmpty($TrustedEventTimestamp) -or
         $EventName -cne 'push' -or
         -not [string]::IsNullOrEmpty($PullRequestAction) -or
-        -not [string]::IsNullOrEmpty($PullRequestBaseChanged) -or
-        -not [string]::IsNullOrEmpty($PreviousHeadRevision) -or
-        -not [string]::IsNullOrEmpty($EventHeadRevision) -or
-        -not [string]::IsNullOrEmpty($EventHeadDistinct) -or
-        -not [string]::IsNullOrEmpty($NewRefCommitCount) -or
-        -not [string]::IsNullOrEmpty($NewRefCommitEvidenceJson)) {
+        -not [string]::IsNullOrEmpty($PullRequestBaseChanged)) {
         throw 'Push-applicability mode received incompatible validation fields.'
     }
     $objPushApplicability = Get-PushGovernedPathApplicability `
         -RepositoryRootPath $strRepositoryRootPath `
-        -BaseRevision $RangeBaseRevision `
-        -HeadRevision $RangeHeadRevision `
-        -IsNewRef ([bool]$RangeIsNewRef) `
-        -IsDeletedRef ([bool]$RangeIsDeletedRef)
+        -BaseRevision $PublishedBaselineRevision `
+        -HeadRevision $PublishedFinalRevision `
+        -IsNewRef ([bool]$PublishedBaselineAbsent) `
+        -IsDeletedRef ([bool]$PublishedFinalDeleted)
     Write-Output $objPushApplicability.ShouldValidate.ToString().ToLowerInvariant()
     return
 }
-if ($RangeIsDeletedRef) {
+if ($PublishedFinalDeleted) {
     throw 'Deleted-ref push validation must stop after its applicability decision.'
 }
 $arrBootstrapFailures = @(Get-MarkdownParserBootstrapFailure `
@@ -7157,71 +5744,36 @@ $arrGovernedMetadataDocuments += @(
     }
 )
 $strValidatedInputRevision = ''
-$boolEventRangeRequested = -not [string]::IsNullOrEmpty($RangeBaseRevision) -or
-    -not [string]::IsNullOrEmpty($RangeHeadRevision)
-$boolCommitDateOnlyEvent = $EventName -ceq 'pull_request_target'
-if ($boolEventRangeRequested -and
+$boolPublishedEndpointsRequested =
+    -not [string]::IsNullOrEmpty($PublishedBaselineRevision) -or
+    -not [string]::IsNullOrEmpty($PublishedFinalRevision)
+if ($boolPublishedEndpointsRequested -and
     ([string]::IsNullOrEmpty($EventName) -or
-        ([string]::IsNullOrEmpty($TrustedEventTimestamp) -and
-            -not $boolCommitDateOnlyEvent))) {
-    throw 'A metadata event range requires a trusted GitHub event name and timestamp.'
+        [string]::IsNullOrEmpty($TrustedEventTimestamp))) {
+    throw 'Published metadata endpoints require a trusted GitHub event name and timestamp.'
 }
-if (-not $boolEventRangeRequested -and
+if (-not $boolPublishedEndpointsRequested -and
     (-not [string]::IsNullOrEmpty($TrustedEventTimestamp) -or
         -not [string]::IsNullOrEmpty($EventName) -or
         -not [string]::IsNullOrEmpty($PullRequestAction) -or
         -not [string]::IsNullOrEmpty($PullRequestBaseChanged) -or
-        -not [string]::IsNullOrEmpty($PreviousHeadRevision) -or
-        $RangeIsDeletedRef -or
-        -not [string]::IsNullOrEmpty($EventHeadRevision) -or
-        -not [string]::IsNullOrEmpty($EventHeadDistinct) -or
-        -not [string]::IsNullOrEmpty($NewRefCommitCount) -or
-        -not [string]::IsNullOrEmpty($NewRefCommitEvidenceJson))) {
-    throw 'Metadata event fields require a complete base and head range.'
+        $PublishedBaselineAbsent -or $PublishedFinalDeleted)) {
+    throw 'Metadata event fields require complete published endpoints.'
 }
+$strTrustedEventUtcDate = ''
 if (-not [string]::IsNullOrEmpty($TrustedEventTimestamp)) {
-    [void](ConvertFrom-TrustedEventTimestamp -Timestamp $TrustedEventTimestamp)
+    $strTrustedEventUtcDate = (
+        ConvertFrom-TrustedEventTimestamp -Timestamp $TrustedEventTimestamp
+    ).ToString('yyyy-MM-dd')
 }
-$arrEventHistoryBaseRevisions = @($RangeBaseRevision)
-$arrNewRefBoundaryRevisions = @()
-$arrNewRefIntroducedCommitRevisions = @()
-$boolRequireRangeCommitDateFreshness = $false
-$boolValidateBackwardPushHead = $false
-if ($boolEventRangeRequested -and
-    -not [string]::IsNullOrEmpty($RangeBaseRevision) -and
-    -not [string]::IsNullOrEmpty($RangeHeadRevision)) {
-    $objMetadataEventRevisionContext = Get-MetadataEventRevisionContext `
+if ($boolPublishedEndpointsRequested) {
+    Assert-PublishedEndpointContext `
         -RepositoryRootPath $strRepositoryRootPath `
         -EventName $EventName -PullRequestAction $PullRequestAction `
-        -BaseRevision $RangeBaseRevision -HeadRevision $RangeHeadRevision `
-        -IsNewRefRange ([bool]$RangeIsNewRef) `
-        -PreviousHeadRevision $PreviousHeadRevision `
-        -PullRequestBaseChanged $PullRequestBaseChanged `
-        -EventHeadRevision $EventHeadRevision `
-        -EventHeadDistinct $EventHeadDistinct `
-        -NewRefCommitCount $NewRefCommitCount `
-        -NewRefCommitEvidenceJson $NewRefCommitEvidenceJson
-    $arrEventHistoryBaseRevisions = @(
-        $objMetadataEventRevisionContext.HistoryBaseRevisions
-    )
-    if ($RangeIsNewRef) {
-        $arrNewRefBoundaryRevisions = @(
-            $objMetadataEventRevisionContext.NewRefBoundaryRevisions
-        )
-        $arrNewRefIntroducedCommitRevisions = @(
-            $objMetadataEventRevisionContext.NewRefIntroducedCommitRevisions
-        )
-    }
-    $boolRequireRangeCommitDateFreshness =
-        ($EventName -ceq 'push' -and -not $RangeIsNewRef) -or
-        $boolCommitDateOnlyEvent
-    if ($EventName -ceq 'push' -and -not $RangeIsNewRef -and
-        $EventHeadDistinct -ceq 'false' -and
-        $RangeBaseRevision -ne $RangeHeadRevision) {
-        $boolValidateBackwardPushHead = Test-BackwardCommitMove `
-            -RepositoryRootPath $strRepositoryRootPath `
-            -BaseRevision $RangeBaseRevision -HeadRevision $RangeHeadRevision
-    }
+        -BaselineRevision $PublishedBaselineRevision `
+        -FinalRevision $PublishedFinalRevision `
+        -BaselineAbsent ([bool]$PublishedBaselineAbsent) `
+        -PullRequestBaseChanged $PullRequestBaseChanged
 }
 
 if (-not [string]::IsNullOrEmpty($InputRevision)) {
@@ -7241,13 +5793,13 @@ if (-not [string]::IsNullOrEmpty($InputRevision)) {
         throw "The agent-instruction input commit is unavailable: $InputRevision"
     }
     $strValidatedInputRevision = $strValidatedInputRevision.Trim()
-    if (-not [string]::IsNullOrEmpty($RangeHeadRevision) -and
+    if (-not [string]::IsNullOrEmpty($PublishedFinalRevision) -and
         -not [string]::Equals(
             $strValidatedInputRevision,
-            $RangeHeadRevision,
+            $PublishedFinalRevision,
             [StringComparison]::OrdinalIgnoreCase
         )) {
-        throw 'The input revision must match the metadata event-range head.'
+        throw 'The input revision must match the published final revision.'
     }
 }
 
@@ -7264,15 +5816,15 @@ if (-not [string]::IsNullOrEmpty($strValidatedInputRevision) -and
         $strCheckedOutRevision,
         [StringComparison]::OrdinalIgnoreCase
     )) {
-    $arrTrustRootBaseRevisions = if ($EventName -ceq 'pull_request_target') {
-        $arrEventHistoryBaseRevisions
-    } else { @($RangeBaseRevision) }
-    $arrTrustRootFailures = @(Get-TrustRootRangeMutationFailure `
+    $arrTrustRootBaseRevisions = @($PublishedBaselineRevision)
+    $arrTrustRootFailures = @(
+        Get-TrustRootRangeMutationFailure `
             -RepositoryRootPath $strRepositoryRootPath `
             -BaseRevision $arrTrustRootBaseRevisions `
-            -HeadRevision $RangeHeadRevision `
-            -RepositoryRelativePath $script:arrTrustRootPaths) |
-        Sort-Object -Unique
+            -HeadRevision $PublishedFinalRevision `
+            -RepositoryRelativePath $script:arrTrustRootPaths |
+            Sort-Object -Unique
+    )
     if ($arrTrustRootFailures.Count -gt 0) {
         throw (
             'Trusted validation root changed:' + [Environment]::NewLine + '- ' +
@@ -7285,32 +5837,37 @@ $arrTrackedRepositoryPaths = @(Read-GitTrackedPath `
         -RepositoryRootPath $strRepositoryRootPath `
         -Revision $strValidatedInputRevision `
         -MaximumBytes $intGitPathListMaximumBytes)
-$arrRangeTouchedRepositoryPaths = @()
-if ($boolEventRangeRequested) {
-    $arrRangeTouchedRepositoryPaths = @(Read-GitRangeTouchedPath `
+$arrPublishedBaselinePaths = @()
+$arrPublishedChangedPaths = @()
+if ($boolPublishedEndpointsRequested) {
+    if (-not $PublishedBaselineAbsent) {
+        $arrPublishedBaselinePaths = @(Read-GitTrackedPath `
             -RepositoryRootPath $strRepositoryRootPath `
-            -BaseRevision $arrEventHistoryBaseRevisions `
-            -HeadRevision $RangeHeadRevision `
-            -IsNewRefRange ([bool]$RangeIsNewRef) `
-            -NewRefBoundaryRevision $arrNewRefBoundaryRevisions `
-            -NewRefHasIntroducedCommit `
-                ($arrNewRefIntroducedCommitRevisions.Count -gt 0) `
-            -RepositoryRelativePathspec ':(top)**' `
-            -MaximumBytes $intGitPathListMaximumBytes) | Sort-Object -Unique
+            -Revision $PublishedBaselineRevision `
+            -MaximumBytes $intGitPathListMaximumBytes)
+    }
+    $arrPublishedChangedPaths = @(Read-GitPublishedEndpointChangedPath `
+        -RepositoryRootPath $strRepositoryRootPath `
+        -BaselineRevision $PublishedBaselineRevision `
+        -FinalRevision $PublishedFinalRevision `
+        -BaselineAbsent ([bool]$PublishedBaselineAbsent) `
+        -MaximumBytes $intGitPathListMaximumBytes) | Sort-Object -Unique
 }
-$arrRangeTouchedDecisionPaths = @(
-    $arrRangeTouchedRepositoryPaths |
+$arrPublishedDecisionPaths = @(
+    @($arrPublishedBaselinePaths + $arrTrackedRepositoryPaths +
+        $arrPublishedChangedPaths) |
         Where-Object { $_ -cmatch $script:strDecisionRecordDirectoryPathPattern }
 )
-$arrRangeTouchedGovernedInstructionPaths = @(
-    $arrRangeTouchedRepositoryPaths |
+$arrPublishedGovernedInstructionPaths = @(
+    @($arrPublishedBaselinePaths + $arrTrackedRepositoryPaths +
+        $arrPublishedChangedPaths) |
         Where-Object {
             Test-GovernedInstructionInventoryPath `
                 -RepositoryRelativePath ([string]$_)
         }
 )
 $arrDecisionRecordInventoryPaths = @(
-    @($arrTrackedRepositoryPaths + $arrRangeTouchedDecisionPaths) |
+    @($arrTrackedRepositoryPaths + $arrPublishedDecisionPaths) |
         Where-Object { $_ -cmatch $script:strDecisionRecordDirectoryPathPattern } |
         Sort-Object -Unique
 )
@@ -7326,7 +5883,7 @@ $arrGovernedMetadataDocuments += @(
         }
 )
 $arrTrackedGovernedInstructionPaths = @(
-    @($arrTrackedRepositoryPaths + $arrRangeTouchedGovernedInstructionPaths) |
+    @($arrTrackedRepositoryPaths + $arrPublishedGovernedInstructionPaths) |
         Where-Object {
             Test-GovernedInstructionInventoryPath `
                 -RepositoryRelativePath ([string] $_)
@@ -7350,7 +5907,7 @@ if ([string]::IsNullOrEmpty($strValidatedInputRevision)) {
     $arrRequiredPaths += @(
         $arrGovernedMetadataDocuments |
             Where-Object {
-                $arrRangeTouchedRepositoryPaths -cnotcontains $_.Path -or
+                $arrPublishedChangedPaths -cnotcontains $_.Path -or
                 $arrTrackedRepositoryPaths -ccontains $_.Path
             } |
             ForEach-Object {
@@ -7448,10 +6005,10 @@ foreach ($objDocumentSpec in $arrGovernedMetadataDocuments) {
     $strDocumentPath = Join-Path `
         -Path $strRepositoryRootPath `
         -ChildPath $objDocumentSpec.Path
-    $boolRangeOnlyGovernedDocument =
-        $arrRangeTouchedRepositoryPaths -ccontains $objDocumentSpec.Path -and
+    $boolPublishedBaselineOnlyDocument =
+        $arrPublishedBaselinePaths -ccontains $objDocumentSpec.Path -and
         $arrTrackedRepositoryPaths -cnotcontains $objDocumentSpec.Path
-    $strDocumentContent = if ($boolRangeOnlyGovernedDocument) {
+    $strDocumentContent = if ($boolPublishedBaselineOnlyDocument) {
         $null
     }
     elseif ([string]::IsNullOrEmpty($strValidatedInputRevision)) {
@@ -7477,79 +6034,57 @@ foreach ($objDocumentSpec in $arrGovernedMetadataDocuments) {
 
 $listGovernedDocumentContexts = [Collections.Generic.List[pscustomobject]]::new()
 foreach ($objDocumentSpec in $arrGovernedMetadataDocuments) {
-    $objParentContext = Get-GovernedDocumentParentContext `
-        -RepositoryRootPath $strRepositoryRootPath `
-        -RepositoryRelativePath $objDocumentSpec.Path `
-        -MaximumBytes $objDocumentSpec.MaximumBytes `
-        -Revision $strValidatedInputRevision
-    $strDocumentPolicyMarker = if (
-        $objDocumentSpec.Path -ceq 'STYLE_GUIDE_RATIONALE.md') {
-        $strStyleGuideRationaleMetadataPolicyMarker
-    } elseif ($objDocumentSpec.Path -in $script:arrOperationalLintGuidePaths) {
-        $strLintGuideMetadataPolicyMarker
-    } else {
-        $strMetadataRangePolicyMarker
+    $objParentContext = if ($boolPublishedEndpointsRequested) {
+        $strPublishedBaselineContent = $null
+        if (-not $PublishedBaselineAbsent) {
+            & git -C $strRepositoryRootPath cat-file -e `
+                "$PublishedBaselineRevision`:$($objDocumentSpec.Path)" 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                $strPublishedBaselineContent = Read-GitRevisionText `
+                    -RepositoryRootPath $strRepositoryRootPath `
+                    -Revision $PublishedBaselineRevision `
+                    -RepositoryRelativePath $objDocumentSpec.Path `
+                    -MaximumBytes $objDocumentSpec.MaximumBytes `
+                    -RequireRegularFile
+            }
+        }
+        [pscustomobject]@{
+            ParentContent = $strPublishedBaselineContent
+            ExpectedUtcDate = $strTrustedEventUtcDate
+            ParentRevision = if ($PublishedBaselineAbsent) {
+                $null
+            } else {
+                $PublishedBaselineRevision
+            }
+            IsWorktreeTransition = $true
+        }
     }
-    $boolParentPolicyApplies = $null -ne $objParentContext.ParentRevision -and
-        (Test-HistoricalPolicyMarker `
+    elseif ([string]::IsNullOrEmpty($strValidatedInputRevision)) {
+        Get-PublishedBaselineDocumentContext `
             -RepositoryRootPath $strRepositoryRootPath `
-            -Revision $objParentContext.ParentRevision `
-            -RepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-            -Literal $strDocumentPolicyMarker)
+            -RepositoryRelativePath $objDocumentSpec.Path `
+            -MaximumBytes $objDocumentSpec.MaximumBytes
+    }
+    else {
+        [pscustomobject]@{
+            ParentContent = $hashtableGovernedInstructionContent[$objDocumentSpec.Path]
+            ExpectedUtcDate = ''
+            ParentRevision = $strValidatedInputRevision
+            IsWorktreeTransition = $false
+        }
+    }
     $listGovernedDocumentContexts.Add([pscustomobject]@{
             Path = $objDocumentSpec.Path
             MaximumBytes = $objDocumentSpec.MaximumBytes
             Content = $hashtableGovernedInstructionContent[$objDocumentSpec.Path]
-            ParentContent = if ($boolParentPolicyApplies) {
-                $objParentContext.ParentContent
-            } else { $null }
+            ParentContent = $objParentContext.ParentContent
             ExpectedUtcDate = $objParentContext.ExpectedUtcDate
             IsWorktreeTransition = $objParentContext.IsWorktreeTransition
             RequiresMetadata = $objDocumentSpec.RequiresMetadata
             RequiresVersion = $objDocumentSpec.RequiresVersion
             RequiredDocument = $arrDecisionRecordInventoryPaths -cnotcontains `
                 $objDocumentSpec.Path
-            PolicyMarker = $strDocumentPolicyMarker
         })
-}
-
-$strNoRangeCommitRevision = ''
-$strNoRangeCommitUtcDate = ''
-$boolNoRangeCommitHasParent = $false
-if ([string]::IsNullOrEmpty($RangeBaseRevision) -and
-    [string]::IsNullOrEmpty($RangeHeadRevision)) {
-    $strNoRangeCommitRevision = if ([string]::IsNullOrEmpty($strValidatedInputRevision)) {
-        $strCheckedOutRevision
-    }
-    else {
-        $strValidatedInputRevision
-    }
-    $strNoRangeParentLine = [string] (
-        & git -C $strRepositoryRootPath rev-list --parents -n 1 `
-            $strNoRangeCommitRevision
-    )
-    if ($LASTEXITCODE -ne 0) {
-        throw "Could not read the no-range validation commit: $strNoRangeCommitRevision"
-    }
-    $arrNoRangeCommitAndParents = @($strNoRangeParentLine.Trim() -split '\s+')
-    $boolNoRangeCommitHasParent = $arrNoRangeCommitAndParents.Count -gt 1
-    $strNoRangeCommitTimestamp = [string] (
-        & git -C $strRepositoryRootPath show -s --format=%cI `
-            $strNoRangeCommitRevision
-    )
-    $objNoRangeCommitTimestamp = [DateTimeOffset]::MinValue
-    if ($LASTEXITCODE -ne 0 -or
-        -not [DateTimeOffset]::TryParse(
-            $strNoRangeCommitTimestamp.Trim(),
-            [ref] $objNoRangeCommitTimestamp
-        )) {
-        throw "Could not read the no-range validation commit timestamp: $strNoRangeCommitRevision"
-    }
-    if ($objNoRangeCommitTimestamp -gt $script:objMaximumCommitUtcTimestamp) {
-        throw "The no-range validation commit timestamp is later than trusted UTC."
-    }
-    $strNoRangeCommitUtcDate =
-        $objNoRangeCommitTimestamp.UtcDateTime.ToString('yyyy-MM-dd')
 }
 
 $arrRepositoryFailures = @(Get-AgentInstructionFailure `
@@ -7619,86 +6154,31 @@ foreach ($objDocumentContext in $listGovernedDocumentContexts) {
     if (-not $objDocumentContext.RequiresMetadata) {
         continue
     }
-    if ([string]::IsNullOrEmpty($RangeBaseRevision) -and
-        [string]::IsNullOrEmpty($RangeHeadRevision)) {
-        if (-not $objDocumentContext.RequiresVersion -and
-            ($objDocumentContext.IsWorktreeTransition -or
-                -not $boolNoRangeCommitHasParent)) {
-            $arrRepositoryFailures += @(Get-LastUpdatedMetadataFreshnessFailure `
-                    -Name $objDocumentContext.Path `
-                    -CurrentContent $objDocumentContext.Content `
-                    -BaseContent $objDocumentContext.ParentContent `
-                    -TrustedEventUtcDate $objDocumentContext.ExpectedUtcDate `
-                    -ModifyingCommitUtcDate $(if (
-                        $objDocumentContext.IsWorktreeTransition) {
-                            ''
-                        } else { $strNoRangeCommitUtcDate }) `
-                    -RequireCurrentMaximumDateForRenderedChange `
-                        $objDocumentContext.IsWorktreeTransition)
+    if ($null -eq $objDocumentContext.Content) {
+        if ($objDocumentContext.RequiredDocument) {
+            $arrRepositoryFailures +=
+                "$($objDocumentContext.Path) is required in the published final state."
         }
-        elseif ($objDocumentContext.RequiresVersion -and
-            ($objDocumentContext.IsWorktreeTransition -or
-                -not $boolNoRangeCommitHasParent)) {
-            $arrRepositoryFailures += @(Get-DocumentMetadataTransitionFailure `
-                    -Name $objDocumentContext.Path `
-                    -CurrentContent $objDocumentContext.Content `
-                    -ParentContent $objDocumentContext.ParentContent `
-                    -ExpectedUtcDate $objDocumentContext.ExpectedUtcDate `
-                    -IsNewDocumentTransition (
-                        $null -eq $objDocumentContext.ParentContent -and
-                        -not [string]::IsNullOrEmpty($objDocumentContext.ExpectedUtcDate)
-                    ))
-        }
-        else {
-            $arrRepositoryFailures += @(Get-GovernedDocumentCommitTransitionFailure `
-                    -Name $objDocumentContext.Path `
-                    -RepositoryRootPath $strRepositoryRootPath `
-                    -RepositoryRelativePath $objDocumentContext.Path `
-                    -MaximumBytes $objDocumentContext.MaximumBytes `
-                    -CommitRevision $strNoRangeCommitRevision `
-                    -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                    -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-                    -PolicyMarker $objDocumentContext.PolicyMarker `
-                    -RequiresVersion $objDocumentContext.RequiresVersion `
-                    -RequiredDocument $objDocumentContext.RequiredDocument)
-        }
+        continue
     }
-    $arrRangeTransitionFailures = @(
-        Get-GovernedDocumentRangeTransitionFailure `
-            -Name $objDocumentContext.Path `
-            -RepositoryRootPath $strRepositoryRootPath `
-            -RepositoryRelativePath $objDocumentContext.Path `
-            -MaximumBytes $objDocumentContext.MaximumBytes `
-            -BaseRevision $arrEventHistoryBaseRevisions `
-            -HeadRevision $RangeHeadRevision `
-            -InputRevision $strValidatedInputRevision `
-            -IsNewRefRange ([bool]$RangeIsNewRef) `
-            -PolicyRepositoryRelativePath `
-                '.github/workflows/Test-AgentInstructions.ps1' `
-            -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-            -PolicyMarker $objDocumentContext.PolicyMarker `
-            -RequireExpectedUtcDateForRenderedChange `
-                $boolRequireRangeCommitDateFreshness `
-            -CommitDateFreshnessRevision `
-                $arrNewRefIntroducedCommitRevisions `
-            -RequiresVersion $objDocumentContext.RequiresVersion `
-            -RequiredDocument $objDocumentContext.RequiredDocument
-    ) | Sort-Object -Unique
-    $arrRepositoryFailures += @($arrRangeTransitionFailures)
-    if ($EventName -ceq 'push' -and $EventHeadDistinct -ceq 'false' -and
-        ($RangeIsNewRef -or $boolValidateBackwardPushHead)) {
-        $arrRepositoryFailures += @(Get-GovernedDocumentCommitTransitionFailure `
+    if ($objDocumentContext.RequiresVersion) {
+        $arrRepositoryFailures += @(Get-PublishedEndpointMetadataFailure `
                 -Name $objDocumentContext.Path `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -RepositoryRelativePath $objDocumentContext.Path `
-                -MaximumBytes $objDocumentContext.MaximumBytes `
-                -CommitRevision $RangeHeadRevision `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-                -PolicyMarker $objDocumentContext.PolicyMarker `
-                -RequireExpectedUtcDateForRenderedChange $true `
-                -RequiresVersion $objDocumentContext.RequiresVersion `
-                -RequiredDocument $objDocumentContext.RequiredDocument)
+                -CurrentContent $objDocumentContext.Content `
+                -ParentContent $objDocumentContext.ParentContent `
+                -ExpectedUtcDate $objDocumentContext.ExpectedUtcDate `
+                -IsNewDocumentTransition ($null -eq $objDocumentContext.ParentContent) `
+                -RequireExpectedUtcDateForRenderedChange `
+                    $objDocumentContext.IsWorktreeTransition)
+    }
+    else {
+        $arrRepositoryFailures += @(Get-PublishedEndpointLastUpdatedFailure `
+                -Name $objDocumentContext.Path `
+                -CurrentContent $objDocumentContext.Content `
+                -BaseContent $objDocumentContext.ParentContent `
+                -TrustedEventUtcDate $objDocumentContext.ExpectedUtcDate `
+                -RequireCurrentMaximumDateForRenderedChange `
+                    $objDocumentContext.IsWorktreeTransition)
     }
 }
 if ($arrRepositoryFailures.Count -gt 0) {
@@ -7712,9 +6192,8 @@ Write-Output 'Agent-instruction contract passed.'
 if ($SelfTest) {
     #region Mutation self-tests
 
-    if ($intValidatorMaximumInputBytes -ne 573440 -or
-        $intHistoricalPolicyMarkerMaximumBytes -ne 573440) {
-        throw 'The validator and historical policy-marker caps must be 573440 bytes.'
+    if ($intValidatorMaximumInputBytes -ne 573440) {
+        throw 'The validator input cap must be 573440 bytes.'
     }
 
     $strValidatorSource = [IO.File]::ReadAllText($PSCommandPath)
@@ -7733,8 +6212,8 @@ if ($SelfTest) {
         param($objNode)
         $objNode -is [Management.Automation.Language.FunctionDefinitionAst]
     }, $true))
-    if ($arrValidatorFunctionAsts.Count -ne 57) {
-        throw 'The validator function-help inventory must contain exactly 57 functions.'
+    if ($arrValidatorFunctionAsts.Count -ne 52) {
+        throw 'The validator function-help inventory must contain exactly 52 functions.'
     }
     foreach ($objFunctionAst in $arrValidatorFunctionAsts) {
         $objHelp = $objFunctionAst.GetHelpContent()
@@ -7794,9 +6273,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strValidatorSource,
-            '(?m)^# Version: 1\.7\.20260830\.7$'
+            '(?m)^# Version: 1\.7\.20260831\.0$'
         ).Count -ne 1) {
-        throw 'The validator script version does not use build date 20260830.'
+        throw 'The validator script version does not use build date 20260831.'
     }
     $boolSavedWindowsPython = $script:useWindowsPythonLauncher
     $arrSavedPythonNames = $script:pythonPathNames
@@ -7987,7 +6466,7 @@ if ($SelfTest) {
             "- **Last Updated:** $($objDocsMetadataContext.UpdatedDate)",
             "- **Last Updated:** $strNewDocumentDate"
         )
-        $arrNewDocumentFailures = @(Get-DocumentMetadataTransitionFailure `
+        $arrNewDocumentFailures = @(Get-PublishedEndpointMetadataFailure `
                 -Name '.github/instructions/docs.instructions.md' `
                 -CurrentContent $strNewDocumentMutation `
                 -ParentContent $null `
@@ -7997,14 +6476,14 @@ if ($SelfTest) {
             throw "A new document with date $strNewDocumentDate did not fail closed."
         }
     }
-    $arrDocsStaleMetadataFailures = @(Get-DocumentMetadataTransitionFailure `
+    $arrDocsStaleMetadataFailures = @(Get-PublishedEndpointMetadataFailure `
             -Name '.github/instructions/docs.instructions.md' `
             -CurrentContent $strDocsStaleMetadataMutation `
             -ParentContent $strDocsInstructionsContent `
             -ExpectedUtcDate $objDocsMetadataContext.UpdatedDate `
             -IsNewDocumentTransition $false)
     if (-not ($arrDocsStaleMetadataFailures -match [regex]::Escape(
-                '.github/instructions/docs.instructions.md Version revision must be greater than'
+                '.github/instructions/docs.instructions.md Version revision must be exactly'
             ))) {
         throw 'The docs-only stale-metadata mutation did not fail closed.'
     }
@@ -8026,13 +6505,13 @@ if ($SelfTest) {
         $strStaleMetadataMutation = $objDocumentContext.Content +
             [Environment]::NewLine + [Environment]::NewLine +
             'Rendered governed-instruction metadata mutation.'
-        $arrStaleMetadataFailures = @(Get-DocumentMetadataTransitionFailure `
+        $arrStaleMetadataFailures = @(Get-PublishedEndpointMetadataFailure `
                 -Name $strNewlyCoveredPath `
                 -CurrentContent $strStaleMetadataMutation `
                 -ParentContent $objDocumentContext.Content `
                 -ExpectedUtcDate $objMetadataContext.UpdatedDate `
                 -IsNewDocumentTransition $false)
-        $strFailure = "$strNewlyCoveredPath Version revision must be greater than"
+        $strFailure = "$strNewlyCoveredPath Version revision must be exactly"
         if (-not ($arrStaleMetadataFailures -match [regex]::Escape(
                     $strFailure
                 ))) {
@@ -8112,9 +6591,9 @@ if ($SelfTest) {
     }
     if ([regex]::Matches(
             $strExtractedSelfTestSource,
-            '(?m)^# Version: 1\.0\.20260830\.0$'
+            '(?m)^# Version: 1\.1\.20260831\.0$'
         ).Count -ne 1) {
-        throw 'The extracted self-test lacks first-published version 1.0.20260830.0.'
+        throw 'The extracted self-test lacks version 1.1.20260831.0.'
     }
     foreach ($strExactValidatorInputPath in $script:arrPushGovernedExactPaths) {
         if (-not (Test-AgentInstructionWorkflowPath `
@@ -8137,29 +6616,13 @@ if ($SelfTest) {
         $arrRationaleSpecs[0].RequiresVersion -or
         $intStyleGuideRationaleMaximumInputBytes -ne 196608 -or
         [Text.Encoding]::UTF8.GetByteCount($arrRationaleContexts[0].Content) -gt
-            $intStyleGuideRationaleMaximumInputBytes -or
-        $arrRationaleContexts[0].PolicyMarker -cne
-            $strStyleGuideRationaleMetadataPolicyMarker) {
+            $intStyleGuideRationaleMaximumInputBytes) {
         throw 'The canonical rationale lacks exact bounded Tier 1 catalog enforcement.'
-    }
-    foreach ($objGenericMetadataContext in @(
-            $listGovernedDocumentContexts |
-                Where-Object {
-                    $_.Path -cne $strRationalePath -and
-                    $_.Path -notin $script:arrOperationalLintGuidePaths
-                }
-        )) {
-        if ($objGenericMetadataContext.PolicyMarker -cne
-            $strMetadataRangePolicyMarker) {
-            throw "Generic metadata marker selection changed: $($objGenericMetadataContext.Path)"
-        }
     }
     foreach ($strLintGuidePath in $script:arrOperationalLintGuidePaths) {
         $arrLintGuideContexts = @($listGovernedDocumentContexts |
                 Where-Object { $_.Path -ceq $strLintGuidePath })
-        if ($arrLintGuideContexts.Count -ne 1 -or
-            $arrLintGuideContexts[0].PolicyMarker -cne
-                $strLintGuideMetadataPolicyMarker) {
+        if ($arrLintGuideContexts.Count -ne 1) {
             throw "Lint guide is outside Tier 1 policy: $strLintGuidePath"
         }
     }
@@ -8366,14 +6829,14 @@ if ($SelfTest) {
     if ($arrCatalogedNestedGeminiFailures.Count -ne 0) {
         throw 'A cataloged nested GEMINI.md did not enter the governed inventory.'
     }
-    $arrNestedGeminiMetadataFailures = @(Get-DocumentMetadataTransitionFailure `
+    $arrNestedGeminiMetadataFailures = @(Get-PublishedEndpointMetadataFailure `
             -Name 'tools/GEMINI.md' `
             -CurrentContent $strDocsStaleMetadataMutation `
             -ParentContent $strDocsInstructionsContent `
             -ExpectedUtcDate $objDocsMetadataContext.UpdatedDate `
             -IsNewDocumentTransition $false)
     if (-not ($arrNestedGeminiMetadataFailures -match [regex]::Escape(
-                'tools/GEMINI.md Version revision must be greater than'
+                'tools/GEMINI.md Version revision must be exactly'
             ))) {
         throw 'A cataloged nested GEMINI.md bypassed rendered metadata transition.'
     }
@@ -8388,15 +6851,13 @@ if ($SelfTest) {
         }
         $strMutation = $objDocumentContext.Content -creplace
             '(?m)^## Metadata(?=\r?$)', ''
-        $arrFailures = @(Get-LastUpdatedMetadataFreshnessFailure -Name `
+        $arrFailures = @(Get-PublishedEndpointLastUpdatedFailure -Name `
                 $objDocumentContext.Path -CurrentContent $strMutation -BaseContent `
                 $objDocumentContext.Content -TrustedEventUtcDate $objMetadata.UpdatedDate)
         if (-not ($arrFailures -match 'first level-two heading immediately after the H1')) {
             throw "$($objDocumentContext.Path) accepted missing Metadata."
         }
     }
-    $objUnversionedDocument = $arrUnversionedMetadataContexts[0]
-
     $arrRequiredFieldNames = @('Status', 'Owner', 'Last Updated', 'Scope')
     foreach ($objDocumentContext in @(
             $listGovernedDocumentContexts |
@@ -8415,14 +6876,14 @@ if ($SelfTest) {
                 $objFieldLineMatch.Length
             )
             $arrFieldFailures = if ($objDocumentContext.RequiresVersion) {
-                @(Get-DocumentMetadataTransitionFailure -Name $objDocumentContext.Path `
+                @(Get-PublishedEndpointMetadataFailure -Name $objDocumentContext.Path `
                         -CurrentContent $strFieldDeletion `
                         -ParentContent $objDocumentContext.Content `
                         -ExpectedUtcDate $objDocumentContext.ExpectedUtcDate `
                         -IsNewDocumentTransition $false)
             }
             else {
-                @(Get-LastUpdatedMetadataFreshnessFailure -Name $objDocumentContext.Path `
+                @(Get-PublishedEndpointLastUpdatedFailure -Name $objDocumentContext.Path `
                         -CurrentContent $strFieldDeletion `
                         -BaseContent $objDocumentContext.Content `
                         -TrustedEventUtcDate $objDocumentContext.ExpectedUtcDate)
@@ -8461,7 +6922,7 @@ if ($SelfTest) {
             $objFieldLineMatch.Index,
             $objFieldLineMatch.Length
         ).Insert($objFieldLineMatch.Index, $objFieldMutation.Replacement)
-        $arrFieldFailures = @(Get-DocumentMetadataTransitionFailure `
+        $arrFieldFailures = @(Get-PublishedEndpointMetadataFailure `
                 -Name $objRepresentativeDocument.Path `
                 -CurrentContent $strFieldMutation `
                 -ParentContent $objRepresentativeDocument.Content `
@@ -8488,7 +6949,7 @@ if ($SelfTest) {
             $strStatusLine,
             $strHiddenStatus
         )
-        $arrFieldFailures = @(Get-DocumentMetadataTransitionFailure `
+        $arrFieldFailures = @(Get-PublishedEndpointMetadataFailure `
                 -Name $objRepresentativeDocument.Path `
                 -CurrentContent $strHiddenStatusMutation `
                 -ParentContent $objRepresentativeDocument.Content `
@@ -9123,8 +7584,9 @@ if ($SelfTest) {
         -AgentsContent $strRenderedAgentsMutation `
         -ParentAgentsContent $strAgentsContent `
         -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value `
-        -Failure ("AGENTS.md Version revision must be greater than " +
-            "$intAgentsRevision after a same-day content change.")
+        -Failure ("AGENTS.md Version revision must be exactly " +
+            "$intNextAgentsRevision after a rendered-content change with an " +
+            'unchanged published-baseline major, minor, and date tuple.')
 
     $strHigherRevisionParent = $strAgentsContent.Replace(
         $objAgentsVersionMatch.Value,
@@ -9134,14 +7596,13 @@ if ($SelfTest) {
         -AgentsContent $strRenderedAgentsMutation `
         -ParentAgentsContent $strHigherRevisionParent `
         -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value `
-        -Failure ("AGENTS.md Version revision must not decrease from " +
-            "$intNextAgentsRevision to $intAgentsRevision.")
+        -Failure ("AGENTS.md Version revision must be exactly " +
+            "$($intNextAgentsRevision + 1) after a rendered-content change with " +
+            'an unchanged published-baseline major, minor, and date tuple.')
 
-    Assert-Failure `
+    Assert-FixtureAccepted `
         -ParentAgentsContent $strHigherRevisionParent `
-        -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value `
-        -Failure ("AGENTS.md Version revision must not decrease from " +
-            "$intNextAgentsRevision to $intAgentsRevision.")
+        -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value
 
     Assert-FixtureAccepted `
         -ParentAgentsContent $strAgentsContent
@@ -9158,10 +7619,13 @@ if ($SelfTest) {
         $objAgentsVersionMatch.Value,
         $strAgentsVersionStem + $intJumpedAgentsRevision
     )
-    Assert-FixtureAccepted `
+    Assert-Failure `
         -AgentsContent $strSameDayRevisionJump `
         -ParentAgentsContent $strAgentsContent `
-        -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value
+        -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value `
+        -Failure ("AGENTS.md Version revision must be exactly " +
+            "$intNextAgentsRevision after a rendered-content change with an " +
+            'unchanged published-baseline major, minor, and date tuple.')
 
     $objIsoEvent = ConvertFrom-TrustedEventTimestamp -Timestamp `
         ($objAgentsUpdatedMatch.Groups['Date'].Value + 'T00:00:00Z')
@@ -9191,7 +7655,6 @@ if ($SelfTest) {
             -TrustedEventUtcDate '2024-02-29').Count -ne 0) {
         throw 'Stable event replay changed.'
     }
-    $strNextEventDate = $objIsoEvent.AddDays(1).ToString('yyyy-MM-dd')
     if (@(Get-CurrentInputMetadataFreshnessFailure `
             -Name 'AGENTS.md' -CurrentContent $strHigherRevisionParent `
             -BaseContent $strAgentsContent -TrustedEventUtcDate '2000-01-01').Count -ne 0) {
@@ -9246,8 +7709,10 @@ if ($SelfTest) {
         -AgentsContent $strRegressedDateContent `
         -ParentAgentsContent $strAgentsContent `
         -AgentsExpectedUtcDate '2000-01-01' `
-        -Failure ("AGENTS.md Version date must not move backward from " +
-            "$($objAgentsVersionMatch.Groups['Date'].Value) to 20000101.")
+        -Failure ("AGENTS.md Version major, minor, and date tuple must not move " +
+            "backward from $($objAgentsVersionMatch.Groups['Prefix'].Value)" +
+            "$($objAgentsVersionMatch.Groups['Date'].Value) to " +
+            "$($objAgentsVersionMatch.Groups['Prefix'].Value)20000101.")
 
     $strMetadataOnlyRegressedDate = $strAgentsContent.Replace(
         $objAgentsVersionMatch.Value,
@@ -9260,2582 +7725,155 @@ if ($SelfTest) {
         -AgentsContent $strMetadataOnlyRegressedDate `
         -ParentAgentsContent $strAgentsContent `
         -AgentsExpectedUtcDate $objAgentsUpdatedMatch.Groups['Date'].Value `
-        -Failure ("AGENTS.md Version date must not move backward from " +
-            "$($objAgentsVersionMatch.Groups['Date'].Value) to 20000101.")
+        -Failure ("AGENTS.md Version major, minor, and date tuple must not move " +
+            "backward from $($objAgentsVersionMatch.Groups['Prefix'].Value)" +
+            "$($objAgentsVersionMatch.Groups['Date'].Value) to " +
+            "$($objAgentsVersionMatch.Groups['Prefix'].Value)20000101.")
 
-    $strEarlierStaleMetadataContent = $strAgentsContent +
-        [Environment]::NewLine + 'Earlier rendered change with stale metadata.'
-    $arrMultiCommitTransitionContexts = @(
-        [pscustomobject]@{
-            CurrentContent = $strEarlierStaleMetadataContent
-            ParentContent = $strAgentsContent
-            ExpectedUtcDate = $objAgentsUpdatedMatch.Groups['Date'].Value
-            CurrentRevision = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-            ParentRevision = '0000000000000000000000000000000000000000'
-        },
-        [pscustomobject]@{
-            CurrentContent = $strEarlierStaleMetadataContent
-            ParentContent = $strEarlierStaleMetadataContent
-            ExpectedUtcDate = $objAgentsUpdatedMatch.Groups['Date'].Value
-            CurrentRevision = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-            ParentRevision = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        }
+    # Published endpoint regressions deliberately ignore intermediate topic commits.
+    $strEndpointBaseline = @(
+        '# Endpoint fixture'
+        '**Version:** 1.0.20260830.0'
+        '## Metadata'
+        '- **Status:** Active'
+        '- **Owner:** Repository Maintainers'
+        '- **Last Updated:** 2026-08-30'
+        '- **Scope:** Endpoint metadata regression.'
+        '## Content'
+        'Published baseline.'
+    ) -join "`n"
+    $strEndpointFinal = @(
+        '# Endpoint fixture'
+        '**Version:** 1.0.20260831.0'
+        '## Metadata'
+        '- **Status:** Active'
+        '- **Owner:** Repository Maintainers'
+        '- **Last Updated:** 2026-08-31'
+        '- **Scope:** Endpoint metadata regression.'
+        '## Content'
+        'Corrected published final state.'
+    ) -join "`n"
+    $strInvalidIntermediate = $strEndpointBaseline.Replace(
+        'Published baseline.',
+        'Intermediate rendered change without metadata advancement.'
     )
-    $arrTransitionFailures = @(
-        Get-DocumentMetadataRangeTransitionFailure `
-            -Name 'AGENTS.md' `
-            -TransitionContext $arrMultiCommitTransitionContexts
-    )
-    if ($arrTransitionFailures.Count -ne 1 -or
-        -not $arrTransitionFailures[0].Contains(
-            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            [StringComparison]::Ordinal
-        ) -or
-        -not $arrTransitionFailures[0].Contains(
-            'Version revision must be greater',
-            [StringComparison]::Ordinal
+    if ($strInvalidIntermediate -ceq $strEndpointBaseline) {
+        throw 'The deterministic intermediate fixture changed zero bytes.'
+    }
+    $arrPublishedFinalFailures = @(Get-PublishedEndpointMetadataFailure `
+        -Name 'endpoint-fixture.md' -CurrentContent $strEndpointFinal `
+        -ParentContent $strEndpointBaseline -ExpectedUtcDate '2026-08-31' `
+        -IsNewDocumentTransition $false)
+    if ($arrPublishedFinalFailures.Count -ne 0) {
+        throw ('A corrected multi-commit published final state failed: ' +
+            ($arrPublishedFinalFailures -join '; '))
+    }
+    $strInvalidPublishedFinal = $strEndpointFinal.Replace(
+        '**Version:** 1.0.20260831.0', '**Version:** 1.0.20260831.2')
+    $arrInvalidPublishedFinalFailures = @(Get-PublishedEndpointMetadataFailure `
+        -Name 'endpoint-fixture.md' -CurrentContent $strInvalidPublishedFinal `
+        -ParentContent $strEndpointBaseline -ExpectedUtcDate '2026-08-31' `
+        -IsNewDocumentTransition $false)
+    if ($arrInvalidPublishedFinalFailures -cnotcontains
+        ('endpoint-fixture.md Version revision must be exactly 0 when the major, ' +
+            'minor, or date tuple differs from the published baseline.')) {
+        throw 'A genuinely invalid published final revision did not fail closed.'
+    }
+    $strSameTupleFinal = $strEndpointBaseline.Replace(
+        '**Version:** 1.0.20260830.0', '**Version:** 1.0.20260830.1'
+    ).Replace('Published baseline.', 'Published final on the same tuple.')
+    if (@(Get-PublishedEndpointMetadataFailure -Name 'endpoint-fixture.md' `
+            -CurrentContent $strSameTupleFinal -ParentContent $strEndpointBaseline `
+            -ExpectedUtcDate '2026-08-30' -IsNewDocumentTransition $false).Count -ne 0) {
+        throw 'An exact published-baseline revision increment did not pass.'
+    }
+    $strSkippedRevisionFinal = $strSameTupleFinal.Replace(
+        '**Version:** 1.0.20260830.1', '**Version:** 1.0.20260830.2')
+    if (@(Get-PublishedEndpointMetadataFailure -Name 'endpoint-fixture.md' `
+            -CurrentContent $strSkippedRevisionFinal `
+            -ParentContent $strEndpointBaseline -ExpectedUtcDate '2026-08-30' `
+            -IsNewDocumentTransition $false) -cnotcontains
+        ('endpoint-fixture.md Version revision must be exactly 1 after a ' +
+            'rendered-content change with an unchanged published-baseline major, ' +
+            'minor, and date tuple.')) {
+        throw 'A skipped published-final revision did not fail closed.'
+    }
+    foreach ($strLifecycleStatus in @(
+            'Draft', 'Proposed', 'Active', 'Accepted', 'Superseded', 'Deprecated'
         )) {
-        throw 'Multi-commit metadata validation did not preserve an earlier invalid transition.'
+        $strLifecycleFixture = $strEndpointFinal.Replace(
+            '- **Status:** Active', "- **Status:** $strLifecycleStatus")
+        if ($null -ne (Get-DocumentMetadataContext `
+                -Content $strLifecycleFixture).Failure) {
+            throw "ADR lifecycle status was rejected: $strLifecycleStatus"
+        }
     }
-
-    $strNewRefZeroRevision = '0' * 40
-    $strNewRefTestHead = [string] (
-        & git -C $strRepositoryRootPath rev-parse --verify HEAD
-    )
-    if ($LASTEXITCODE -ne 0 -or
-        $strNewRefTestHead.Trim() -notmatch '^[0-9a-fA-F]{40}$') {
-        throw 'Could not resolve the new-ref metadata self-test head.'
+    Assert-PublishedEndpointContext -RepositoryRootPath $strRepositoryRootPath `
+        -EventName 'pull_request_target' -PullRequestAction 'opened' `
+        -BaselineRevision $strCheckedOutRevision `
+        -FinalRevision $strCheckedOutRevision -BaselineAbsent $false `
+        -PullRequestBaseChanged ''
+    Assert-PublishedEndpointContext -RepositoryRootPath $strRepositoryRootPath `
+        -EventName 'push' -PullRequestAction '' `
+        -BaselineRevision $strCheckedOutRevision `
+        -FinalRevision $strCheckedOutRevision -BaselineAbsent $false `
+        -PullRequestBaseChanged ''
+    if (@(Read-GitPublishedEndpointChangedPath `
+            -RepositoryRootPath $strRepositoryRootPath `
+            -BaselineRevision $strCheckedOutRevision `
+            -FinalRevision $strCheckedOutRevision -BaselineAbsent $false `
+            -MaximumBytes $intGitPathListMaximumBytes).Count -ne 0) {
+        throw 'Identical published endpoint trees reported changed paths.'
     }
-    $strNewRefTestHead = $strNewRefTestHead.Trim()
-    $objNewRef = Get-PushGovernedPathApplicability `
+    $strNewRefTestHead = $strCheckedOutRevision
+    $strNewRefZeroRevision = '0' * $strNewRefTestHead.Length
+    $objNewRefApplicability = Get-PushGovernedPathApplicability `
         -RepositoryRootPath $strRepositoryRootPath `
         -BaseRevision $strNewRefZeroRevision `
-        -HeadRevision $strNewRefTestHead `
-        -IsNewRef $true -IsDeletedRef $false
-    if (-not $objNewRef.ShouldValidate -or
-        $objNewRef.Decision -cne
-            'NEW_REF_REQUIRES_FAIL_CLOSED_VALIDATION') {
-        throw 'A new-ref push did not select fail-closed validation.'
+        -HeadRevision $strNewRefTestHead -IsNewRef $true -IsDeletedRef $false
+    if (-not $objNewRefApplicability.ShouldValidate -or
+        $objNewRefApplicability.Decision -cne
+            'NEW_REF_REQUIRES_FAIL_CLOSED_VALIDATION' -or
+        $objNewRefApplicability.ChangedPathCount -ne 0) {
+        throw 'A new ref did not require fail-closed validation of the exact checked-out head.'
     }
-    $objDeleted = Get-PushGovernedPathApplicability `
-        -RepositoryRootPath $strRepositoryRootPath `
-        -BaseRevision $strNewRefTestHead `
-        -HeadRevision $strNewRefZeroRevision `
-        -IsNewRef $false -IsDeletedRef $true
-    if ($objDeleted.ShouldValidate -or
-        $objDeleted.Decision -cne
-            'DELETED_REF_HAS_NO_REMAINING_BYTES') {
-        throw 'A deleted-ref push did not select its exact no-op.'
-    }
-    $objUnchanged = Get-PushGovernedPathApplicability `
-        -RepositoryRootPath $strRepositoryRootPath `
-        -BaseRevision $strNewRefTestHead `
-        -HeadRevision $strNewRefTestHead `
-        -IsNewRef $false -IsDeletedRef $false
-    if ($objUnchanged.ShouldValidate -or
-        $objUnchanged.ChangedPathCount -ne 0) {
-        throw 'An unchanged existing-ref push did not select its exact no-op.'
-    }
-
-    $strPushRoot = [IO.Path]::GetFullPath(
-        [IO.Path]::Combine(
-            [IO.Path]::GetTempPath(),
-            'agent-instruction-push-' + [guid]::NewGuid().ToString('N')
-        )
-    )
-    $strPushTempRoot = [IO.Path]::GetFullPath(
-        [IO.Path]::GetTempPath()
-    )
-    if (-not $strPushRoot.StartsWith(
-            $strPushTempRoot,
-            [StringComparison]::OrdinalIgnoreCase
-        )) {
-        throw 'The push-applicability fixture escaped the system temporary directory.'
-    }
+    $strDifferentNewRefHead =
+        $(if ($strNewRefTestHead[0] -ceq '0') { '1' } else { '0' }) +
+        $strNewRefTestHead.Substring(1)
     try {
-        [void][System.IO.Directory]::CreateDirectory($strPushRoot)
-        & git -C $strPushRoot init --quiet
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not initialize the push-applicability fixture.'
-        }
-        $objImportText = [Text.StringBuilder]::new()
-        foreach ($strHeaderLine in @(
-                'commit refs/heads/base',
-                'mark :1',
-                'author Fixture <fixture@example.invalid> 1700000000 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000000 +0000',
-                'data 4',
-                'base',
-                'deleteall',
-                'commit refs/heads/ungoverned',
-                'mark :2',
-                'author Fixture <fixture@example.invalid> 1700000001 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000001 +0000',
-                'data 10',
-                'ungoverned',
-                'from :1'
-            )) {
-            [void]$objImportText.AppendLine($strHeaderLine)
-        }
-        foreach ($intFixturePath in 1..3000) {
-            [void]$objImportText.AppendLine(
-                'M 100644 inline bulk/file' +
-                    $intFixturePath.ToString('D4') + '.txt'
-            )
-            [void]$objImportText.AppendLine('data 0')
-            [void]$objImportText.AppendLine()
-        }
-        foreach ($strTrailerLine in @(
-                'commit refs/heads/governed',
-                'mark :3',
-                'author Fixture <fixture@example.invalid> 1700000002 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000002 +0000',
-                'data 8',
-                'governed',
-                'from :2',
-                'M 100644 inline zzzz/tools/GEMINI.md',
-                'data 0',
-                '',
-                'commit refs/heads/malformed-decision',
-                'mark :8',
-                'author Fixture <fixture@example.invalid> 1700000002 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000002 +0000',
-                'data 18',
-                'malformed decision',
-                'from :2',
-                'M 100644 inline docs/decisions/archive/0003-new-policy.md',
-                'data 0',
-                '',
-                'commit refs/heads/multi',
-                'mark :5',
-                'author Fixture <fixture@example.invalid> 1700000003 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000003 +0000',
-                'data 5',
-                'multi',
-                'from :3',
-                'M 100644 inline unrelated.txt',
-                'data 0',
-                '',
-                'commit refs/heads/divergent',
-                'mark :4',
-                'author Fixture <fixture@example.invalid> 1700000004 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000004 +0000',
-                'data 9',
-                'divergent',
-                'from :1',
-                'M 100644 inline zzzz/AGENTS.md',
-                'data 0',
-                '',
-                'commit refs/heads/restore-change',
-                'mark :6',
-                'author Fixture <fixture@example.invalid> 1700000005 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000005 +0000',
-                'data 14',
-                'restore change',
-                'from :1',
-                'M 100644 inline AGENTS.md',
-                'data 0',
-                '',
-                'commit refs/heads/restore',
-                'mark :7',
-                'author Fixture <fixture@example.invalid> 1700000006 +0000',
-                'committer Fixture <fixture@example.invalid> 1700000006 +0000',
-                'data 7',
-                'restore',
-                'from :6',
-                'D AGENTS.md',
-                '',
-                'done'
-            )) {
-            [void]$objImportText.AppendLine($strTrailerLine)
-        }
-        $objImportStart = [Diagnostics.ProcessStartInfo]::new('git')
-        $objImportStart.UseShellExecute = $false
-        $objImportStart.CreateNoWindow = $true
-        $objImportStart.RedirectStandardInput = $true
-        $objImportStart.RedirectStandardOutput = $true
-        $objImportStart.RedirectStandardError = $true
-        foreach ($strImportArgument in @(
-                '-C', $strPushRoot, 'fast-import', '--quiet'
-            )) {
-            $objImportStart.ArgumentList.Add($strImportArgument)
-        }
-        $objImportProcess = [Diagnostics.Process]::new()
-        $objImportProcess.StartInfo = $objImportStart
-        if (-not $objImportProcess.Start()) {
-            throw 'Could not start the push-applicability fixture import.'
-        }
-        $objImportErrorTask = $objImportProcess.StandardError.ReadToEndAsync()
-        $objImportOutputTask = $objImportProcess.StandardOutput.ReadToEndAsync()
-        $objImportWriteFailure = $null
-        try {
-            $objImportProcess.StandardInput.Write(
-                $objImportText.ToString().Replace("`r`n", "`n")
-            )
-        }
-        catch {
-            $objImportWriteFailure = $_.Exception
-        }
-        $objImportProcess.StandardInput.Close()
-        if (-not $objImportProcess.WaitForExit(10000)) {
-            $objImportProcess.Kill($true)
-            throw 'The push-applicability fixture import timed out.'
-        }
-        $strImportError = $objImportErrorTask.GetAwaiter().GetResult()
-        [void]$objImportOutputTask.GetAwaiter().GetResult()
-        if ($null -ne $objImportWriteFailure -or
-            $objImportProcess.ExitCode -ne 0) {
-            throw (
-                'Could not import the push-applicability fixture: ' +
-                $strImportError.Trim()
-            )
-        }
-        $objImportProcess.Dispose()
-
-        $strPushBase = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/base
-        )
-        $strPushUngoverned = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/ungoverned
-        )
-        $strPushGoverned = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/governed
-        )
-        $strPushMalformedDecision = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/malformed-decision
-        )
-        $strPushMulti = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/multi
-        )
-        $strPushDivergent = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/divergent
-        )
-        $strPushRestore = [string] (
-            & git -C $strPushRoot rev-parse refs/heads/restore
-        )
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not resolve the push-applicability fixture commits.'
-        }
-        $strPushBase = $strPushBase.Trim()
-        $strPushUngoverned = $strPushUngoverned.Trim()
-        $strPushGoverned = $strPushGoverned.Trim()
-        $strPushMalformedDecision = $strPushMalformedDecision.Trim()
-        $strPushMulti = $strPushMulti.Trim()
-        $strPushDivergent = $strPushDivergent.Trim()
-        $strPushRestore = $strPushRestore.Trim()
-
-        $strMultiEvidence = ConvertTo-Json -Compress -InputObject @(
-            $strPushMulti,
-            $strPushUngoverned,
-            $strPushGoverned
-        )
-        $objMultiContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strPushRoot `
-            -EventName 'push' -PullRequestAction '' `
-            -BaseRevision ('0' * 40) -HeadRevision $strPushMulti `
-            -IsNewRefRange $true -PreviousHeadRevision '' `
-            -EventHeadRevision $strPushMulti -EventHeadDistinct 'true' `
-            -NewRefCommitCount '3' `
-            -NewRefCommitEvidenceJson $strMultiEvidence
-        if ($objMultiContext.FreshnessBaseRevision -cne
-                $strPushBase -or
-            @($objMultiContext.FreshnessBaseRevisions).Count -ne 1 -or
-            $objMultiContext.FreshnessBaseRevisions[0] -cne $strPushBase -or
-            -not $objMultiContext.EvaluateFreshness) {
-            throw 'Complete multi-commit new-ref evidence did not select its full boundary.'
-        }
-        $strZeroRevision = '0' * 40
-        $objExistingContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strPushRoot -EventName 'push' -PullRequestAction '' `
-            -BaseRevision $strZeroRevision -HeadRevision $strPushMulti `
-            -IsNewRefRange $true -PreviousHeadRevision '' -EventHeadRevision $strPushMulti `
-            -EventHeadDistinct 'false' `
-            -NewRefCommitCount '0' -NewRefCommitEvidenceJson '[]'
-        if ($objExistingContext.HistoryBaseRevision -cne
-                $strZeroRevision -or
-            $objExistingContext.FreshnessBaseRevision -cne '' -or
-            $objExistingContext.EvaluateFreshness) {
-            throw 'Existing new-ref context is invalid.'
-        }
-        $strLongHead = $strPushMulti
-        $arrLongEvidence = @(foreach ($intLongCommit in 1..21) {
-            $strLongHead = ([string](& git -C $strPushRoot -c user.name=Fixture `
-                        -c user.email=fixture@example.invalid commit-tree `
-                        "$strLongHead`^{tree}" -p $strLongHead `
-                        -m "long $intLongCommit")).Trim()
-            if ($LASTEXITCODE -ne 0) { throw 'Could not create long new-ref history.' }
-            $strLongHead
-        })
-        $objLongContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strPushRoot -EventName push -PullRequestAction '' `
-            -BaseRevision ('0' * 40) -HeadRevision $strLongHead `
-            -IsNewRefRange $true -PreviousHeadRevision '' `
-            -EventHeadRevision $strLongHead -EventHeadDistinct true `
-            -NewRefCommitCount 21 -NewRefCommitEvidenceJson `
-                (ConvertTo-Json -Compress -InputObject $arrLongEvidence[0..19])
-        if ($objLongContext.FreshnessBaseRevision -cne $strPushMulti) {
-            throw 'Truncated evidence for a 21-commit new-ref push was not recovered.'
-        }
-        foreach ($objInvalidNewRefEvidence in @(
-                [pscustomobject]@{
-                    Name = 'non-array evidence'
-                    Count = '1'
-                    Json = ConvertTo-Json -Compress -InputObject $strPushMulti
-                    Failure = 'commit evidence is malformed'
-                },
-                [pscustomobject]@{
-                    Name = 'duplicate evidence'
-                    Count = '3'
-                    Json = ConvertTo-Json -Compress -InputObject @(
-                        $strPushUngoverned,
-                        $strPushUngoverned,
-                        $strPushMulti
-                    )
-                    Failure = 'contains a duplicate commit'
-                },
-                [pscustomobject]@{
-                    Name = 'missing head evidence'
-                    Count = '1'
-                    Json = ConvertTo-Json -Compress -InputObject @($strPushUngoverned)
-                    Failure = 'does not contain the event head'
-                },
-                [pscustomobject]@{
-                    Name = 'disconnected evidence'
-                    Count = '2'
-                    Json = ConvertTo-Json -Compress -InputObject @(
-                        $strPushMulti,
-                        $strPushDivergent
-                    )
-                    Failure = 'contains a disconnected commit'
-                },
-                [pscustomobject]@{
-                    Name = 'unavailable evidence'
-                    Count = '1'
-                    Json = ConvertTo-Json -Compress -InputObject @(('f' * 40))
-                    Failure = 'commit evidence is unavailable'
-                },
-                [pscustomobject]@{
-                    Name = 'excessive evidence count'
-                    Count = '2049'
-                    Json = '[]'
-                    Failure = 'commit count exceeds the maximum of 2048'
-                }
-            )) {
-            $boolInvalidEvidenceRejected = $false
-            try {
-                [void](Get-MetadataEventRevisionContext `
-                        -RepositoryRootPath $strPushRoot `
-                        -EventName 'push' -PullRequestAction '' `
-                        -BaseRevision ('0' * 40) -HeadRevision $strPushMulti `
-                        -IsNewRefRange $true -PreviousHeadRevision '' `
-                        -EventHeadRevision $strPushMulti -EventHeadDistinct 'true' `
-                        -NewRefCommitCount $objInvalidNewRefEvidence.Count `
-                        -NewRefCommitEvidenceJson $objInvalidNewRefEvidence.Json)
-            }
-            catch {
-                $boolInvalidEvidenceRejected = $_.Exception.Message.Contains(
-                    $objInvalidNewRefEvidence.Failure,
-                    [StringComparison]::Ordinal
-                )
-            }
-            if (-not $boolInvalidEvidenceRejected) {
-                throw "$($objInvalidNewRefEvidence.Name) did not fail closed."
-            }
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushUngoverned
-        $objUngoverned = Get-PushGovernedPathApplicability `
-            -RepositoryRootPath $strPushRoot `
-            -BaseRevision $strPushBase `
-            -HeadRevision $strPushUngoverned `
-            -IsNewRef $false -IsDeletedRef $false
-        if ($objUngoverned.ShouldValidate -or
-            $objUngoverned.ChangedPathCount -ne 3000) {
-            throw 'An exact 3,000-path ungoverned push did not select no-op.'
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushGoverned
-        $objGoverned = Get-PushGovernedPathApplicability `
-            -RepositoryRootPath $strPushRoot `
-            -BaseRevision $strPushBase `
-            -HeadRevision $strPushGoverned `
-            -IsNewRef $false -IsDeletedRef $false
-        if (-not $objGoverned.ShouldValidate -or
-            $objGoverned.ChangedPathCount -ne 3001) {
-            throw 'A governed path after 3,000 other paths was not validated.'
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushMalformedDecision
-        $arrMalformedDecisionPaths = @(& git -C $strPushRoot diff `
-                --name-only $strPushUngoverned $strPushMalformedDecision --)
-        $objMalformedDecision = Get-PushGovernedPathApplicability `
-            -RepositoryRootPath $strPushRoot `
-            -BaseRevision $strPushUngoverned `
-            -HeadRevision $strPushMalformedDecision `
-            -IsNewRef $false -IsDeletedRef $false
-        if ($arrMalformedDecisionPaths.Count -ne 1 -or
-            $arrMalformedDecisionPaths[0] -cne
-                'docs/decisions/archive/0003-new-policy.md' -or
-            -not $objMalformedDecision.ShouldValidate -or
-            $objMalformedDecision.ChangedPathCount -ne 1) {
-            throw 'A nested decision-record push escaped exact applicability.'
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushDivergent
-        $objDivergent = Get-PushGovernedPathApplicability `
-            -RepositoryRootPath $strPushRoot `
-            -BaseRevision $strPushUngoverned `
-            -HeadRevision $strPushDivergent `
-            -IsNewRef $false -IsDeletedRef $false
-        if (-not $objDivergent.ShouldValidate) {
-            throw 'A divergent governed push did not use exact endpoint trees.'
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushRestore
-        $objRestore = Get-PushGovernedPathApplicability `
-            -RepositoryRootPath $strPushRoot `
-            -BaseRevision $strPushBase `
-            -HeadRevision $strPushRestore `
-            -IsNewRef $false -IsDeletedRef $false
-        if (-not $objRestore.ShouldValidate -or
-            $objRestore.ChangedPathCount -ne 2) {
-            throw 'A governed change-then-restore push escaped range applicability.'
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushUngoverned
-        $objBackward = Get-PushGovernedPathApplicability `
-            -RepositoryRootPath $strPushRoot `
-            -BaseRevision $strPushGoverned `
-            -HeadRevision $strPushUngoverned `
-            -IsNewRef $false -IsDeletedRef $false
-        if (-not $objBackward.ShouldValidate -or
-            $objBackward.ChangedPathCount -ne 1) {
-            throw 'A backward governed endpoint change escaped applicability.'
-        }
-
-        & git -C $strPushRoot update-ref HEAD $strPushDivergent
-        $boolMissingPushEndpointRejected = $false
-        try {
-            [void](Get-PushGovernedPathApplicability `
-                    -RepositoryRootPath $strPushRoot `
-                    -BaseRevision ('f' * 40) `
-                    -HeadRevision $strPushDivergent `
-                    -IsNewRef $false -IsDeletedRef $false)
-        }
-        catch {
-            $boolMissingPushEndpointRejected = $_.Exception.Message.Contains(
-                'Push endpoint commit is unavailable',
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolMissingPushEndpointRejected) {
-            throw 'A missing push endpoint did not fail closed.'
-        }
-    }
-    finally {
-        if ([System.IO.Directory]::Exists($strPushRoot) -and
-            $strPushRoot.StartsWith(
-                $strPushTempRoot,
-                [StringComparison]::OrdinalIgnoreCase
-            )) {
-            Remove-Item -LiteralPath $strPushRoot -Recurse -Force
-        }
-    }
-    $strRevisionAgentsFixture = Read-GitRevisionText `
-        -RepositoryRootPath $strRepositoryRootPath `
-        -Revision $strNewRefTestHead `
-        -RepositoryRelativePath 'AGENTS.md' `
-        -MaximumBytes $intAgentsMaximumInputBytes `
-        -RequireRegularFile
-    if (-not [string]::Equals(
-            $strRevisionAgentsFixture,
-            (Read-GitRevisionText `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -Revision $strNewRefTestHead `
-                -RepositoryRelativePath 'AGENTS.md' `
-                -MaximumBytes $intAgentsMaximumInputBytes),
-            [StringComparison]::Ordinal
-        )) {
-        throw 'Regular revision input validation changed the accepted blob content.'
-    }
-    $boolMissingRevisionInputRejected = $false
-    try {
-        [void](Read-GitRevisionText `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -Revision $strNewRefTestHead `
-                -RepositoryRelativePath '.missing-agent-instruction-input' `
-                -MaximumBytes 128 `
-                -RequireRegularFile)
-    }
-    catch {
-        $boolMissingRevisionInputRejected = $_.Exception.Message.Contains(
-            'not one regular 100644 blob',
-            [StringComparison]::Ordinal
-        )
-    }
-    if (-not $boolMissingRevisionInputRejected) {
-        throw 'A missing revision input did not fail the regular-blob check.'
-    }
-    & "$PSScriptRoot/Test-AgentInstructions.SelfTest.ps1" `
-        -RepositoryRootPath $strRepositoryRootPath `
-        -Revision $strNewRefTestHead -MaximumBytes $intAgentsMaximumInputBytes `
-        -MaximumMetadataUtcDate $script:strMaximumMetadataUtcDate
-    $arrNewRefRangeFailures = @(Get-GovernedDocumentRangeTransitionFailure `
-            -Name 'AGENTS.md' `
+        $null = Get-PushGovernedPathApplicability `
             -RepositoryRootPath $strRepositoryRootPath `
-            -RepositoryRelativePath 'AGENTS.md' `
-            -MaximumBytes $intAgentsMaximumInputBytes `
             -BaseRevision $strNewRefZeroRevision `
-            -HeadRevision $strNewRefTestHead `
-            -IsNewRefRange $true `
-            -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-            -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-            -PolicyMarker $strMetadataRangePolicyMarker)
-    if ($arrNewRefRangeFailures.Count -ne 0) {
-        throw "Valid new-ref metadata range failed: $($arrNewRefRangeFailures -join '; ')"
-    }
-    $boolInconsistentNewRefEvidenceRejected = $false
-    try {
-        [void](Get-MetadataEventRevisionContext `
-                -RepositoryRootPath $strRepositoryRootPath -EventName 'push' `
-                -PullRequestAction '' -BaseRevision $strNewRefZeroRevision `
-                -HeadRevision $strNewRefTestHead -IsNewRefRange $true `
-                -PreviousHeadRevision '' -EventHeadRevision $strNewRefTestHead `
-                -EventHeadDistinct 'false' -NewRefCommitCount '1' `
-                -NewRefCommitEvidenceJson (ConvertTo-Json -Compress `
-                    -InputObject @($strNewRefTestHead)))
+            -HeadRevision $strDifferentNewRefHead `
+            -IsNewRef $true -IsDeletedRef $false
+        throw 'A new ref accepted a final revision other than the exact checked-out event head.'
     }
     catch {
-        $boolInconsistentNewRefEvidenceRejected = $_.Exception.Message.Contains(
-            'must report zero introduced commits',
-            [StringComparison]::Ordinal
-        )
-    }
-    if (-not $boolInconsistentNewRefEvidenceRejected) {
-        throw 'Inconsistent new-ref evidence did not fail closed.'
-    }
-    if (@(Get-CurrentInputMetadataFreshnessFailure -Name 'AGENTS.md' `
-            -CurrentContent $strSameDayRevisionJump -BaseContent $strAgentsContent `
-            -TrustedEventUtcDate $strNextEventDate).Count -ne 1) {
-        throw 'Stale new-ref head passed.'
-    }
-
-    $strExistingPushBase = [string] (
-        & git -C $strRepositoryRootPath rev-parse --verify 'HEAD^'
-    )
-    if ($LASTEXITCODE -ne 0 -or
-        $strExistingPushBase.Trim() -notmatch '^[0-9a-fA-F]{40}$') {
-        throw 'Could not resolve the existing-ref metadata self-test base.'
-    }
-    $strExistingPushBase = $strExistingPushBase.Trim()
-    $arrTruncatedPushCommitIds = @(
-        foreach ($intCommitId in 1..2048) {
-            $intCommitId.ToString('x40')
-        }
-    )
-    if ($arrTruncatedPushCommitIds.Count -ne 2048 -or
-        $arrTruncatedPushCommitIds -contains $strNewRefTestHead) {
-        throw 'The truncated push payload fixture is invalid.'
-    }
-    $objTruncatedPushContext = Get-MetadataEventRevisionContext `
-        -RepositoryRootPath $strRepositoryRootPath -EventName 'push' `
-        -PullRequestAction '' -BaseRevision $strExistingPushBase `
-        -HeadRevision $strNewRefTestHead -IsNewRefRange $false `
-        -PreviousHeadRevision '' -EventHeadRevision $strNewRefTestHead `
-        -EventHeadDistinct 'true'
-    if ($objTruncatedPushContext.HistoryBaseRevision -cne $strExistingPushBase -or
-        $objTruncatedPushContext.FreshnessBaseRevision -cne $strExistingPushBase) {
-        throw 'A truncated push payload suppressed exact pushed-head freshness.'
-    }
-    $objExistingHeadPushContext = Get-MetadataEventRevisionContext `
-        -RepositoryRootPath $strRepositoryRootPath -EventName 'push' `
-        -PullRequestAction '' -BaseRevision $strExistingPushBase `
-        -HeadRevision $strNewRefTestHead -IsNewRefRange $false `
-        -PreviousHeadRevision '' -EventHeadRevision $strNewRefTestHead `
-        -EventHeadDistinct 'false'
-    if ($objExistingHeadPushContext.FreshnessBaseRevision -cne '') {
-        throw 'A move to an existing pushed head required event-date freshness.'
-    }
-
-    foreach ($objInvalidPushHead in @(
-            [pscustomobject]@{
-                Name = 'missing expanded head'
-                Revision = ''
-                Distinct = 'true'
-                Failure = 'requires a valid expanded head revision'
-            },
-            [pscustomobject]@{
-                Name = 'mismatched expanded head'
-                Revision = $strExistingPushBase
-                Distinct = 'true'
-                Failure = 'must match the event after revision'
-            },
-            [pscustomobject]@{
-                Name = 'missing distinct value'
-                Revision = $strNewRefTestHead
-                Distinct = ''
-                Failure = 'distinct value must be true or false'
-            },
-            [pscustomobject]@{
-                Name = 'null distinct value'
-                Revision = $strNewRefTestHead
-                Distinct = 'null'
-                Failure = 'distinct value must be true or false'
-            },
-            [pscustomobject]@{
-                Name = 'wrong-case distinct value'
-                Revision = $strNewRefTestHead
-                Distinct = 'True'
-                Failure = 'distinct value must be true or false'
-            }
-        )) {
-        $boolInvalidPushHeadRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strRepositoryRootPath -EventName 'push' `
-                    -PullRequestAction '' -BaseRevision $strExistingPushBase `
-                    -HeadRevision $strNewRefTestHead -IsNewRefRange $false `
-                    -PreviousHeadRevision '' `
-                    -EventHeadRevision $objInvalidPushHead.Revision `
-                    -EventHeadDistinct $objInvalidPushHead.Distinct)
-        }
-        catch {
-            $boolInvalidPushHeadRejected = $_.Exception.Message.Contains(
-                $objInvalidPushHead.Failure,
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolInvalidPushHeadRejected) {
-            throw "Invalid push head passed: $($objInvalidPushHead.Name)"
-        }
-    }
-
-    $boolUnflaggedZeroBaseRejected = $false
-    try {
-        [void](Get-GovernedDocumentRangeTransitionFailure `
-                -Name 'AGENTS.md' `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -RepositoryRelativePath 'AGENTS.md' `
-                -MaximumBytes $intAgentsMaximumInputBytes `
-                -BaseRevision $strNewRefZeroRevision `
-                -HeadRevision $strNewRefTestHead `
-                -IsNewRefRange $false `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-                -PolicyMarker $strMetadataRangePolicyMarker)
-    }
-    catch {
-        $boolUnflaggedZeroBaseRejected = $_.Exception.Message.Contains(
-            'requires the new-ref flag',
-            [StringComparison]::Ordinal
-        )
-    }
-    if (-not $boolUnflaggedZeroBaseRejected) {
-        throw 'An unflagged all-zero metadata range base did not fail closed.'
-    }
-
-    $boolFlaggedNonzeroBaseRejected = $false
-    try {
-        [void](Get-GovernedDocumentRangeTransitionFailure `
-                -Name 'AGENTS.md' `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -RepositoryRelativePath 'AGENTS.md' `
-                -MaximumBytes $intAgentsMaximumInputBytes `
-                -BaseRevision $strNewRefTestHead `
-                -HeadRevision $strNewRefTestHead `
-                -IsNewRefRange $true `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-                -PolicyMarker $strMetadataRangePolicyMarker)
-    }
-    catch {
-        $boolFlaggedNonzeroBaseRejected = $_.Exception.Message.Contains(
-            'requires an all-zero base revision',
-            [StringComparison]::Ordinal
-        )
-    }
-    if (-not $boolFlaggedNonzeroBaseRejected) {
-        throw 'A flagged nonzero metadata range base did not fail closed.'
-    }
-
-    $arrOrdinarySameHeadFailures = @(Get-GovernedDocumentRangeTransitionFailure `
-            -Name 'AGENTS.md' `
-            -RepositoryRootPath $strRepositoryRootPath `
-            -RepositoryRelativePath 'AGENTS.md' `
-            -MaximumBytes $intAgentsMaximumInputBytes `
-            -BaseRevision $strNewRefTestHead `
-            -HeadRevision $strNewRefTestHead `
-            -InputRevision $strNewRefTestHead `
-            -IsNewRefRange $false `
-            -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-            -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-            -PolicyMarker $strMetadataRangePolicyMarker)
-    if ($arrOrdinarySameHeadFailures.Count -ne 0) {
-        throw 'An unchanged ordinary metadata range did not retain its prior behavior.'
-    }
-
-    $strMergeFixtureRoot = [IO.Path]::GetFullPath(
-        [IO.Path]::Combine(
-            [IO.Path]::GetTempPath(),
-            'agent-instruction-merge-' + [guid]::NewGuid().ToString('N')
-        )
-    )
-    $strSystemTempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
-    if (-not $strMergeFixtureRoot.StartsWith(
-            $strSystemTempRoot,
-            [StringComparison]::OrdinalIgnoreCase
-        )) {
-        throw 'The merge-transition fixture path escaped the system temporary directory.'
-    }
-    $boolHadAuthorDate = Test-Path -LiteralPath Env:GIT_AUTHOR_DATE
-    $boolHadCommitterDate = Test-Path -LiteralPath Env:GIT_COMMITTER_DATE
-    $strOriginalAuthorDate = if ($boolHadAuthorDate) { $env:GIT_AUTHOR_DATE } else { '' }
-    $strOriginalCommitterDate = if ($boolHadCommitterDate) {
-        $env:GIT_COMMITTER_DATE
-    }
-    else {
-        ''
-    }
-    try {
-        [void][System.IO.Directory]::CreateDirectory($strMergeFixtureRoot)
-        & git -C $strMergeFixtureRoot init --quiet
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not initialize the merge-transition fixture repository.'
-        }
-        & git -C $strMergeFixtureRoot config core.autocrlf false
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not configure the merge-transition fixture repository.'
-        }
-        $strMergePolicyPath = [IO.Path]::Combine(
-            $strMergeFixtureRoot,
-            '.github',
-            'workflows',
-            'Test-AgentInstructions.ps1'
-        )
-        $strMergeUnversionedRelativePath = 'docs/ISSUE_EVALUATION_PROMPT.md'
-        $strMergeUnversionedPath = [IO.Path]::Combine(
-            $strMergeFixtureRoot,
-            'docs',
-            'ISSUE_EVALUATION_PROMPT.md'
-        )
-        $strRationaleFixtureRelativePath = 'STYLE_GUIDE_RATIONALE.md'
-        $strRationaleFixturePath = [IO.Path]::Combine(
-            $strMergeFixtureRoot,
-            $strRationaleFixtureRelativePath
-        )
-        $strMergeGitIgnorePath = [IO.Path]::Combine(
-            $strMergeFixtureRoot,
-            '.gitignore'
-        )
-        [void][System.IO.Directory]::CreateDirectory(
-            [IO.Path]::GetDirectoryName($strMergePolicyPath)
-        )
-        [void][System.IO.Directory]::CreateDirectory(
-            [IO.Path]::GetDirectoryName($strMergeUnversionedPath)
-        )
-        $objUtf8WithoutBom = [System.Text.UTF8Encoding]::new($false)
-        $objMergeCurrentDate = [DateTime]::ParseExact(
-            $objAgentsUpdatedMatch.Groups['Date'].Value,
-            'yyyy-MM-dd',
-            [System.Globalization.CultureInfo]::InvariantCulture
-        )
-        $strMergeCurrentDate = $objMergeCurrentDate.ToString(
-            'yyyy-MM-dd',
-            [System.Globalization.CultureInfo]::InvariantCulture
-        )
-        $strMergeCurrentTimestamp = $script:objValidationUtcNow.ToString('o')
-        $strMergeHistoricalDate = $objMergeCurrentDate.AddDays(-1).ToString(
-            'yyyy-MM-dd',
-            [System.Globalization.CultureInfo]::InvariantCulture
-        )
-        $strMergeBaseVersion = '**Version:** ' +
-            $objAgentsVersionMatch.Groups['Prefix'].Value +
-            $strMergeHistoricalDate.Replace('-', '') + '.0'
-        $strMergeBaseContent = $strAgentsContent.Replace(
-            $objAgentsVersionMatch.Value,
-            $strMergeBaseVersion
-        ).Replace(
-            $objAgentsUpdatedMatch.Value,
-            "- **Last Updated:** $strMergeHistoricalDate"
-        )
-        $strRationaleFixturePrePolicy = @(
-            '# Rationale fixture',
-            '',
-            '## Table of Contents',
-            '',
-            'Pre-policy rationale content.'
-        ) -join "`n"
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strMergeBaseContent,
-            $objUtf8WithoutBom
-        )
-        [IO.File]::WriteAllText(
-            $strMergePolicyPath,
-            $strMetadataRangePolicyMarker,
-            $objUtf8WithoutBom
-        )
-        [IO.File]::WriteAllText(
-            $strMergeUnversionedPath,
-            $objUnversionedDocument.Content,
-            $objUtf8WithoutBom
-        )
-        [IO.File]::WriteAllText(
-            $strRationaleFixturePath,
-            $strRationaleFixturePrePolicy + "`n",
-            $objUtf8WithoutBom
-        )
-        [IO.File]::WriteAllText(
-            $strMergeGitIgnorePath,
-            "/CLAUDE.local.md`n",
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- `
-            'AGENTS.md' '.github/workflows/Test-AgentInstructions.ps1' `
-            $strMergeUnversionedRelativePath $strRationaleFixtureRelativePath `
-            '.gitignore'
-        $strMergeBaseTree = [string] (& git -C $strMergeFixtureRoot write-tree)
-        if ($LASTEXITCODE -ne 0 -or
-            $strMergeBaseTree.Trim() -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-            throw 'Could not create the merge-transition base tree.'
-        }
-        $strMergeBaseTree = $strMergeBaseTree.Trim()
-
-        $scriptBlockNewPolicyTree = {
-            param([byte[]] $Bytes, [string] $Mode = '100644')
-            [IO.File]::WriteAllBytes($strMergePolicyPath, $Bytes)
-            $strBlob = ([string](& git -C $strMergeFixtureRoot hash-object -w -- `
-                        $strMergePolicyPath)).Trim()
-            & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-            & git -C $strMergeFixtureRoot update-index --cacheinfo `
-                "$Mode,$strBlob,.github/workflows/Test-AgentInstructions.ps1"
-            $strTree = ([string](& git -C $strMergeFixtureRoot write-tree)).Trim()
-            if ($LASTEXITCODE -ne 0 -or $strTree -notmatch '^[0-9a-fA-F]{40}$') {
-                throw 'Could not create an immutable policy-marker fixture.'
-            }
-            return $strTree
-        }
-        $scriptBlockAssertHistoryFailure = {
-            param([string] $Tree, [string] $Message)
-            $boolRejected = $false
-            try {
-                [void](Test-HistoricalPolicyMarker -RepositoryRootPath $strMergeFixtureRoot `
-                        -Revision $Tree -RepositoryRelativePath `
-                        '.github/workflows/Test-AgentInstructions.ps1' `
-                        -Literal $strMetadataRangePolicyMarker)
-            }
-            catch {
-                $boolRejected = $_.Exception.Message.Contains(
-                    $Message, [StringComparison]::Ordinal)
-            }
-            if (-not $boolRejected) { throw "Historical policy fixture was not rejected: $Message" }
-        }
-        $arrBoundedHistory = [Text.Encoding]::UTF8.GetBytes(
-            $strMetadataRangePolicyMarker +
-            ('x' * (393217 - $strMetadataRangePolicyMarker.Length)))
-        $strBoundedHistoryTree = & $scriptBlockNewPolicyTree $arrBoundedHistory
-        if (-not (Test-HistoricalPolicyMarker -RepositoryRootPath $strMergeFixtureRoot `
-                    -Revision $strBoundedHistoryTree -RepositoryRelativePath `
-                    '.github/workflows/Test-AgentInstructions.ps1' `
-                    -Literal $strMetadataRangePolicyMarker)) {
-            throw 'A bounded immutable historical marker was not found.'
-        }
-        $strAbsentHistoryTree = & $scriptBlockNewPolicyTree `
-            ([Text.Encoding]::UTF8.GetBytes('marker absent'))
-        if (Test-HistoricalPolicyMarker -RepositoryRootPath $strMergeFixtureRoot `
-                -Revision $strAbsentHistoryTree -RepositoryRelativePath `
-                '.github/workflows/Test-AgentInstructions.ps1' `
-                -Literal $strMetadataRangePolicyMarker) {
-            throw 'A historical marker-absent policy was classified as governed.'
-        }
-        & $scriptBlockAssertHistoryFailure `
-            (& $scriptBlockNewPolicyTree ([byte[]]::new(573441))) 'must not exceed 573440 bytes'
-        & $scriptBlockAssertHistoryFailure `
-            (& $scriptBlockNewPolicyTree ([byte[]] @(0xC3, 0x28))) 'valid UTF-8 without a BOM'
-        & $scriptBlockAssertHistoryFailure `
-            (& $scriptBlockNewPolicyTree `
-                ([Text.Encoding]::UTF8.GetBytes($strMetadataRangePolicyMarker)) '120000') `
-            'not one regular 100644 blob'
-
-        $scriptBlockCreateMergeFixtureCommit = {
-            param(
-                [string] $Tree,
-                [string[]] $Parents,
-                [string] $Timestamp,
-                [string] $Message
-            )
-
-            $env:GIT_AUTHOR_DATE = $Timestamp
-            $env:GIT_COMMITTER_DATE = $Timestamp
-            $arrCommitArguments = @(
-                '-C', $strMergeFixtureRoot,
-                '-c', 'user.name=Agent Instruction Validator',
-                '-c', 'user.email=validator@example.invalid',
-                'commit-tree', $Tree
-            )
-            foreach ($strFixtureParent in $Parents) {
-                $arrCommitArguments += @('-p', $strFixtureParent)
-            }
-            $arrCommitArguments += @('-m', $Message)
-            $strFixtureCommit = [string] (& git @arrCommitArguments)
-            if ($LASTEXITCODE -ne 0 -or
-                $strFixtureCommit.Trim() -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-                throw "Could not create merge-transition fixture commit: $Message"
-            }
-            return $strFixtureCommit.Trim()
-        }
-        $scriptBlockGetMergeRangeFailure = {
-            param(
-                [string[]] $Base,
-                [string] $Head,
-                [bool] $RequireCommitDate = $false,
-                [string] $Path = 'AGENTS.md',
-                [int] $MaximumBytes = $intAgentsMaximumInputBytes,
-                [bool] $IsNewRef = $false,
-                [string[]] $FreshnessRevision = @(),
-                [bool] $RequiresVersion = $true,
-                [bool] $RequiredDocument = $true
-            )
-            Get-GovernedDocumentRangeTransitionFailure -Name $Path `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -RepositoryRelativePath $Path `
-                -MaximumBytes $MaximumBytes `
-                -BaseRevision $Base -HeadRevision $Head -InputRevision $Head `
-                -IsNewRefRange $IsNewRef `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes 1024 -PolicyMarker $strMetadataRangePolicyMarker `
-                -RequireExpectedUtcDateForRenderedChange $RequireCommitDate `
-                -CommitDateFreshnessRevision $FreshnessRevision `
-                -RequiresVersion $RequiresVersion -RequiredDocument $RequiredDocument
-        }
-        $scriptBlockGetDirectFailure = {
-            param([string] $Commit)
-            Get-GovernedDocumentCommitTransitionFailure -Name 'AGENTS.md' `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -RepositoryRelativePath 'AGENTS.md' `
-                -MaximumBytes $intAgentsMaximumInputBytes `
-                -CommitRevision $Commit `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes 1024 -PolicyMarker $strMetadataRangePolicyMarker `
-                -RequireExpectedUtcDateForRenderedChange $true
-        }
-        $scriptBlockGetUnversionedRangeFailure = {
-            param([string] $Base, [string] $Head)
-            Get-GovernedDocumentRangeTransitionFailure `
-                -Name $strMergeUnversionedRelativePath `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -RepositoryRelativePath $strMergeUnversionedRelativePath `
-                -MaximumBytes $intInstructionDocumentMaximumInputBytes `
-                -BaseRevision $Base -HeadRevision $Head -InputRevision $Head `
-                -IsNewRefRange $false `
-                -PolicyRepositoryRelativePath `
-                    '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes 1024 `
-                -PolicyMarker $strMetadataRangePolicyMarker `
-                -RequireExpectedUtcDateForRenderedChange $true `
-                -RequiresVersion $false
-        }
-
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-        $strCaseFixtureBlob = [string] (
-            'case-folded instruction fixture' |
-                & git -C $strMergeFixtureRoot hash-object -w --stdin
-        )
-        if ($LASTEXITCODE -ne 0 -or
-            $strCaseFixtureBlob.Trim() -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-            throw 'Could not create the case-folded instruction fixture blob.'
-        }
-        foreach ($strCaseFoldedGovernedPath in $arrCaseFoldedGovernedPaths) {
-            & git -C $strMergeFixtureRoot update-index --add --cacheinfo `
-                "100644,$($strCaseFixtureBlob.Trim()),$strCaseFoldedGovernedPath"
-            if ($LASTEXITCODE -ne 0) {
-                throw "Could not add case-folded instruction fixture: $strCaseFoldedGovernedPath"
-            }
-        }
-        $strCaseFoldedTree = ([string] (
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $arrCaseFoldedTreePaths = @(Read-GitTrackedPath `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -Revision $strCaseFoldedTree `
-                -MaximumBytes $intGitPathListMaximumBytes)
-        foreach ($strCaseFoldedGovernedPath in $arrCaseFoldedGovernedPaths) {
-            if ($arrCaseFoldedTreePaths -cnotcontains $strCaseFoldedGovernedPath) {
-                throw "A case-folded path was lost from the synthetic Git tree: $strCaseFoldedGovernedPath"
-            }
-        }
-        $arrCaseFoldedInventoryPaths = @(
-            $arrCaseFoldedTreePaths |
-                Where-Object {
-                    Test-GovernedInstructionInventoryPath `
-                        -RepositoryRelativePath ([string] $_)
-                }
-        )
-        foreach ($strCaseFoldedGovernedPath in $arrCaseFoldedGovernedPaths) {
-            if ($arrCaseFoldedInventoryPaths -cnotcontains $strCaseFoldedGovernedPath) {
-                throw "A case-folded path escaped the synthetic tracked inventory: $strCaseFoldedGovernedPath"
-            }
-            $arrCaseFoldedInventoryFailures = @(
-                Get-GovernedInstructionInventoryFailure `
-                    -CatalogPaths @($arrGovernedInstructionDocuments.Path) `
-                    -TrackedPaths @(
-                        $arrTrackedGovernedInstructionPaths +
-                            $strCaseFoldedGovernedPath
-                    )
-            )
-            if (-not ($arrCaseFoldedInventoryFailures -ccontains (
-                        'Tracked governed instruction is missing from the catalog: ' +
-                        $strCaseFoldedGovernedPath
-                    ))) {
-                throw "A case-folded exact path did not fail ordinal inventory: $strCaseFoldedGovernedPath"
-            }
-        }
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-
-        $strMergeBaseCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents @() `
-            -Timestamp ($strMergeHistoricalDate + 'T08:00:00Z') `
-            -Message 'merge fixture base'
-
-        $scriptBlockNewFixturePathTree = {
-            param(
-                [string] $BaseTree,
-                [hashtable] $PathContent
-            )
-
-            & git -C $strMergeFixtureRoot read-tree $BaseTree
-            if ($LASTEXITCODE -ne 0) {
-                throw 'Could not reset the range-path fixture tree.'
-            }
-            foreach ($strFixturePath in $PathContent.Keys) {
-                $strFixtureFile = [IO.Path]::Combine(
-                    $strMergeFixtureRoot,
-                    $strFixturePath.Replace('/', [IO.Path]::DirectorySeparatorChar)
-                )
-                [void][IO.Directory]::CreateDirectory(
-                    [IO.Path]::GetDirectoryName($strFixtureFile)
-                )
-                [IO.File]::WriteAllText(
-                    $strFixtureFile,
-                    [string]$PathContent[$strFixturePath],
-                    $objUtf8WithoutBom
-                )
-                & git -C $strMergeFixtureRoot add -- $strFixturePath
-                if ($LASTEXITCODE -ne 0) {
-                    throw "Could not add range-path fixture: $strFixturePath"
-                }
-            }
-            $strFixtureTree = ([string] (
-                    & git -C $strMergeFixtureRoot write-tree
-                )).Trim()
-            if ($LASTEXITCODE -ne 0 -or
-                $strFixtureTree -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-                throw 'Could not create the range-path fixture tree.'
-            }
-            return $strFixtureTree
-        }
-        $scriptBlockNewFixtureDeletionTree = {
-            param(
-                [string] $BaseTree,
-                [string[]] $Path
-            )
-
-            & git -C $strMergeFixtureRoot read-tree $BaseTree
-            foreach ($strFixturePath in $Path) {
-                & git -C $strMergeFixtureRoot update-index `
-                    --force-remove -- $strFixturePath
-                if ($LASTEXITCODE -ne 0) {
-                    throw "Could not delete range-path fixture: $strFixturePath"
-                }
-            }
-            $strFixtureTree = ([string] (
-                    & git -C $strMergeFixtureRoot write-tree
-                )).Trim()
-            if ($LASTEXITCODE -ne 0 -or
-                $strFixtureTree -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-                throw 'Could not create the deleted range-path fixture tree.'
-            }
-            return $strFixtureTree
-        }
-
-        if (@(& $scriptBlockGetDirectFailure $strMergeBaseCommit).Count -ne 0) {
-            throw 'Valid policy-active root metadata failed.'
-        }
-        $strMalformedRootTree = & $scriptBlockNewFixturePathTree `
-            -BaseTree $strMergeBaseTree -PathContent @{'AGENTS.md' = 'invalid'}
-        $strMalformedRootCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMalformedRootTree -Parents @() `
-            -Timestamp ($strMergeHistoricalDate + 'T08:00:00Z') `
-            -Message 'malformed policy-active root'
-        if (-not ((@(& $scriptBlockGetDirectFailure $strMalformedRootCommit) -join '; ').Contains(
-                    'must contain exactly one document-level H1',
-                    [StringComparison]::Ordinal))) {
-            throw 'Malformed policy-active root metadata passed.'
-        }
-
-        $strIntroducedStaleVersion = $strMergeBaseVersion -replace '\.0$', '.1'
-        $strIntroducedRestoredVersion = $strMergeBaseVersion -replace '\.0$', '.2'
-        $strIntroducedStaleContent = $strMergeBaseContent.Replace(
-            $strMergeBaseVersion,
-            $strIntroducedStaleVersion
-        ) + "`nIntroduced stale rendered content.`n"
-        $strIntroducedStaleTree = & $scriptBlockNewFixturePathTree `
-            -BaseTree $strMergeBaseTree `
-            -PathContent @{'AGENTS.md' = $strIntroducedStaleContent}
-        $strIntroducedStaleCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strIntroducedStaleTree -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'introduced stale new-ref content'
-        $strIntroducedRestoreContent = $strMergeBaseContent.Replace(
-            $strMergeBaseVersion,
-            $strIntroducedRestoredVersion
-        )
-        $strIntroducedRestoreTree = & $scriptBlockNewFixturePathTree `
-            -BaseTree $strIntroducedStaleTree `
-            -PathContent @{'AGENTS.md' = $strIntroducedRestoreContent}
-        $strIntroducedRestoreCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strIntroducedRestoreTree `
-            -Parents @($strIntroducedStaleCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'introduced endpoint restore'
-        $objIntroducedRestoreContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'push' -PullRequestAction '' `
-            -BaseRevision ('0' * 40) `
-            -HeadRevision $strIntroducedRestoreCommit `
-            -IsNewRefRange $true -PreviousHeadRevision '' `
-            -EventHeadRevision $strIntroducedRestoreCommit `
-            -EventHeadDistinct 'true' -NewRefCommitCount '2' `
-            -NewRefCommitEvidenceJson (ConvertTo-Json -Compress -InputObject @(
-                    $strIntroducedStaleCommit,
-                    $strIntroducedRestoreCommit
-                ))
-        $arrIntroducedRestoreFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base ('0' * 40) -Head $strIntroducedRestoreCommit `
-                -IsNewRef $true -FreshnessRevision `
-                    $objIntroducedRestoreContext.NewRefIntroducedCommitRevisions)
-        if (-not ($arrIntroducedRestoreFailures -join '; ').Contains(
-                "Last Updated must be $strMergeCurrentDate",
+        if (-not $_.Exception.Message.Contains(
+                'does not match the exact event head',
                 [StringComparison]::Ordinal
             )) {
-            throw 'A stale introduced new-ref commit escaped commit-date freshness.'
+            throw
         }
-
-        $strInheritedStaleVersion = $strMergeBaseVersion -replace '\.0$', '.3'
-        $strInheritedStaleContent = $strMergeBaseContent.Replace(
-            $strMergeBaseVersion,
-            $strInheritedStaleVersion
-        ) + "`nInherited stale rendered content.`n"
-        $strInheritedStaleTree = & $scriptBlockNewFixturePathTree `
-            -BaseTree $strMergeBaseTree `
-            -PathContent @{'AGENTS.md' = $strInheritedStaleContent}
-        $strInheritedStaleCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strInheritedStaleTree -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'inherited stale boundary content'
-        $strInheritedBoundaryHead = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strInheritedStaleTree -Parents @($strInheritedStaleCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'introduced unchanged boundary head'
-        $objInheritedBoundaryContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'push' -PullRequestAction '' `
-            -BaseRevision ('0' * 40) `
-            -HeadRevision $strInheritedBoundaryHead `
-            -IsNewRefRange $true -PreviousHeadRevision '' `
-            -EventHeadRevision $strInheritedBoundaryHead `
-            -EventHeadDistinct 'true' -NewRefCommitCount '1' `
-            -NewRefCommitEvidenceJson (ConvertTo-Json -Compress `
-                -InputObject @($strInheritedBoundaryHead))
-        if (@($objInheritedBoundaryContext.NewRefIntroducedCommitRevisions).Count -ne 1 -or
-            $objInheritedBoundaryContext.NewRefIntroducedCommitRevisions[0] -cne
-                $strInheritedBoundaryHead) {
-            throw 'The new-ref freshness allowlist included inherited history.'
-        }
-        $arrInheritedBoundaryFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base ('0' * 40) -Head $strInheritedBoundaryHead `
-                -IsNewRef $true -FreshnessRevision `
-                    $objInheritedBoundaryContext.NewRefIntroducedCommitRevisions)
-        if ($arrInheritedBoundaryFailures.Count -ne 0) {
-            throw (
-                'Inherited new-ref history received introduced-commit freshness: ' +
-                ($arrInheritedBoundaryFailures -join '; ')
-            )
-        }
-
-        $strDecisionPath = 'docs/decisions/0001-range-fixture.md'
-        $strMalformedDecisionPath = 'docs/decisions/range-fixture.md'
-        $strUnrelatedRangePath = 'docs/range-fixture.md'
-        $arrTransientGovernedPaths = @(
-            '.cursor/rules/transient.mdc',
-            'tools/AGENTS.md'
-        )
-        $strDecisionContentPrefix = @(
-            '# Range fixture decision',
-            '',
-            '## Metadata',
-            '',
-            '- **Status:** Active',
-            '- **Owner:** Repository Maintainer'
-        ) -join "`n"
-        $strStaleDecisionContent = $strDecisionContentPrefix + "`n" +
-            "- **Last Updated:** $strMergeHistoricalDate`n" +
-            "- **Scope:** Tests range-only decision records.`n"
-        $strMalformedDecisionContent = $strStaleDecisionContent.Replace(
-            '# Range fixture decision',
-            '# Malformed range fixture decision'
-        )
-        $strDecisionAddTree = & $scriptBlockNewFixturePathTree `
-            -BaseTree $strMergeBaseTree `
-            -PathContent @{
-                $strDecisionPath = $strStaleDecisionContent
-                $strMalformedDecisionPath = $strMalformedDecisionContent
-                $strUnrelatedRangePath = 'Unrelated range fixture.'
-                '.cursor/rules/transient.mdc' = 'Transient Cursor instruction.'
-                'tools/AGENTS.md' = 'Transient nested agent instruction.'
-            }
-        $strDecisionAddCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strDecisionAddTree -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'add range-only decision fixtures'
-        $strDecisionDeleteTree = & $scriptBlockNewFixtureDeletionTree `
-            -BaseTree $strDecisionAddTree `
-            -Path @(
-                $strDecisionPath,
-                $strMalformedDecisionPath,
-                $strUnrelatedRangePath,
-                $arrTransientGovernedPaths[0],
-                $arrTransientGovernedPaths[1]
-            )
-        $strDecisionDeleteCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strDecisionDeleteTree -Parents @($strDecisionAddCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'delete range-only decision fixtures'
-        $arrTouchedDecisionPaths = @(Read-GitRangeTouchedPath `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $strMergeBaseCommit `
-                -HeadRevision $strDecisionDeleteCommit `
-                -IsNewRefRange $false `
-                -RepositoryRelativePathspec 'docs/decisions/' `
-                -MaximumBytes $intGitPathListMaximumBytes)
-        if ($arrTouchedDecisionPaths -cnotcontains $strDecisionPath -or
-            $arrTouchedDecisionPaths -cnotcontains $strMalformedDecisionPath -or
-            $arrTouchedDecisionPaths -ccontains $strUnrelatedRangePath) {
-            throw 'Authenticated range-touched decision discovery was incomplete.'
-        }
-        $arrTouchedRepositoryPaths = @(Read-GitRangeTouchedPath `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $strMergeBaseCommit `
-                -HeadRevision $strDecisionDeleteCommit `
-                -IsNewRefRange $false `
-                -RepositoryRelativePathspec ':(top)**' `
-                -MaximumBytes $intGitPathListMaximumBytes)
-        $arrTouchedGovernedPaths = @(
-            $arrTouchedRepositoryPaths |
-                Where-Object {
-                    Test-GovernedInstructionInventoryPath `
-                        -RepositoryRelativePath ([string]$_)
-                }
-        )
-        $arrTransientInventoryFailures = @(
-            Get-GovernedInstructionInventoryFailure `
-                -CatalogPaths @($arrGovernedInstructionDocuments.Path) `
-                -TrackedPaths @(
-                    $arrTrackedGovernedInstructionPaths + $arrTouchedGovernedPaths
-                )
-        )
-        foreach ($strTransientGovernedPath in $arrTransientGovernedPaths) {
-            $strExpectedTransientFailure =
-                'Tracked governed instruction is missing from the catalog: ' +
-                $strTransientGovernedPath
-            if ($arrTouchedGovernedPaths -cnotcontains $strTransientGovernedPath -or
-                $arrTransientInventoryFailures -cnotcontains $strExpectedTransientFailure) {
-                throw "Transient governed path escaped range inventory: $strTransientGovernedPath"
-            }
-        }
-        $arrMalformedDecisionFailures = @(Get-DecisionRecordPathFailure `
-                -RepositoryRelativePath $strMalformedDecisionPath)
-        if ($arrMalformedDecisionFailures.Count -ne 1) {
-            throw 'A deleted malformed decision path escaped range inventory validation.'
-        }
-        $arrStaleDecisionFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strMergeBaseCommit -Head $strDecisionDeleteCommit `
-                -RequireCommitDate $true -Path $strDecisionPath `
-                -MaximumBytes $intInstructionDocumentMaximumInputBytes `
-                -RequiresVersion $false -RequiredDocument $false)
-        if (-not ($arrStaleDecisionFailures -join '; ').Contains(
-                "Last Updated must be $strMergeCurrentDate",
-                [StringComparison]::Ordinal
-            )) {
-            throw 'A stale add-then-delete decision record escaped range validation.'
-        }
-
-        $strFreshDecisionContent = $strStaleDecisionContent.Replace(
-            $strMergeHistoricalDate,
-            $strMergeCurrentDate
-        )
-        $strFreshDecisionAddTree = & $scriptBlockNewFixturePathTree `
-            -BaseTree $strMergeBaseTree `
-            -PathContent @{$strDecisionPath = $strFreshDecisionContent}
-        $strFreshDecisionAddCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strFreshDecisionAddTree -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'add valid range-only decision fixture'
-        $strFreshDecisionDeleteTree = & $scriptBlockNewFixtureDeletionTree `
-            -BaseTree $strFreshDecisionAddTree -Path @($strDecisionPath)
-        $strFreshDecisionDeleteCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strFreshDecisionDeleteTree `
-            -Parents @($strFreshDecisionAddCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'delete valid range-only decision fixture'
-        $arrFreshDecisionFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strMergeBaseCommit -Head $strFreshDecisionDeleteCommit `
-                -RequireCommitDate $true -Path $strDecisionPath `
-                -MaximumBytes $intInstructionDocumentMaximumInputBytes `
-                -RequiresVersion $false -RequiredDocument $false)
-        if ($arrFreshDecisionFailures.Count -ne 0) {
-            throw (
-                'A valid add-then-delete decision record failed validation: ' +
-                ($arrFreshDecisionFailures -join '; ')
-            )
-        }
-
-        $strRationaleFixturePolicy = $strMetadataRangePolicyMarker + "`n" +
-            $strStyleGuideRationaleMetadataPolicyMarker + "`n"
-        $strRationaleFixtureActive = @(
-            '# Rationale fixture',
-            '',
-            '## Metadata',
-            '',
-            '- **Status:** Active',
-            '- **Owner:** Repository Maintainer',
-            "- **Last Updated:** $strMergeHistoricalDate",
-            '- **Scope:** Explains the rationale fixture.',
-            '',
-            '## Rationale body',
-            '',
-            'Activation content.'
-        ) -join "`n"
-        $strRationaleFixtureActive += "`n"
-        $scriptBlockNewRationaleTree = {
-            param([string] $PolicyContent, [string] $RationaleContent)
-
-            & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-            if ($LASTEXITCODE -ne 0) {
-                throw 'Could not reset the rationale adoption fixture tree.'
-            }
-            [IO.File]::WriteAllText(
-                $strMergePolicyPath,
-                $PolicyContent,
-                $objUtf8WithoutBom
-            )
-            [IO.File]::WriteAllText(
-                $strRationaleFixturePath,
-                $RationaleContent,
-                $objUtf8WithoutBom
-            )
-            & git -C $strMergeFixtureRoot add -- `
-                '.github/workflows/Test-AgentInstructions.ps1' `
-                $strRationaleFixtureRelativePath
-            $strRationaleTree = ([string] (
-                    & git -C $strMergeFixtureRoot write-tree
-                )).Trim()
-            if ($LASTEXITCODE -ne 0 -or
-                $strRationaleTree -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
-                throw 'Could not create the rationale adoption fixture tree.'
-            }
-            return $strRationaleTree
-        }
-        $scriptBlockGetRationaleRangeFailure = {
-            param([string] $Base, [string] $Head)
-
-            Get-GovernedDocumentRangeTransitionFailure `
-                -Name $strRationaleFixtureRelativePath `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -RepositoryRelativePath $strRationaleFixtureRelativePath `
-                -MaximumBytes $intStyleGuideRationaleMaximumInputBytes `
-                -BaseRevision $Base -HeadRevision $Head -InputRevision $Head `
-                -IsNewRefRange $false `
-                -PolicyRepositoryRelativePath `
-                    '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes 1024 `
-                -PolicyMarker $strStyleGuideRationaleMetadataPolicyMarker `
-                -RequireExpectedUtcDateForRenderedChange $true `
-                -RequiresVersion $false
-        }
-        if (Test-HistoricalPolicyMarker `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -Revision $strMergeBaseCommit `
-                -RepositoryRelativePath `
-                    '.github/workflows/Test-AgentInstructions.ps1' `
-                -Literal $strStyleGuideRationaleMetadataPolicyMarker) {
-            throw 'The rationale pre-policy parent contained the adoption marker.'
-        }
-        $strRationaleActivationTree = & $scriptBlockNewRationaleTree `
-            -PolicyContent $strRationaleFixturePolicy `
-            -RationaleContent $strRationaleFixtureActive
-        $strRationaleActivationCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strRationaleActivationTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T09:00:00Z') `
-            -Message 'activate rationale metadata policy'
-        if (-not (Test-HistoricalPolicyMarker `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -Revision $strRationaleActivationCommit `
-                -RepositoryRelativePath `
-                    '.github/workflows/Test-AgentInstructions.ps1' `
-                -Literal $strStyleGuideRationaleMetadataPolicyMarker)) {
-            throw 'The rationale activation child lacked the dedicated marker.'
-        }
-        $arrRationaleActivationFailures = @(
-            & $scriptBlockGetRationaleRangeFailure `
-                -Base $strMergeBaseCommit `
-                -Head $strRationaleActivationCommit
-        )
-        if ($arrRationaleActivationFailures.Count -ne 0) {
-            throw (
-                'The first governed rationale revision failed adoption: ' +
-                ($arrRationaleActivationFailures -join '; ')
-            )
-        }
-
-        $strRationaleFixtureMissingOwner = $strRationaleFixtureActive.Replace(
-            '- **Owner:** Repository Maintainer' + "`n",
-            ''
-        )
-        $strRationaleFixtureStale = $strRationaleFixtureActive.Replace(
-            'Activation content.',
-            'Rendered content changed after activation.'
-        )
-        $strRationaleFixtureMalformed = @(
-            '# Rationale fixture',
-            '',
-            '## Rationale body',
-            '',
-            'Metadata has the wrong position.',
-            '',
-            '## Metadata',
-            '',
-            '- **Status:** Active',
-            '- **Owner:** Repository Maintainer',
-            "- **Last Updated:** $strMergeCurrentDate",
-            '- **Scope:** Explains the rationale fixture.'
-        ) -join "`n"
-        $strRationaleFixtureMalformed += "`n"
-        $strRationaleFixtureRemoved = @(
-            '# Rationale fixture',
-            '',
-            '## Rationale body',
-            '',
-            'The complete metadata block was removed.'
-        ) -join "`n"
-        $strRationaleFixtureRemoved += "`n"
-        $arrRationaleNegativeCases = @(
-            [pscustomobject]@{
-                Name = 'missing owner'
-                Content = $strRationaleFixtureMissingOwner
-                Failure = 'must contain one exact top-level Owner list item'
-            },
-            [pscustomobject]@{
-                Name = 'stale date'
-                Content = $strRationaleFixtureStale
-                Failure = "Last Updated must be $strMergeCurrentDate"
-            },
-            [pscustomobject]@{
-                Name = 'malformed placement'
-                Content = $strRationaleFixtureMalformed
-                Failure = 'must place Metadata as the first level-two heading'
-            },
-            [pscustomobject]@{
-                Name = 'removed metadata'
-                Content = $strRationaleFixtureRemoved
-                Failure = 'must place Metadata as the first level-two heading'
-            }
-        )
-        $intRationaleNegativeCase = 0
-        foreach ($objRationaleNegativeCase in $arrRationaleNegativeCases) {
-            $intRationaleNegativeCase++
-            $strRationaleNegativeTree = & $scriptBlockNewRationaleTree `
-                -PolicyContent $strRationaleFixturePolicy `
-                -RationaleContent $objRationaleNegativeCase.Content
-            $strRationaleNegativeCommit = & $scriptBlockCreateMergeFixtureCommit `
-                -Tree $strRationaleNegativeTree `
-                -Parents @($strRationaleActivationCommit) `
-                -Timestamp $strMergeCurrentTimestamp `
-                -Message "rationale $($objRationaleNegativeCase.Name)"
-            $arrRationaleNegativeFailures = @(
-                & $scriptBlockGetRationaleRangeFailure `
-                    -Base $strRationaleActivationCommit `
-                    -Head $strRationaleNegativeCommit
-            )
-            if (-not ($arrRationaleNegativeFailures -join '; ').Contains(
-                    $objRationaleNegativeCase.Failure,
-                    [StringComparison]::Ordinal
-                )) {
-                throw (
-                    "Rationale $($objRationaleNegativeCase.Name) did not fail closed: " +
-                    ($arrRationaleNegativeFailures -join '; ')
-                )
-            }
-        }
-
-        $strRationaleMarkerRemovalTree = & $scriptBlockNewRationaleTree `
-            -PolicyContent ($strMetadataRangePolicyMarker + "`n") `
-            -RationaleContent ($strRationaleFixtureActive.Replace(
-                'Activation content.',
-                'Content changed while the rationale marker was absent.'
-            ))
-        $strRationaleMarkerRemovalCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strRationaleMarkerRemovalTree `
-            -Parents @($strRationaleActivationCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'remove rationale metadata policy marker'
-        $strRationaleMarkerRestoreCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strRationaleActivationTree `
-            -Parents @($strRationaleMarkerRemovalCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'restore rationale marker and endpoint bytes'
-        $arrRationaleMarkerRemovalFailures = @(
-            & $scriptBlockGetRationaleRangeFailure `
-                -Base $strRationaleActivationCommit `
-                -Head $strRationaleMarkerRestoreCommit
-        )
-        $strRationaleMarkerRemovalFailure =
-            'governance marker style-guide-rationale-metadata-policy-v1 ' +
-            'must not be removed'
-        if (-not ($arrRationaleMarkerRemovalFailures -join '; ').Contains(
-                $strRationaleMarkerRemovalFailure,
-                [StringComparison]::Ordinal
-            )) {
-            throw 'An intermediate rationale policy-marker removal escaped validation.'
-        }
-
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-        [IO.File]::WriteAllText(
-            $strMergeGitIgnorePath,
-            "node_modules/`n",
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- '.gitignore'
-        $strProposedGitIgnoreTree = ([string] (
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $strProposedGitIgnoreCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strProposedGitIgnoreTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'proposed gitignore deletion'
-        $strProposedGitIgnore = Read-GitRevisionText `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -Revision $strProposedGitIgnoreCommit `
-            -RepositoryRelativePath '.gitignore' `
-            -MaximumBytes $intGitIgnoreMaximumInputBytes `
-            -RequireRegularFile
-        if ($strProposedGitIgnore -cmatch '(?m)^/CLAUDE\.local\.md$') {
-            throw 'The proposed .gitignore deletion fixture retained the required rule.'
-        }
-        [IO.File]::WriteAllText(
-            $strMergeGitIgnorePath,
-            "/CLAUDE.local.md`n",
-            $objUtf8WithoutBom
-        )
-
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-        [IO.File]::WriteAllText(
-            $strMergeUnversionedPath,
-            $objUnversionedDocument.Content + "`nRendered stale range change.`n",
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- $strMergeUnversionedRelativePath
-        $strUnversionedStaleTree = ([string] (
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $strUnversionedStaleCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strUnversionedStaleTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'stale unversioned transition'
-        $strUnversionedRestoreCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents @($strUnversionedStaleCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'restore unversioned endpoint'
-        $arrUnversionedRangeFailures = @(
-            & $scriptBlockGetUnversionedRangeFailure `
-                -Base $strMergeBaseCommit -Head $strUnversionedRestoreCommit
-        )
-        if (($arrUnversionedRangeFailures -join "`n") -cnotmatch
-                'Last Updated must') {
-            throw 'A stale change-then-restore unversioned range escaped validation.'
-        }
-        [IO.File]::WriteAllText(
-            $strMergeUnversionedPath,
-            $objUnversionedDocument.Content,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-
-        & git -C $strMergeFixtureRoot rm --cached --force --quiet -- `
-            '.github/workflows/Test-AgentInstructions.ps1'
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not remove the policy marker from the transition fixture index.'
-        }
-        & git -C $strMergeFixtureRoot rm --cached --force --quiet -- 'AGENTS.md'
-        $strMarkerRemovalTree = ([string] (
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $strMarkerRemovalCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMarkerRemovalTree -Parents @($strMergeBaseCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T00:47:00Z') `
-            -Message 'remove marker during governed transition'
-        $strMarkerRestoreCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strMarkerRemovalCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T00:48:00Z') `
-            -Message 'restore marker and endpoint bytes'
-        $arrMarkerRemovalFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strMergeBaseCommit -Head $strMarkerRestoreCommit)
-        if (-not ($arrMarkerRemovalFailures -join '; ').Contains(
-                'governance marker metadata-range-transition-policy-v1 must not be removed',
-                [StringComparison]::Ordinal
-            )) {
-            throw 'An intermediate policy-marker removal escaped edge validation.'
-        }
-        if (($arrMarkerRemovalFailures -join '; ') -cnotmatch
-                'Required governed document AGENTS\.md must exist') {
-            throw 'An intermediate required-document deletion escaped range validation.'
-        }
-        if ((@(& $scriptBlockGetMergeRangeFailure -Base $strMergeBaseCommit `
-                    -Head $strMarkerRestoreCommit -RequiredDocument $false) -join '; ') -cmatch
-                'Required governed document') {
-            throw 'An optional document deletion was rejected as required.'
-        }
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-
-        & git -C $strMergeFixtureRoot rm --cached --force --quiet -- `
-            '.github/workflows/Test-AgentInstructions.ps1'
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not remove the policy marker from the pre-policy fixture index.'
-        }
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            'pre-policy root',
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strPrePolicyRootTree = (& git -C $strMergeFixtureRoot write-tree).Trim()
-        $strPrePolicyRootCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strPrePolicyRootTree -Parents @() `
-            -Timestamp ($strMergeHistoricalDate + 'T01:00:00Z') `
-            -Message 'pre-policy root'
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            'changed pre-policy side',
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strPrePolicySideTree = (& git -C $strMergeFixtureRoot write-tree).Trim()
-        $strPrePolicySideCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strPrePolicySideTree -Parents @($strPrePolicyRootCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T02:00:00Z') `
-            -Message 'pre-policy side'
-        if (@(& $scriptBlockGetDirectFailure `
-                -Commit $strPrePolicySideCommit).Count -ne 0) {
-            throw 'A wholly pre-policy transition failed marker-continuity validation.'
-        }
-        $strSideAdoptsPolicy = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strPrePolicySideCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'side adopts policy'
-        if (@(& $scriptBlockGetMergeRangeFailure -Base $strPrePolicySideCommit `
-                -Head $strSideAdoptsPolicy -RequireCommitDate $true).Count -ne 0) {
-            throw 'A side branch could not adopt the policy.'
-        }
-        $strPolicyBaseCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strPrePolicyRootCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T03:00:00Z') `
-            -Message 'policy introduction'
-        $strPolicyMergeCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents @($strPolicyBaseCommit, $strPrePolicySideCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T04:00:00Z') `
-            -Message 'compliant pre-policy merge'
-        $arrPrePolicyMergeFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strPolicyBaseCommit -Head $strPolicyMergeCommit)
-        if ($arrPrePolicyMergeFailures.Count -ne 0) {
-            throw 'A compliant merge of a pre-policy side branch failed.'
-        }
-        & git -C $strMergeFixtureRoot read-tree $strPrePolicySideTree
-        $strPolicyBlob = (& git -C $strMergeFixtureRoot rev-parse `
-                "$strMergeBaseTree`:.github/workflows/Test-AgentInstructions.ps1").Trim()
-        & git -C $strMergeFixtureRoot update-index --add --cacheinfo `
-            "100644,$strPolicyBlob,.github/workflows/Test-AgentInstructions.ps1"
-        $strImportedTree = (& git -C $strMergeFixtureRoot write-tree).Trim()
-        $strImportedMerge = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strImportedTree `
-            -Parents @($strPolicyBaseCommit, $strPrePolicySideCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T05:00:00Z') `
-            -Message 'noncompliant side import'
-        $arrImportedFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strPolicyBaseCommit -Head $strImportedMerge)
-        if ($arrImportedFailures.Count -eq 0) {
-            throw 'A marker-bearing merge imported noncompliant side content.'
-        }
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-        $strMergeTopicVersion = '**Version:** ' +
-            $objAgentsVersionMatch.Groups['Prefix'].Value +
-            $strMergeHistoricalDate.Replace('-', '') + '.1'
-        $strMergeTopicContent = $strMergeBaseContent.Replace(
-            $strMergeBaseVersion,
-            $strMergeTopicVersion
-        ) + [Environment]::NewLine + 'Inherited merge fixture.' +
-            [Environment]::NewLine
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strMergeTopicContent,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strMergeTopicTree = ([string] (& git -C $strMergeFixtureRoot write-tree)).Trim()
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not create the inherited merge-transition tree.'
-        }
-        $strMergeTopicCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeTopicTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T12:00:00Z') `
-            -Message 'merge fixture topic'
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-        $strAdvancedBaseContent = $strMergeBaseContent +
-            [Environment]::NewLine + 'Base-only governed fixture.' +
-            [Environment]::NewLine
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strAdvancedBaseContent,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strAdvancedBaseTree = ([string](& git -C $strMergeFixtureRoot write-tree)).Trim()
-        $strAdvancedBaseCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAdvancedBaseTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture advanced base'
-        $strAdvancedBaseDescendant = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAdvancedBaseTree `
-            -Parents @($strAdvancedBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture unchanged advanced-base descendant'
-        & git -C $strMergeFixtureRoot read-tree $strMergeBaseTree
-        $strBaseOnlyTrustBlob = [string] (
-            'base-only trust-root fixture' |
-                & git -C $strMergeFixtureRoot hash-object -w --stdin
-        )
-        & git -C $strMergeFixtureRoot update-index --add --cacheinfo `
-            "100644,$($strBaseOnlyTrustBlob.Trim()),.gitattributes"
-        $strAdvancedTrustBaseTree = ([string] (
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $strAdvancedTrustBaseCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAdvancedTrustBaseTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture advanced trust base'
-        & git -C $strMergeFixtureRoot read-tree $strMergeTopicTree
-        & git -C $strMergeFixtureRoot update-index --add --cacheinfo `
-            "100644,$($strBaseOnlyTrustBlob.Trim()),.gitattributes"
-        $strTopicTrustTree = ([string] (
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $strTopicTrustCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strTopicTrustTree `
-            -Parents @($strMergeTopicCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture topic trust-root change'
-        $strTrustMergeCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeTopicTree `
-            -Parents @($strMergeTopicCommit, $strTopicTrustCommit) `
-            -Timestamp $strMergeCurrentTimestamp -Message 'topic trust-root merge restore'
-        $arrRestoredTrustFailures = @(Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $strMergeTopicCommit -HeadRevision $strTrustMergeCommit `
-                -RepositoryRelativePath @('.gitattributes'))
-        if ($arrRestoredTrustFailures.Count -ne 1) {
-            throw 'A restored merge-parent trust-root mutation passed.'
-        }
-        & git -C $strMergeFixtureRoot read-tree $strMergeTopicTree
-        $strSynchronizedTopicCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeTopicTree `
-            -Parents @($strMergeTopicCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture synchronized topic'
-        $arrDirectStaleFailures = @(
-            & $scriptBlockGetDirectFailure $strAdvancedBaseCommit
-        )
-        if (($arrDirectStaleFailures -join "`n") -cnotmatch
-                "Last Updated must be $strMergeCurrentDate") {
-            throw 'A non-distinct governed change escaped commit-date freshness.'
-        }
-        $arrNonDistinctRangeFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strMergeBaseCommit -Head $strAdvancedBaseDescendant `
-                -RequireCommitDate $true)
-        if (($arrNonDistinctRangeFailures -join "`n") -cnotmatch
-                "Last Updated must be $strMergeCurrentDate") {
-            throw 'An earlier non-distinct range transition escaped commit-date freshness.'
-        }
-        foreach ($objDirectPassingFixture in @(
-                [pscustomobject]@{ Commit = $strMergeTopicCommit; Name = 'matching metadata' },
-                [pscustomobject]@{ Commit = $strSynchronizedTopicCommit; Name = 'unchanged head' }
-            )) {
-            if (@(& $scriptBlockGetDirectFailure $objDirectPassingFixture.Commit).Count -ne 0) {
-                throw "A non-distinct $($objDirectPassingFixture.Name) fixture failed."
-            }
-        }
-        foreach ($strHistoryOnlyAction in @('opened', 'reopened')) {
-            $objHistoryOnlyContext = Get-MetadataEventRevisionContext `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -EventName 'pull_request_target' `
-                -PullRequestAction $strHistoryOnlyAction `
-                -BaseRevision $strAdvancedBaseCommit `
-                -HeadRevision $strSynchronizedTopicCommit `
-                -IsNewRefRange $false -PreviousHeadRevision '' `
-                -EventHeadRevision '' -EventHeadDistinct ''
-            if ($objHistoryOnlyContext.HistoryBaseRevision -cne $strMergeBaseCommit -or
-                $objHistoryOnlyContext.FreshnessBaseRevision -cne $strMergeBaseCommit) {
-                throw "$strHistoryOnlyAction did not use its bounded merge base."
-            }
-            $arrInitialFreshnessFailures = @(& $scriptBlockGetMergeRangeFailure `
-                    -Base $objHistoryOnlyContext.HistoryBaseRevision `
-                    -Head $strSynchronizedTopicCommit -RequireCommitDate $true)
-            if ($arrInitialFreshnessFailures.Count -ne 0) {
-                throw "$strHistoryOnlyAction rejected correctly dated commit metadata."
-            }
-        }
-        $objEditedContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'pull_request_target' -PullRequestAction 'edited' `
-            -BaseRevision $strAdvancedBaseCommit `
-            -HeadRevision $strSynchronizedTopicCommit `
-            -IsNewRefRange $false -PreviousHeadRevision '' `
-            -PullRequestBaseChanged 'true' `
-            -EventHeadRevision '' -EventHeadDistinct ''
-        if ($objEditedContext.HistoryBaseRevision -cne $strMergeBaseCommit -or
-            $objEditedContext.FreshnessBaseRevision -cne $strMergeBaseCommit) {
-            throw 'A base-changing edited event did not rebind to its merge base.'
-        }
-        if (@(& $scriptBlockGetMergeRangeFailure `
-                -Base $objEditedContext.HistoryBaseRevision `
-                -Head $strSynchronizedTopicCommit -RequireCommitDate $true).Count -ne 0) {
-            throw 'A base-changing edited event rejected commit-dated metadata.'
-        }
-        $boolEditedWithoutProofRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -EventName 'pull_request_target' -PullRequestAction 'edited' `
-                    -BaseRevision $strAdvancedBaseCommit `
-                    -HeadRevision $strSynchronizedTopicCommit `
-                    -IsNewRefRange $false -PreviousHeadRevision '' `
-                    -EventHeadRevision '' -EventHeadDistinct '')
-        }
-        catch {
-            $boolEditedWithoutProofRejected = $_.Exception.Message.Contains(
-                'requires trusted base-change proof',
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolEditedWithoutProofRejected) {
-            throw 'An edited event without base-change proof did not fail closed.'
-        }
-        $boolNonEditedProofRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -EventName 'pull_request_target' -PullRequestAction 'opened' `
-                    -BaseRevision $strAdvancedBaseCommit `
-                    -HeadRevision $strSynchronizedTopicCommit `
-                    -IsNewRefRange $false -PreviousHeadRevision '' `
-                    -PullRequestBaseChanged 'true' `
-                    -EventHeadRevision '' -EventHeadDistinct '')
-        }
-        catch {
-            $boolNonEditedProofRejected = $_.Exception.Message.Contains(
-                'Only an edited pull request event',
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolNonEditedProofRejected) {
-            throw 'A nonedited event accepted base-change proof.'
-        }
-        $objSynchronizeContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'pull_request_target' -PullRequestAction 'synchronize' `
-            -BaseRevision $strAdvancedBaseCommit `
-            -HeadRevision $strSynchronizedTopicCommit `
-            -IsNewRefRange $false `
-            -PreviousHeadRevision $strMergeTopicCommit `
-            -EventHeadRevision '' -EventHeadDistinct ''
-        if ($objSynchronizeContext.HistoryBaseRevision -cne $strMergeBaseCommit -or
-            $objSynchronizeContext.FreshnessBaseRevision -cne $strMergeTopicCommit) {
-            throw 'Synchronize did not separate merge-base history from topic introduction.'
-        }
-        $objDivergentSynchronizeContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'pull_request_target' `
-            -PullRequestAction 'synchronize' `
-            -BaseRevision $strAdvancedBaseCommit `
-            -HeadRevision $strSynchronizedTopicCommit `
-            -IsNewRefRange $false `
-            -PreviousHeadRevision $strAdvancedBaseCommit `
-            -EventHeadRevision '' -EventHeadDistinct ''
-        if ($objDivergentSynchronizeContext.HistoryBaseRevision -cne
-                $strMergeBaseCommit -or
-            $objDivergentSynchronizeContext.FreshnessBaseRevision -cne
-                $strAdvancedBaseCommit) {
-            throw 'A divergent synchronize lost its independent comparison bases.'
-        }
-        $arrDivergentFreshnessFailures = @(
-            Get-CurrentInputMetadataFreshnessFailure `
-                -Name 'AGENTS.md' `
-                -CurrentContent $strMergeTopicContent `
-                -BaseContent $strMergeBaseContent `
-                -TrustedEventUtcDate $strMergeCurrentDate
-        )
-        if ($arrDivergentFreshnessFailures.Count -ne 1) {
-            throw 'A divergent governed replacement bypassed current-event freshness.'
-        }
-
-        & git -C $strMergeFixtureRoot read-tree $strAdvancedBaseTree
-        $strRebasedTopicContent = $strAdvancedBaseContent.Replace(
-            $strMergeBaseVersion,
-            $strMergeTopicVersion
-        ) +
-            [Environment]::NewLine + 'Inherited merge fixture.' +
-            [Environment]::NewLine
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strRebasedTopicContent,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strRebasedTopicTree = ([string](& git -C $strMergeFixtureRoot write-tree)).Trim()
-        $strRebasedTopicCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strRebasedTopicTree -Parents @($strAdvancedBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture rebased topic'
-        $objRebasedSynchronizeContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'pull_request_target' `
-            -PullRequestAction 'synchronize' `
-            -BaseRevision $strAdvancedBaseCommit `
-            -HeadRevision $strRebasedTopicCommit `
-            -IsNewRefRange $false `
-            -PreviousHeadRevision $strMergeTopicCommit `
-            -EventHeadRevision '' -EventHeadDistinct ''
-        if ($objRebasedSynchronizeContext.HistoryBaseRevision -cne
-                $strAdvancedBaseCommit -or
-            $objRebasedSynchronizeContext.FreshnessBaseRevision -cne
-                $strMergeTopicCommit) {
-            throw 'A rebased topic did not retain authenticated topic delta context.'
-        }
-        if (-not (Test-TopicOwnedGitPathDeltaEqual `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -PreviousBaseRevision $objRebasedSynchronizeContext.PreviousTopicBaseRevision `
-                    -PreviousHeadRevision $objRebasedSynchronizeContext.PreviousTopicHeadRevision `
-                    -CurrentBaseRevision $objRebasedSynchronizeContext.CurrentTopicBaseRevision `
-                    -CurrentHeadRevision $objRebasedSynchronizeContext.CurrentTopicHeadRevision `
-                    -RepositoryRelativePath 'AGENTS.md')) {
-            throw 'A base-only governed rebase was falsely attributed to the topic.'
-        }
-        $strChangedRebasedTopicContent = $strRebasedTopicContent.Replace(
-            $strMergeHistoricalDate.Replace('-', '') + '.1',
-            $strMergeHistoricalDate.Replace('-', '') + '.2'
-        )
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strChangedRebasedTopicContent,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strChangedRebasedTopicTree = ([string](
-                & git -C $strMergeFixtureRoot write-tree
-            )).Trim()
-        $strChangedRebasedTopicCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strChangedRebasedTopicTree -Parents @($strAdvancedBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture changed rebased topic'
-        if (Test-TopicOwnedGitPathDeltaEqual `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -PreviousBaseRevision $objRebasedSynchronizeContext.PreviousTopicBaseRevision `
-                -PreviousHeadRevision $objRebasedSynchronizeContext.PreviousTopicHeadRevision `
-                -CurrentBaseRevision $strAdvancedBaseCommit `
-                -CurrentHeadRevision $strChangedRebasedTopicCommit `
-                -RepositoryRelativePath 'AGENTS.md') {
-            throw 'An actual rebased topic delta change was ignored.'
-        }
-        & git -C $strMergeFixtureRoot read-tree $strRebasedTopicTree
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strRebasedTopicContent,
-            $objUtf8WithoutBom
-        )
-
-        $boolMissingPreviousHeadRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -EventName 'pull_request_target' `
-                    -PullRequestAction 'synchronize' `
-                    -BaseRevision $strAdvancedBaseCommit `
-                    -HeadRevision $strRebasedTopicCommit `
-                    -IsNewRefRange $false `
-                    -PreviousHeadRevision ('f' * 40) `
-                    -EventHeadRevision '' -EventHeadDistinct '')
-        }
-        catch {
-            $boolMissingPreviousHeadRejected = $_.Exception.Message.Contains(
-                'previous topic head is unavailable',
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolMissingPreviousHeadRejected) {
-            throw 'An unavailable synchronize previous head did not fail closed.'
-        }
-        $boolSamePreviousHeadRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -EventName 'pull_request_target' `
-                    -PullRequestAction 'synchronize' `
-                    -BaseRevision $strAdvancedBaseCommit `
-                    -HeadRevision $strRebasedTopicCommit `
-                    -IsNewRefRange $false `
-                    -PreviousHeadRevision $strRebasedTopicCommit `
-                    -EventHeadRevision '' -EventHeadDistinct '')
-        }
-        catch {
-            $boolSamePreviousHeadRejected = $_.Exception.Message.Contains(
-                'distinct valid previous topic head',
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolSamePreviousHeadRejected) {
-            throw 'A synchronize event accepted the new head as its previous head.'
-        }
-        foreach ($strHistoryOnlyAction in @('opened', 'reopened')) {
-            $boolUnexpectedPreviousHeadRejected = $false
-            try {
-                [void](Get-MetadataEventRevisionContext `
-                        -RepositoryRootPath $strMergeFixtureRoot `
-                        -EventName 'pull_request_target' `
-                        -PullRequestAction $strHistoryOnlyAction `
-                        -BaseRevision $strAdvancedBaseCommit `
-                        -HeadRevision $strRebasedTopicCommit `
-                        -IsNewRefRange $false `
-                        -PreviousHeadRevision $strMergeTopicCommit `
-                        -EventHeadRevision '' -EventHeadDistinct '')
-            }
-            catch {
-                $boolUnexpectedPreviousHeadRejected = $_.Exception.Message.Contains(
-                    'must not supply a previous head',
-                    [StringComparison]::Ordinal
-                )
-            }
-            if (-not $boolUnexpectedPreviousHeadRejected) {
-                throw "$strHistoryOnlyAction accepted a previous-head field."
-            }
-        }
-        $arrAdvancedBaseHistoryFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $objSynchronizeContext.HistoryBaseRevision `
-                -Head $strSynchronizedTopicCommit)
-        if ($arrAdvancedBaseHistoryFailures.Count -ne 0) {
-            throw 'Merge-base history validation rejected an advanced-base topic.'
-        }
-        $arrAdvancedBaseTrustFailures = @(Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $strMergeBaseCommit `
-                -HeadRevision $strSynchronizedTopicCommit `
-                -RepositoryRelativePath $script:arrTrustRootPaths)
-        if ($arrAdvancedBaseTrustFailures.Count -ne 0) {
-            throw 'A base-only trust-root change was attributed to the topic.'
-        }
-        $arrBaseTipTrustFailures = @(Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $strAdvancedTrustBaseCommit `
-                -HeadRevision $strSynchronizedTopicCommit `
-                -RepositoryRelativePath $script:arrTrustRootPaths)
-        if ($arrBaseTipTrustFailures.Count -ne 1) {
-            throw 'The advanced-base trust-root reproduction did not distinguish the base tip.'
-        }
-        $arrTopicTrustFailures = @(Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $strMergeBaseCommit `
-                -HeadRevision $strTopicTrustCommit `
-                -RepositoryRelativePath $script:arrTrustRootPaths)
-        if ($arrTopicTrustFailures.Count -ne 1 -or
-            -not ($arrTopicTrustFailures -match [regex]::Escape('.gitattributes'))) {
-            throw 'A topic trust-root change did not fail closed.'
-        }
-        $strMixedPolicyPreBase = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAbsentHistoryTree -Parents @() `
-            -Timestamp ($strMergeHistoricalDate + 'T12:50:00Z') `
-            -Message 'mixed policy pre-base'
-        $strMixedPolicyActiveBase = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strMixedPolicyPreBase) `
-            -Timestamp ($strMergeHistoricalDate + 'T12:51:00Z') `
-            -Message 'mixed policy active base'
-        $strMixedPolicyInactiveBase = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAbsentHistoryTree -Parents @($strMixedPolicyPreBase) `
-            -Timestamp ($strMergeHistoricalDate + 'T12:52:00Z') `
-            -Message 'mixed policy inactive base'
-        $strMixedPolicyHead = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents @($strMixedPolicyActiveBase, $strMixedPolicyInactiveBase) `
-            -Timestamp ($strMergeHistoricalDate + 'T12:53:00Z') `
-            -Message 'mixed policy head'
-        $arrMixedPolicyOutsideBases = @(
-            & git -C $strMergeFixtureRoot log --reverse --topo-order `
-                --format=%H "-S$strMetadataRangePolicyMarker" `
-                $strMixedPolicyHead --not $strMixedPolicyActiveBase `
-                $strMixedPolicyInactiveBase -- `
-                '.github/workflows/Test-AgentInstructions.ps1'
-        )
-        if ($LASTEXITCODE -ne 0 -or $arrMixedPolicyOutsideBases.Count -ne 0) {
-            throw 'The mixed-policy fixture did not exclude the active-base introduction.'
-        }
-        $arrMixedPolicyFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base @($strMixedPolicyActiveBase, $strMixedPolicyInactiveBase) `
-                -Head $strMixedPolicyHead)
-        if ($arrMixedPolicyFailures.Count -ne 0) {
-            throw (
-                'A valid mixed-policy best-base range was rejected: ' +
-                ($arrMixedPolicyFailures -join '; ')
-            )
-        }
-        $strCrissCrossLeft = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strMergeBaseCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:00:00Z') `
-            -Message 'criss-cross left'
-        $strCrissCrossSharedMutation = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAdvancedTrustBaseTree -Parents @($strMergeBaseCommit) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:01:00Z') `
-            -Message 'criss-cross shared-history trust mutation'
-        $strCrissCrossRight = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strCrissCrossSharedMutation) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:01:30Z') `
-            -Message 'criss-cross shared-history trust restore'
-        $strCrissCrossMergeLeft = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents @($strCrissCrossLeft, $strCrissCrossRight) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:02:00Z') `
-            -Message 'criss-cross merge left'
-        $strCrissCrossMergeRight = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents @($strCrissCrossRight, $strCrissCrossLeft) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:03:00Z') `
-            -Message 'criss-cross merge right'
-        $arrExpectedCrissCrossBases = @(
-            $strCrissCrossLeft,
-            $strCrissCrossRight
-        ) | Sort-Object
-        $objCrissCrossOpenedContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'pull_request_target' `
-            -PullRequestAction 'opened' `
-            -BaseRevision $strCrissCrossMergeLeft `
-            -HeadRevision $strCrissCrossMergeRight `
-            -IsNewRefRange $false -PreviousHeadRevision '' `
-            -EventHeadRevision '' -EventHeadDistinct ''
-        if ($objCrissCrossOpenedContext.HistoryBaseRevision -cne '' -or
-            $objCrissCrossOpenedContext.FreshnessBaseRevision -cne '' -or
-            (@($objCrissCrossOpenedContext.HistoryBaseRevisions) -join ',') -cne
-                ($arrExpectedCrissCrossBases -join ',') -or
-            (@($objCrissCrossOpenedContext.FreshnessBaseRevisions) -join ',') -cne
-                ($arrExpectedCrissCrossBases -join ',')) {
-            throw 'A valid opened criss-cross range did not retain every best merge base.'
-        }
-        $arrCrissCrossSharedHistoryTrustFailures = @(
-            Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $arrExpectedCrissCrossBases `
-                -HeadRevision $strCrissCrossMergeRight `
-                -RepositoryRelativePath @('.gitattributes')
-        )
-        if ($arrCrissCrossSharedHistoryTrustFailures.Count -ne 0) {
-            throw 'A mutation excluded by another best base was attributed to the topic.'
-        }
-        $arrCrissCrossSharedHistoryTouchedPaths = @(Read-GitRangeTouchedPath `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $arrExpectedCrissCrossBases `
-                -HeadRevision $strCrissCrossMergeRight `
-                -IsNewRefRange $false `
-                -RepositoryRelativePathspec ':(top)**' `
-                -MaximumBytes $intGitPathListMaximumBytes)
-        if ($arrCrissCrossSharedHistoryTouchedPaths -ccontains '.gitattributes') {
-            throw 'The combined best-base path walk included excluded shared history.'
-        }
-        $strCrissCrossTopicTrustCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strAdvancedTrustBaseTree `
-            -Parents @($strCrissCrossMergeRight) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:03:30Z') `
-            -Message 'criss-cross topic trust mutation'
-        $arrCrissCrossTopicTrustFailures = @(Get-TrustRootRangeMutationFailure `
-                -RepositoryRootPath $strMergeFixtureRoot `
-                -BaseRevision $arrExpectedCrissCrossBases `
-                -HeadRevision $strCrissCrossTopicTrustCommit `
-                -RepositoryRelativePath @('.gitattributes'))
-        if ($arrCrissCrossTopicTrustFailures.Count -ne 1) {
-            throw 'A topic-owned mutation after all best bases did not fail closed.'
-        }
-        $strCrissCrossCurrentHead = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents @($strCrissCrossMergeRight) `
-            -Timestamp ($strMergeHistoricalDate + 'T13:04:00Z') `
-            -Message 'criss-cross synchronize current head'
-        $objCrissCrossSynchronizeContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'pull_request_target' `
-            -PullRequestAction 'synchronize' `
-            -BaseRevision $strCrissCrossMergeLeft `
-            -HeadRevision $strCrissCrossCurrentHead `
-            -IsNewRefRange $false `
-            -PreviousHeadRevision $strCrissCrossMergeRight `
-            -EventHeadRevision '' -EventHeadDistinct ''
-        if ((@($objCrissCrossSynchronizeContext.HistoryBaseRevisions) -join ',') -cne
-                ($arrExpectedCrissCrossBases -join ',') -or
-            $objCrissCrossSynchronizeContext.FreshnessBaseRevision -cne
-                $strCrissCrossMergeRight -or
-            $objCrissCrossSynchronizeContext.PreviousTopicBaseRevision -cne '' -or
-            $objCrissCrossSynchronizeContext.CurrentTopicBaseRevision -cne '') {
-            throw 'A valid synchronize criss-cross range used an incomplete base contract.'
-        }
-        $listExcessiveMergeBases = [Collections.Generic.List[string]]::new()
-        for ($intBaseIndex = 0; $intBaseIndex -lt 65; $intBaseIndex++) {
-            $listExcessiveMergeBases.Add(
-                (& $scriptBlockCreateMergeFixtureCommit `
-                    -Tree $strMergeBaseTree -Parents @($strMergeBaseCommit) `
-                    -Timestamp ([DateTimeOffset]::Parse(
-                            $strMergeHistoricalDate + 'T14:00:00Z'
-                        ).AddSeconds($intBaseIndex).ToString('o')) `
-                    -Message "excessive merge base $intBaseIndex")
-            )
-        }
-        $arrExcessiveMergeBases = $listExcessiveMergeBases.ToArray()
-        $strExcessiveMergeLeft = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents $arrExcessiveMergeBases `
-            -Timestamp ($strMergeHistoricalDate + 'T14:02:00Z') `
-            -Message 'excessive merge-base left'
-        [array]::Reverse($arrExcessiveMergeBases)
-        $strExcessiveMergeRight = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree -Parents $arrExcessiveMergeBases `
-            -Timestamp ($strMergeHistoricalDate + 'T14:03:00Z') `
-            -Message 'excessive merge-base right'
-        $boolExcessiveMergeBasesRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -EventName 'pull_request_target' -PullRequestAction 'opened' `
-                    -BaseRevision $strExcessiveMergeLeft `
-                    -HeadRevision $strExcessiveMergeRight `
-                    -IsNewRefRange $false -PreviousHeadRevision '' `
-                    -EventHeadRevision '' -EventHeadDistinct '')
-        }
-        catch {
-            $boolExcessiveMergeBasesRejected = $_.Exception.Message.Contains(
-                'must have 1 through 64 available merge bases',
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolExcessiveMergeBasesRejected) {
-            throw 'A pull request with more than 64 best merge bases did not fail closed.'
-        }
-        $strInheritedMergeCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeTopicTree `
-            -Parents @($strAdvancedBaseCommit, $strMergeTopicCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture inherited result'
-        $arrInheritedMergeFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strAdvancedBaseCommit -Head $strInheritedMergeCommit `
-                -RequireCommitDate $true)
-        if ($arrInheritedMergeFailures.Count -ne 0) {
-            throw (
-                'A merge that inherited governed content from its non-first parent failed: ' +
-                ($arrInheritedMergeFailures -join '; ')
-            )
-        }
-        $objCreatedMergeContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'push' -PullRequestAction '' `
-            -BaseRevision ('0' * 40) -HeadRevision $strInheritedMergeCommit `
-            -IsNewRefRange $true -PreviousHeadRevision '' `
-            -EventHeadRevision $strInheritedMergeCommit -EventHeadDistinct 'true' `
-            -NewRefCommitCount '1' `
-            -NewRefCommitEvidenceJson (ConvertTo-Json -Compress `
-                -InputObject @($strInheritedMergeCommit))
-        $arrCreatedMergeBoundaries = @(
-            $objCreatedMergeContext.FreshnessBaseRevisions
-        )
-        if ($objCreatedMergeContext.FreshnessBaseRevision -cne '' -or
-            $arrCreatedMergeBoundaries.Count -ne 2 -or
-            $arrCreatedMergeBoundaries -cnotcontains $strAdvancedBaseCommit -or
-            $arrCreatedMergeBoundaries -cnotcontains $strMergeTopicCommit) {
-            throw 'A valid created-ref merge did not retain both authenticated boundaries.'
-        }
-        $strReorderedMergeEvidence = ConvertTo-Json -Compress -InputObject @(
-            $strInheritedMergeCommit,
-            $strMergeTopicCommit,
-            $strAdvancedBaseCommit
-        )
-        $objReorderedMergeContext = Get-MetadataEventRevisionContext `
-            -RepositoryRootPath $strMergeFixtureRoot `
-            -EventName 'push' -PullRequestAction '' `
-            -BaseRevision ('0' * 40) -HeadRevision $strInheritedMergeCommit `
-            -IsNewRefRange $true -PreviousHeadRevision '' `
-            -EventHeadRevision $strInheritedMergeCommit -EventHeadDistinct 'true' `
-            -NewRefCommitCount '3' `
-            -NewRefCommitEvidenceJson $strReorderedMergeEvidence
-        if ($objReorderedMergeContext.FreshnessBaseRevision -cne
-                $strMergeBaseCommit -or
-            @($objReorderedMergeContext.FreshnessBaseRevisions).Count -ne 1 -or
-            $objReorderedMergeContext.FreshnessBaseRevisions[0] -cne
-                $strMergeBaseCommit) {
-            throw 'Reordered exact created-ref DAG evidence was rejected or misbounded.'
-        }
-        $strFutureTopicCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeTopicTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp '2099-12-31T12:00:00Z' `
-            -Message 'merge fixture future topic'
-        $arrFutureTopicFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strMergeBaseCommit -Head $strFutureTopicCommit)
-        if (-not ($arrFutureTopicFailures -join '; ').Contains(
-                "Metadata range commit $strFutureTopicCommit timestamp",
-                [StringComparison]::Ordinal
-            )) {
-            throw 'An ordinary future commit timestamp did not fail closed.'
-        }
-        $strUniqueMergeContent = $strMergeTopicContent.Replace(
-            $strMergeHistoricalDate.Replace('-', '') + '.1',
-            $strMergeHistoricalDate.Replace('-', '') + '.2'
-        ) +
-            [Environment]::NewLine + 'Merge-authored content with stale metadata.'
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strUniqueMergeContent,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strUniqueMergeTree = ([string] (& git -C $strMergeFixtureRoot write-tree)).Trim()
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not create the unique merge-transition tree.'
-        }
-        $strUniqueMergeCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strUniqueMergeTree `
-            -Parents @($strAdvancedBaseCommit, $strMergeTopicCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture unique result'
-        $arrUniqueMergeFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strAdvancedBaseCommit -Head $strUniqueMergeCommit `
-                -RequireCommitDate $true)
-        if ($arrUniqueMergeFailures.Count -eq 0 -or
-            -not ($arrUniqueMergeFailures -join '; ').Contains(
-                "Last Updated must be $strMergeCurrentDate",
-                [StringComparison]::Ordinal
-            )) {
-            throw 'Merge-authored stale metadata did not fail the commit-date rule.'
-        }
-        $arrUniqueFreshnessFailures = @(Get-CurrentInputMetadataFreshnessFailure `
-                -Name 'AGENTS.md' `
-                -CurrentContent $strUniqueMergeContent `
-                -BaseContent $strMergeBaseContent `
-                -TrustedEventUtcDate $strMergeCurrentDate)
-        if (-not ($arrUniqueFreshnessFailures -join '; ').Contains(
-                "Last Updated must be $strMergeCurrentDate",
-                [StringComparison]::Ordinal
-            )) {
-            throw 'Trusted current-input freshness accepted stale merge metadata.'
-        }
-
-        $strNewerParentContent = $strAgentsContent +
-            [Environment]::NewLine + 'Newer first-parent merge fixture.'
-        [IO.File]::WriteAllText(
-            [IO.Path]::Combine($strMergeFixtureRoot, 'AGENTS.md'),
-            $strNewerParentContent,
-            $objUtf8WithoutBom
-        )
-        & git -C $strMergeFixtureRoot add -- 'AGENTS.md'
-        $strNewerParentTree = ([string] (& git -C $strMergeFixtureRoot write-tree)).Trim()
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Could not create the newer merge-parent tree.'
-        }
-        $strNewerParentCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strNewerParentTree `
-            -Parents @($strMergeBaseCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture newer parent'
-        $strRegressingMergeCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeTopicTree `
-            -Parents @($strNewerParentCommit, $strMergeTopicCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture regressing inherited result'
-        $arrRegressingMergeFailures = @(& $scriptBlockGetMergeRangeFailure `
-                -Base $strNewerParentCommit -Head $strRegressingMergeCommit `
-                -RequireCommitDate $true)
-        if ($arrRegressingMergeFailures.Count -eq 0 -or
-            -not ($arrRegressingMergeFailures -join '; ').Contains(
-                'Version date must not move backward',
-                [StringComparison]::Ordinal
-            )) {
-            throw 'An inherited merge metadata rollback did not fail closed.'
-        }
-        $strBackwardBaseCommit = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strNewerParentTree -Parents @($strRegressingMergeCommit) `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'backward push base fixture'
-        $arrBackwardRangeCommits = @(& git -C $strMergeFixtureRoot rev-list `
-                "$strBackwardBaseCommit..$strRegressingMergeCommit")
-        $arrBackwardEndpointPaths = @(& git -C $strMergeFixtureRoot diff `
-                --name-only $strBackwardBaseCommit $strRegressingMergeCommit --)
-        $arrBackwardHeadFailures = @(Get-GovernedDocumentCommitTransitionFailure `
-                -Name 'AGENTS.md' -RepositoryRootPath $strMergeFixtureRoot `
-                -RepositoryRelativePath 'AGENTS.md' `
-                -MaximumBytes $intAgentsMaximumInputBytes `
-                -CommitRevision $strRegressingMergeCommit `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes 1024 -PolicyMarker $strMetadataRangePolicyMarker `
-                -RequireExpectedUtcDateForRenderedChange $true)
-        if ($arrBackwardRangeCommits.Count -ne 0 -or
-            $arrBackwardEndpointPaths.Count -ne 1 -or
-            $arrBackwardEndpointPaths[0] -cne 'AGENTS.md' -or
-            -not (Test-BackwardCommitMove -RepositoryRootPath $strMergeFixtureRoot `
-                    -BaseRevision $strBackwardBaseCommit `
-                    -HeadRevision $strRegressingMergeCommit) -or
-            (Test-BackwardCommitMove -RepositoryRootPath $strMergeFixtureRoot `
-                    -BaseRevision $strRegressingMergeCommit `
-                    -HeadRevision $strBackwardBaseCommit) -or
-            -not ($arrBackwardHeadFailures -join '; ').Contains(
-                'Version date must not move backward',
-                [StringComparison]::Ordinal
-            )) {
-            throw 'A reused backward target did not receive exact direct transition validation.'
-        }
-        $listExcessParents = [Collections.Generic.List[string]]::new()
-        foreach ($intFixtureParent in 1..($intMetadataMaximumParents + 1)) {
-            $listExcessParents.Add((& $scriptBlockCreateMergeFixtureCommit `
-                        -Tree $strMergeBaseTree `
-                        -Parents @($strMergeBaseCommit) `
-                        -Timestamp ($strMergeHistoricalDate + 'T12:00:00Z') `
-                        -Message "merge fixture excess parent $intFixtureParent"))
-        }
-        $strExcessParentMerge = & $scriptBlockCreateMergeFixtureCommit `
-            -Tree $strMergeBaseTree `
-            -Parents $listExcessParents.ToArray() `
-            -Timestamp $strMergeCurrentTimestamp `
-            -Message 'merge fixture excessive parent count'
-        $boolExcessParentCountRejected = $false
-        try {
-            [void](& $scriptBlockGetMergeRangeFailure `
-                    -Base $strMergeBaseCommit -Head $strExcessParentMerge)
-        }
-        catch {
-            $boolExcessParentCountRejected = $_.Exception.Message.Contains(
-                "maximum is $intMetadataMaximumParents",
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolExcessParentCountRejected) {
-            throw 'An excessive metadata merge-parent count did not fail closed.'
-        }
-        $boolExcessEvidenceParentCountRejected = $false
-        try {
-            [void](Get-MetadataEventRevisionContext `
-                    -RepositoryRootPath $strMergeFixtureRoot `
-                    -EventName 'push' -PullRequestAction '' `
-                    -BaseRevision ('0' * 40) -HeadRevision $strExcessParentMerge `
-                    -IsNewRefRange $true -PreviousHeadRevision '' `
-                    -EventHeadRevision $strExcessParentMerge `
-                    -EventHeadDistinct 'true' -NewRefCommitCount '1' `
-                    -NewRefCommitEvidenceJson (ConvertTo-Json -Compress `
-                        -InputObject @($strExcessParentMerge)))
-        }
-        catch {
-            $boolExcessEvidenceParentCountRejected = $_.Exception.Message.Contains(
-                "the maximum is $intMetadataMaximumParents",
-                [StringComparison]::Ordinal
-            )
-        }
-        if (-not $boolExcessEvidenceParentCountRejected) {
-            throw 'Excessive created-ref merge-parent evidence did not fail closed.'
-        }
-    }
-    finally {
-        if ($boolHadAuthorDate) {
-            $env:GIT_AUTHOR_DATE = $strOriginalAuthorDate
-        }
-        else {
-            Remove-Item -LiteralPath Env:GIT_AUTHOR_DATE -ErrorAction SilentlyContinue
-        }
-        if ($boolHadCommitterDate) {
-            $env:GIT_COMMITTER_DATE = $strOriginalCommitterDate
-        }
-        else {
-            Remove-Item -LiteralPath Env:GIT_COMMITTER_DATE -ErrorAction SilentlyContinue
-        }
-        if ([System.IO.Directory]::Exists($strMergeFixtureRoot) -and
-            $strMergeFixtureRoot.StartsWith(
-                $strSystemTempRoot,
-                [StringComparison]::OrdinalIgnoreCase
-            )) {
-            Remove-Item -LiteralPath $strMergeFixtureRoot -Recurse -Force
-        }
-    }
-
-    $strRevisionMismatchFixture = [string] (
-        & git -C $strRepositoryRootPath rev-parse --verify HEAD^1
-    )
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Could not resolve the revision-mismatch self-test fixture.'
-    }
-    $boolRevisionMismatchRejected = $false
-    try {
-        [void](Get-GovernedDocumentRangeTransitionFailure `
-                -Name 'AGENTS.md' `
-                -RepositoryRootPath $strRepositoryRootPath `
-                -RepositoryRelativePath 'AGENTS.md' `
-                -MaximumBytes $intAgentsMaximumInputBytes `
-                -BaseRevision $strNewRefTestHead `
-                -HeadRevision $strNewRefTestHead `
-                -InputRevision $strRevisionMismatchFixture.Trim() `
-                -IsNewRefRange $false `
-                -PolicyRepositoryRelativePath '.github/workflows/Test-AgentInstructions.ps1' `
-                -PolicyMaximumBytes $intValidatorMaximumInputBytes `
-                -PolicyMarker $strMetadataRangePolicyMarker)
-    }
-    catch {
-        $boolRevisionMismatchRejected = $_.Exception.Message.Contains(
-            'does not match the validation revision',
-            [StringComparison]::Ordinal
-        )
-    }
-    if (-not $boolRevisionMismatchRejected) {
-        throw 'A mismatched explicit validation revision did not fail closed.'
     }
 
     $strAgentWorkflowContent = [IO.File]::ReadAllText(
         [IO.Path]::Combine($PSScriptRoot, 'agent-instructions.yml')
     )
     $strValidatorSourceContent = [IO.File]::ReadAllText($PSCommandPath)
-    if ($strValidatorSourceContent -notmatch
-        '\(\$EventName -ceq ''push'' -and -not \$RangeIsNewRef\)' -or
-        $strValidatorSourceContent -notmatch
-        '\$boolCommitDateOnlyEvent = \$EventName -ceq ''pull_request_target''') {
-        throw 'Commit-date range freshness selectors are incomplete.'
-    }
-    if (@($objValidatorAst.FindAll({
-                param($objNode)
-                $objNode -is [Management.Automation.Language.VariableExpressionAst] -and
-                $objNode.VariablePath.UserPath -ceq 'strTrustedEventUtcDate'
-            }, $true)).Count -ne 0) {
-        throw 'A push-event endpoint equality clock remains active.'
+    foreach ($strRemovedTransitionIdentity in @(
+            ('PreviousHead' + 'Revision'), ('EventHead' + 'Revision'),
+            ('EventHead' + 'Distinct'), ('NewRefCommit' + 'Count'),
+            ('NewRefCommitEvidence' + 'Json'),
+            ('Test-HistoricalPolicy' + 'Marker'),
+            ('Get-MetadataEventRevision' + 'Context')
+        )) {
+        if ($strValidatorSourceContent.Contains(
+                $strRemovedTransitionIdentity,
+                [StringComparison]::Ordinal
+            )) {
+            throw "Transition-only validator identity remains: $strRemovedTransitionIdentity"
+        }
     }
     foreach ($objNestedLintDocumentation in @(
             [pscustomobject]@{
@@ -11874,7 +7912,6 @@ if ($SelfTest) {
                 'PUSH_DELETED: ${{ github.event.deleted }}',
                 'refs/remotes/event/push-base',
                 'refs/remotes/event/pr-head',
-                'refs/remotes/event/pr-previous-head',
                 '      - edited',
                 "github.event.action != 'edited' ||",
                 "github.event.changes.base.ref.from != ''",
@@ -11882,18 +7919,14 @@ if ($SelfTest) {
                 '-PullRequestBaseChanged $env:AGENT_INSTRUCTION_PULL_REQUEST_BASE_CHANGED',
                 'test "${fetched_base}" = "${PUSH_BASE_SHA}"',
                 'test "${fetched_head}" = "${PR_HEAD_SHA}"',
-                'test "${fetched_previous_head}" = "${PR_PREVIOUS_HEAD_SHA}"',
-                'github.event.action == ''synchronize'' && github.event.before',
-                'AGENT_INSTRUCTION_EVENT_HEAD_REVISION:',
-                'github.event.head_commit.id',
-                'AGENT_INSTRUCTION_EVENT_HEAD_DISTINCT:',
-                'toJSON(github.event.head_commit.distinct)',
-                '-EventHeadRevision $env:AGENT_INSTRUCTION_EVENT_HEAD_REVISION',
-                '-EventHeadDistinct $env:AGENT_INSTRUCTION_EVENT_HEAD_DISTINCT',
-                'github.event.size',
-                'toJSON(github.event.commits.*.id)',
-                '-NewRefCommitCount $env:AGENT_INSTRUCTION_NEW_REF_COMMIT_COUNT',
-                '-NewRefCommitEvidenceJson $env:AGENT_INSTRUCTION_NEW_REF_COMMITS_JSON',
+                'AGENT_INSTRUCTION_PUBLISHED_BASELINE:',
+                'AGENT_INSTRUCTION_PUBLISHED_FINAL:',
+                'AGENT_INSTRUCTION_PUBLISHED_BASELINE_ABSENT:',
+                'AGENT_INSTRUCTION_PUBLISHED_FINAL_DELETED:',
+                '-PublishedBaselineRevision $env:AGENT_INSTRUCTION_PUBLISHED_BASELINE',
+                '-PublishedFinalRevision $env:AGENT_INSTRUCTION_PUBLISHED_FINAL',
+                'github.event.repository.pushed_at',
+                'github.event.pull_request.updated_at',
                 'persist-credentials: false',
                 'ref: ${{ github.sha }}'
             )) {
@@ -11910,19 +7943,20 @@ if ($SelfTest) {
             $Content -cmatch '"\+[^" ]+:') {
             $listFailures.Add('Event-data fetches must not force a destination ref.')
         }
-        if ($Content -cmatch
-            '(?s)AGENT_INSTRUCTION_EVENT_HEAD_REVISION:.{0,300}github\.event\.commits\.\*\.id') {
-            $listFailures.Add(
-                'The bounded push commits array must not decide head introduction.'
-            )
-        }
-        if ($Content.Contains(
-                'github.event.pull_request.updated_at',
-                [StringComparison]::Ordinal
+        foreach ($strForbiddenTransitionLiteral in @(
+                'PR_PREVIOUS_HEAD_SHA', 'refs/remotes/event/pr-previous-head',
+                'github.event.head_commit.id', 'github.event.commits.*.id',
+                'AGENT_INSTRUCTION_EVENT_HEAD_REVISION',
+                'AGENT_INSTRUCTION_NEW_REF_COMMITS_JSON'
             )) {
-            $listFailures.Add(
-                'Pull request metadata freshness must use commit dates.'
-            )
+            if ($Content.Contains(
+                    $strForbiddenTransitionLiteral,
+                    [StringComparison]::Ordinal
+                )) {
+                $listFailures.Add(
+                    "Workflow retains transition-only input: $strForbiddenTransitionLiteral"
+                )
+            }
         }
         $intExpensiveGateCount = [regex]::Matches(
             $Content,
@@ -11987,20 +8021,12 @@ if ($SelfTest) {
             Expected = 'push must not use a paths or paths-ignore filter.'
         },
         [pscustomobject]@{
-            Name = 'forcing previous-head fetch'
+            Name = 'forcing pull request head fetch'
             Content = $strAgentWorkflowContent.Replace(
-                '"${PR_PREVIOUS_HEAD_SHA}:refs/remotes/event/pr-previous-head"',
-                '"+${PR_PREVIOUS_HEAD_SHA}:refs/remotes/event/pr-previous-head"'
+                '"${PR_HEAD_SHA}:refs/remotes/event/pr-head"',
+                '"+${PR_HEAD_SHA}:refs/remotes/event/pr-head"'
             )
             Expected = 'Event-data fetches must not force a destination ref.'
-        },
-        [pscustomobject]@{
-            Name = 'missing previous-head identity proof'
-            Content = $strAgentWorkflowContent.Replace(
-                'test "${fetched_previous_head}" = "${PR_PREVIOUS_HEAD_SHA}"',
-                'test -n "${fetched_previous_head}"'
-            )
-            Expected = 'Workflow contract literal is missing: test'
         },
         [pscustomobject]@{
             Name = 'persisted checkout credential'
@@ -12009,14 +8035,6 @@ if ($SelfTest) {
                 'persist-credentials: true'
             )
             Expected = 'Workflow contract literal is missing: persist-credentials: false'
-        },
-        [pscustomobject]@{
-            Name = 'bounded push commit-list head evidence'
-            Content = $strAgentWorkflowContent.Replace(
-                'github.event.head_commit.id',
-                'github.event.commits.*.id'
-            )
-            Expected = 'The bounded push commits array must not decide head introduction.'
         },
         [pscustomobject]@{
             Name = 'ungated expensive steps'
@@ -12051,13 +8069,12 @@ if ($SelfTest) {
             Expected = 'Workflow contract literal is missing: -PullRequestBaseChanged'
         },
         [pscustomobject]@{
-            Name = 'mutable pull request activity timestamp'
-            Content = $strAgentWorkflowContent -replace (
-                "github.event_name == 'push' &&\r?\n\s+" +
-                'github.event.repository.pushed_at'
-            ),
-                'github.event.pull_request.updated_at'
-            Expected = 'Pull request metadata freshness must use commit dates.'
+            Name = 'missing pull request final-state timestamp'
+            Content = $strAgentWorkflowContent.Replace(
+                'github.event.pull_request.updated_at',
+                'github.event.pull_request.created_at'
+            )
+            Expected = 'Workflow contract literal is missing: github.event.pull_request.updated_at'
         }
     )
     foreach ($objWorkflowMutation in $arrWorkflowMutations) {
@@ -12079,25 +8096,36 @@ if ($SelfTest) {
         }
     }
 
-    $arrUnchangedFailures = @(Get-TrustRootRangeMutationFailure `
+    $arrUnchangedFailures = @(
+        Get-TrustRootRangeMutationFailure `
             -RepositoryRootPath $strRepositoryRootPath `
             -BaseRevision $strNewRefTestHead `
             -HeadRevision $strNewRefTestHead `
-            -RepositoryRelativePath $script:arrTrustRootPaths)
-    if ($arrUnchangedFailures.Count -ne 0) {
-        throw 'An unchanged trusted validation range did not pass.'
+            -RepositoryRelativePath $script:arrTrustRootPaths |
+            Sort-Object -Unique
+    )
+    if ($arrUnchangedFailures -isnot [array] -or
+        $arrUnchangedFailures.Count -ne 0) {
+        throw 'The zero-result trust-root array regression did not pass.'
     }
     $strTrustRootBase = [string] (
         & git -C $strRepositoryRootPath rev-list --max-parents=0 HEAD |
             Select-Object -First 1
     )
-    $arrTrustRootFailures = @(Get-TrustRootRangeMutationFailure `
+    $arrTrustRootFailures = @(
+        Get-TrustRootRangeMutationFailure `
             -RepositoryRootPath $strRepositoryRootPath `
             -BaseRevision $strTrustRootBase.Trim() `
             -HeadRevision $strNewRefTestHead `
-            -RepositoryRelativePath $script:arrTrustRootPaths)
+            -RepositoryRelativePath $script:arrTrustRootPaths |
+            Sort-Object -Unique
+    )
     if ($LASTEXITCODE -ne 0) {
         throw 'The trusted validation mutation query leaked a nonzero native status.'
+    }
+    if ($arrTrustRootFailures -isnot [array] -or
+        $arrTrustRootFailures.Count -le 1) {
+        throw 'The many-result trust-root array regression did not pass.'
     }
     $arrHistoricallyChangedTrustPaths = @(
         & git -C $strRepositoryRootPath diff --name-only --no-renames `
@@ -12120,15 +8148,19 @@ if ($SelfTest) {
     if ($arrTrustRootFailures.Count -ne $arrHistoricallyChangedTrustPaths.Count) {
         throw 'The trusted validation mutation test returned an unexpected failure count.'
     }
-    $arrAttributeOnlyFailures = @(Get-TrustRootRangeMutationFailure `
+    $arrAttributeOnlyFailures = @(
+        Get-TrustRootRangeMutationFailure `
             -RepositoryRootPath $strRepositoryRootPath `
             -BaseRevision $strTrustRootBase.Trim() `
             -HeadRevision $strNewRefTestHead `
-            -RepositoryRelativePath @('.gitattributes'))
-    if ($arrAttributeOnlyFailures.Count -ne 1 -or
+            -RepositoryRelativePath @('.gitattributes') |
+            Sort-Object -Unique
+    )
+    if ($arrAttributeOnlyFailures -isnot [array] -or
+        $arrAttributeOnlyFailures.Count -ne 1 -or
         -not ($arrAttributeOnlyFailures -match
             [regex]::Escape('changes trusted validation path .gitattributes.'))) {
-        throw 'An attribute-only trust-root query did not fail closed.'
+        throw 'The one-result trust-root array regression did not fail closed.'
     }
 
     $strMetadataNormalizationBase = @(

--- a/.github/workflows/Test-TrustRootAuthorization.ps1
+++ b/.github/workflows/Test-TrustRootAuthorization.ps1
@@ -529,6 +529,45 @@ function Assert-SemanticInvariant {
         return
     }
 
+    if ($Invariant -ceq 'workflow-created-push-history-fetch-is-bounded') {
+        $arrRequiredLiteral = @(
+            'PUSH_COMMIT_EVIDENCE: ${{ toJson(github.event.commits) }}',
+            'const evidence = process.env.PUSH_COMMIT_EVIDENCE;',
+            'Buffer.byteLength(evidence, "utf8") > 1048576',
+            'commits = JSON.parse(evidence);',
+            '!Array.isArray(commits) || commits.length > 2048',
+            '!/^[0-9a-f]{40}$/.test(entry.id)',
+            'seenCommitIds.has(entry.id)',
+            'if (ids.length > 0 &&',
+            'ids[ids.length - 1] !== process.env.PUSH_AFTER_SHA',
+            '(ids.length > 0 ? "\n" : ""), "utf8");',
+            'fetch_depth=$((push_commit_count + 1))',
+            'test "${fetch_depth}" -le 2049',
+            "destination_local_ref='refs/remotes/event/created-destination'",
+            '--no-write-fetch-head --no-recurse-submodules origin',
+            '"${PUSH_REF}:${destination_local_ref}"',
+            'test "${fetched_destination}" = "${PUSH_AFTER_SHA}"',
+            'git cat-file -e "${push_commit_id}^{commit}"',
+            'cmp --silent "${raw_refs}" "${raw_refs_after}"'
+        )
+        foreach ($strRequiredLiteral in $arrRequiredLiteral) {
+            if (-not $Text.Contains(
+                    $strRequiredLiteral,
+                    [StringComparison]::Ordinal
+                )) {
+                throw "$Path does not satisfy semantic invariant $Invariant."
+            }
+        }
+        if ($Text -cmatch '(?m)(^|\s)--force(\s|$)' -or
+            $Text.Contains(
+                '"+${PUSH_REF}:${destination_local_ref}"',
+                [StringComparison]::Ordinal
+            )) {
+            throw "$Path does not satisfy semantic invariant $Invariant."
+        }
+        return
+    }
+
     $hashtablePatterns = @{
         'docs-status-lifecycle-values' =
             'Draft \| Proposed \| Active \| Accepted \| Superseded \| Deprecated'

--- a/.github/workflows/Test-TrustRootAuthorization.ps1
+++ b/.github/workflows/Test-TrustRootAuthorization.ps1
@@ -23,7 +23,7 @@
 # .OUTPUTS
 # [System.Boolean] True only for the exact authorized candidate.
 # .NOTES
-# Version: 1.0.20260902.0
+# Version: 1.0.20260902.1
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([bool])]
@@ -569,6 +569,14 @@ function Assert-SemanticInvariant {
     }
 
     $hashtablePatterns = @{
+        'adr-lifecycle-migration-is-enforced' =
+            '(?s)function Get-DecisionRecordLifecycleFailure.*?' +
+            'An unchanged published legacy ADR did not remain valid\..*?' +
+            'A changed legacy ADR did not require lifecycle migration'
+        'created-ref-metadata-baseline-is-consumed' =
+            '(?s)function Get-CreatedRefMetadataBaselineRevision.*?' +
+            '\$strCreatedRefMetadataBaselineRevision =\s+' +
+            'Get-CreatedRefMetadataBaselineRevision'
         'docs-status-lifecycle-values' =
             'Draft \| Proposed \| Active \| Accepted \| Superseded \| Deprecated'
         'docs-owner-enforcer-relationship' =
@@ -587,8 +595,19 @@ function Assert-SemanticInvariant {
             '\$intMetadataMaximumBoundaries = 64'
         'pr-merge-bases-use-all-and-cap' =
             'merge-base --all'
+        'published-finalization-date-is-enforced' =
+            '(?s)\$strTrustedEventUtcDate = ' +
+            '\$objTrustedEventTimestamp\.ToString\(.*?' +
+            'ExpectedUtcDate = \$strTrustedEventUtcDate.*?' +
+            'IsWorktreeTransition = \$true'
+        'ordinary-pr-uses-normal-trust-audit' =
+            '(?s)if \(\s*\$script:boolTrustedMaintenanceAuthorizationValidated' +
+            '.*?-ExactAuthorizedMaintenanceProductionCall.*?else \{\s+' +
+            '@\(Get-TrustRootRangeMutationFailure'
         'trusted-maintenance-switch-is-explicit' =
             '\$TrustedMaintenanceAuthorizationValidated'
+        'verifier-audits-authorized-history' =
+            'The candidate history contains unauthorized path'
         'verifier-reads-trusted-revision-manifest' =
             'ls-tree\s+`?\s*\$TrustedRevision\s+--\s+\$AuthorizationManifestPath'
         'workflow-checkout-is-trusted-sha' =
@@ -822,6 +841,27 @@ if ($setChangedPaths.Count -ne $setAllowedPaths.Count) {
 foreach ($strChangedPath in $setChangedPaths) {
     if (-not $setAllowedPaths.Contains($strChangedPath)) {
         throw "The candidate contains unauthorized path $strChangedPath."
+    }
+}
+
+$objHistory = Invoke-BoundedProcessByte -FileName 'git' -MaximumBytes 1048576 `
+    -ArgumentList @(
+        '-C', $RepositoryRootPath, 'log', '--format=', '--name-only', '-z',
+        '--no-renames', '--no-ext-diff', '--no-textconv',
+        '--diff-merges=separate', '--root', $HeadRevision, '--not',
+        $BaseRevision, '--'
+    )
+if ($objHistory.ExitCode -ne 0) {
+    throw 'Could not enumerate the authorized candidate history.'
+}
+$strHistory = ConvertFrom-StrictUtf8Text -Bytes $objHistory.Bytes `
+    -Name 'The candidate history path list' -AllowNul
+$arrHistoryPaths = @(
+    $strHistory -split "`0" | Where-Object { $_ -cne '' }
+)
+foreach ($strHistoryPath in $arrHistoryPaths) {
+    if (-not $setAllowedPaths.Contains($strHistoryPath)) {
+        throw "The candidate history contains unauthorized path $strHistoryPath."
     }
 }
 

--- a/.github/workflows/Test-TrustRootAuthorization.ps1
+++ b/.github/workflows/Test-TrustRootAuthorization.ps1
@@ -414,6 +414,57 @@ function Assert-SemanticInvariant {
         return
     }
 
+    if ($Invariant -ceq 'published-path-array-binding-is-explicit') {
+        $arrTokens = $null
+        $arrParseErrors = $null
+        [void] [Management.Automation.Language.Parser]::ParseInput(
+            $Text,
+            [ref] $arrTokens,
+            [ref] $arrParseErrors
+        )
+        $strExplicitCallPattern =
+            '(?s)\[string\[\]\] ' +
+            '\$arrPublishedNewRefBoundaryRevisions = @\(\).*?' +
+            '\[string\[\]\] ' +
+            '\$arrPublishedNewRefIntroducedCommitRevisions = @\(\).*?' +
+            '-NewRefBoundaryRevision ' +
+            '\$arrPublishedNewRefBoundaryRevisions\s+`.*?' +
+            '-NewRefIntroducedCommitRevision\s+`\s+' +
+            '\$arrPublishedNewRefIntroducedCommitRevisions\s+`'
+        $strHelperValidationPattern =
+            '(?s)\$arrBoundaries = @\(\$NewRefBoundaryRevision\)\s+' +
+            '\$arrIntroducedCommits = ' +
+            '@\(\$NewRefIntroducedCommitRevision\).*?' +
+            'foreach \(\$strRevision in ' +
+            '@\(\$arrBoundaries \+ \$arrIntroducedCommits\)\).*?' +
+            '\[string\]::IsNullOrEmpty\(\$strRevision\).*?' +
+            "throw 'The created-ref path range contains an invalid revision\.'"
+        if ($arrParseErrors.Count -ne 0 -or
+            $Text -cnotmatch $strExplicitCallPattern -or
+            $Text -cnotmatch $strHelperValidationPattern -or
+            $Text -cmatch
+                '(?s)-NewRefBoundaryRevision\s+\$\(' -or
+            $Text -cmatch
+                '(?s)-NewRefIntroducedCommitRevision\s+\$\(' -or
+            $Text -cnotmatch
+                'A created ref with no introduced commits reported changed paths\.' -or
+            $Text -cnotmatch
+                'A zero-boundary created ref returned an incorrect ' +
+                'final-tree path set\.' -or
+            $Text -cnotmatch
+                'A nonzero-boundary created ref returned an incorrect ' +
+                'changed-path set\.' -or
+            $Text -cnotmatch
+                "Name = 'null boundary'" -or
+            $Text -cnotmatch
+                "Name = 'empty boundary'" -or
+            $Text -cnotmatch
+                "Name = 'invalid introduced revision'") {
+            throw "$Path does not satisfy semantic invariant $Invariant."
+        }
+        return
+    }
+
     if ($Invariant -ceq 'legacy-transition-marker-is-inert-data') {
         $arrTokens = $null
         $arrParseErrors = $null

--- a/.github/workflows/Test-TrustRootAuthorization.ps1
+++ b/.github/workflows/Test-TrustRootAuthorization.ps1
@@ -354,9 +354,31 @@ function Assert-SemanticInvariant {
             }
         }
         $strAuthorizedFixturePattern =
-            '(?s)\$arrAuthorizedFixtureFailures = @\(\s+' +
+            '(?s)\$script:boolTrustedMaintenanceAuthorizationValidated = ' +
+            '\$true\s+\$arrAuthorizedFixtureFailures = @\(\s+' +
             'Get-TrustRootRangeMutationFailure\s+`.*?' +
-            '-RepositoryRelativePath \$script:arrTrustRootPaths\s+\)'
+            '-RepositoryRelativePath \$strAuthorizationFixtureTrustPath\s+\)'
+        $strHermeticFixturePattern =
+            '(?s)\$strAuthorizationFixtureRoot = \[IO\.Path\]::Combine\(' +
+            '.*?agent-instruction-trust-root-.*?' +
+            '\$strAuthorizationFixtureRepository =.*?' +
+            "commit --quiet --no-gpg-sign -m 'trust-root baseline'.*?" +
+            "commit --quiet --no-gpg-sign -m 'trust-root mutation'.*?" +
+            'git clone --quiet --depth 1 --no-local --no-hardlinks.*?' +
+            '--is-shallow-repository.*?rev-list\s+`\s+' +
+            '--max-parents=0 HEAD.*?' +
+            'The depth-one clone did not reproduce the apparent-root condition\.'
+        $strNoMutationFixturePattern =
+            '(?s)\$arrNoMutationFixtureFailures = @\(\s+' +
+            'Get-TrustRootRangeMutationFailure\s+`.*?' +
+            '-BaseRevision \$strAuthorizationFixtureHead\.Trim\(\)\s+`.*?' +
+            '-HeadRevision \$strAuthorizationFixtureHead\.Trim\(\).*?' +
+            '\$arrNoMutationFixtureFailures\.Count -ne 0'
+        $strFixtureCleanupPattern =
+            '(?s)finally \{\s+' +
+            '\$script:boolTrustedMaintenanceAuthorizationValidated =.*?' +
+            'Remove-Item -LiteralPath \$strAuthorizationFixtureRoot ' +
+            '-Recurse -Force\s+\}\s+\}'
         if ($arrParseErrors.Count -ne 0 -or
             $Text -cnotmatch
                 '(?s)if \(\$ExactAuthorizedMaintenanceProductionCall -and\s+' +
@@ -369,6 +391,7 @@ function Assert-SemanticInvariant {
                 '\{\s+return' -or
             $intProductionSwitchCalls -ne 1 -or
             $intSelfTestSwitchCalls -ne 2 -or
+            $Text -cnotmatch $strHermeticFixturePattern -or
             $Text -cnotmatch $strAuthorizedFixturePattern -or
             ([regex]::Match(
                     $Text,
@@ -377,6 +400,13 @@ function Assert-SemanticInvariant {
                     '-ExactAuthorizedMaintenanceProductionCall',
                     [StringComparison]::Ordinal
                 )) -or
+            $Text -cnotmatch
+                'The hermetic trust-root mutation fixture was not diagnosed\.' -or
+            $Text -cnotmatch $strNoMutationFixturePattern -or
+            $Text -cnotmatch $strFixtureCleanupPattern -or
+            $Text -cmatch
+                '(?s)\$strAuthorizationFixtureBase = \[string\] \(\s+' +
+                '& git -C \$strRepositoryRootPath rev-list --max-parents=0 HEAD' -or
             $Text -cnotmatch
                 'An unauthorized production maintenance call did not fail closed\.') {
             throw "$Path does not satisfy semantic invariant $Invariant."
@@ -472,7 +502,9 @@ function Assert-SemanticInvariant {
         'verifier-reads-trusted-revision-manifest' =
             'ls-tree\s+`?\s*\$TrustedRevision\s+--\s+\$AuthorizationManifestPath'
         'workflow-checkout-is-trusted-sha' =
-            'ref: \$\{\{ github\.sha \}\}'
+            '(?s)ref: \$\{\{ github\.sha \}\}.*?fetch-depth: >-\s+' +
+            "\$\{\{ github\.event_name == 'push' && github\.event\.created " +
+            '&& 1 \|\| 0 \}\}'
         'workflow-permissions-are-read-only' =
             'permissions:\s+contents: read'
         'workflow-persist-credentials-is-false' =

--- a/.github/workflows/Test-TrustRootAuthorization.ps1
+++ b/.github/workflows/Test-TrustRootAuthorization.ps1
@@ -23,7 +23,7 @@
 # .OUTPUTS
 # [System.Boolean] True only for the exact authorized candidate.
 # .NOTES
-# Version: 1.0.20260901.0
+# Version: 1.0.20260902.0
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([bool])]
@@ -580,7 +580,7 @@ function Assert-SemanticInvariant {
         'extracted-self-test-is-invoked' =
             '& \(Join-Path \$strRepositoryRootPath \$strExtractedSelfTestPath\)'
         'extracted-self-test-version-and-topology' =
-            '(?s)# Version: 1\.2\.20260831\.0.*Get-CreatedRefBoundaryContext'
+            '(?s)# Version: 1\.2\.\d{8}\.\d+.*Get-CreatedRefBoundaryContext'
         'metadata-history-validates-parent-edges' =
             'function Get-GovernedMetadataHistoryFailure'
         'new-ref-boundary-cap-is-64' =

--- a/.github/workflows/Test-TrustRootAuthorization.ps1
+++ b/.github/workflows/Test-TrustRootAuthorization.ps1
@@ -1,0 +1,706 @@
+# .SYNOPSIS
+# Validates one exact trust-root maintenance candidate as inert Git data.
+# .DESCRIPTION
+# Reads the authorization manifest only from the authenticated trusted revision.
+# Candidate blobs are decoded and parsed, but never sourced, imported, invoked,
+# built, installed, or executed.
+# .PARAMETER RepositoryRootPath
+# The trusted repository worktree.
+# .PARAMETER TrustedRevision
+# The exact checked-out default-branch commit that owns the verifier and manifest.
+# .PARAMETER BaseRevision
+# The exact authorized candidate base commit.
+# .PARAMETER HeadRevision
+# The exact authorized candidate head commit.
+# .PARAMETER AuthorizationManifestPath
+# The fixed trusted-revision authorization path.
+# .EXAMPLE
+# ./Test-TrustRootAuthorization.ps1 @hashtableArguments
+#
+# # Validates an exact candidate and writes one Boolean result.
+# .INPUTS
+# None. This script does not accept pipeline input.
+# .OUTPUTS
+# [System.Boolean] True only for the exact authorized candidate.
+# .NOTES
+# Version: 1.0.20260901.0
+
+[CmdletBinding(PositionalBinding = $false)]
+[OutputType([bool])]
+param(
+    [Parameter(Mandatory)][string] $RepositoryRootPath,
+    [Parameter(Mandatory)][string] $TrustedRevision,
+    [Parameter(Mandatory)][string] $BaseRevision,
+    [Parameter(Mandatory)][string] $HeadRevision,
+    [Parameter()][switch] $AuthorizationApplicabilityOnly,
+    [Parameter()][string] $AuthorizationManifestPath =
+        '.github/workflows/trust-root-authorization.json'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$intManifestMaximumBytes = 65536
+$intCandidateMaximumPaths = 16
+$intCandidateMaximumBlobBytes = 573440
+$strObjectIdPattern = '^[0-9a-f]{40}$'
+$strAuthorizationPath = '.github/workflows/trust-root-authorization.json'
+$strVerifierPath = '.github/workflows/Test-TrustRootAuthorization.ps1'
+$arrTrustRootPaths = @(
+    '.gitattributes',
+    '.github/.gitattributes',
+    '.github/workflows/.gitattributes',
+    '.github/workflows/Test-TrustRootAuthorization.ps1',
+    '.github/workflows/Test-AgentInstructions.SelfTest.ps1',
+    '.github/workflows/Test-AgentInstructions.ps1',
+    '.github/workflows/Test-AgentInstructionParserManifest.mjs',
+    '.github/workflows/trust-root-authorization.json',
+    '.github/workflows/agent-instructions.yml'
+)
+
+function Invoke-BoundedProcessByte {
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][string] $FileName,
+        [Parameter(Mandatory)][string[]] $ArgumentList,
+        [Parameter(Mandatory)][ValidateRange(1, 2147483646)][int] $MaximumBytes,
+        [Parameter()][ValidateRange(100, 60000)][int] $TimeoutMilliseconds = 10000
+    )
+
+    $objStartInfo = [Diagnostics.ProcessStartInfo]::new($FileName)
+    $objStartInfo.UseShellExecute = $false
+    $objStartInfo.CreateNoWindow = $true
+    $objStartInfo.RedirectStandardOutput = $true
+    $objStartInfo.RedirectStandardError = $true
+    foreach ($strArgument in $ArgumentList) {
+        $objStartInfo.ArgumentList.Add($strArgument)
+    }
+    $objProcess = [Diagnostics.Process]::new()
+    $objProcess.StartInfo = $objStartInfo
+    if (-not $objProcess.Start()) {
+        throw "Could not start $FileName."
+    }
+    $objMemory = [IO.MemoryStream]::new()
+    $arrBuffer = [byte[]]::new(8192)
+    $objStopwatch = [Diagnostics.Stopwatch]::StartNew()
+    $objErrorTask = $objProcess.StandardError.ReadToEndAsync()
+    while ($true) {
+        $intRemainingMilliseconds =
+            $TimeoutMilliseconds - [int] $objStopwatch.ElapsedMilliseconds
+        if ($intRemainingMilliseconds -le 0) {
+            $objProcess.Kill($true)
+            throw "$FileName exceeded its time limit."
+        }
+        $objReadTask = $objProcess.StandardOutput.BaseStream.ReadAsync(
+            $arrBuffer,
+            0,
+            $arrBuffer.Length
+        )
+        $objCompletedTask = [Threading.Tasks.Task]::WhenAny(
+            $objReadTask,
+            [Threading.Tasks.Task]::Delay($intRemainingMilliseconds)
+        ).GetAwaiter().GetResult()
+        if (-not [object]::ReferenceEquals($objCompletedTask, $objReadTask)) {
+            $objProcess.Kill($true)
+            throw "$FileName exceeded its time limit."
+        }
+        $intRead = $objReadTask.GetAwaiter().GetResult()
+        if ($intRead -eq 0) {
+            break
+        }
+        if ($objMemory.Length + $intRead -gt $MaximumBytes) {
+            $objProcess.Kill($true)
+            throw "$FileName output exceeded $MaximumBytes bytes."
+        }
+        $objMemory.Write($arrBuffer, 0, $intRead)
+    }
+    $intRemainingMilliseconds =
+        $TimeoutMilliseconds - [int] $objStopwatch.ElapsedMilliseconds
+    if ($intRemainingMilliseconds -le 0 -or
+        -not $objProcess.WaitForExit($intRemainingMilliseconds)) {
+        $objProcess.Kill($true)
+        throw "$FileName exceeded its time limit."
+    }
+    $strError = $objErrorTask.GetAwaiter().GetResult()
+    $arrBytes = $objMemory.ToArray()
+    if ([Text.Encoding]::UTF8.GetByteCount($strError) -gt 65536) {
+        throw "$FileName error output exceeded 65536 bytes."
+    }
+    return [pscustomobject]@{
+        ExitCode = $objProcess.ExitCode
+        Bytes = $arrBytes
+        Error = $strError
+    }
+}
+
+function ConvertFrom-StrictUtf8Text {
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][byte[]] $Bytes,
+        [Parameter(Mandatory)][string] $Name,
+        [Parameter()][switch] $AllowNul
+    )
+
+    if ($Bytes.Length -ge 3 -and $Bytes[0] -eq 0xEF -and
+        $Bytes[1] -eq 0xBB -and $Bytes[2] -eq 0xBF) {
+        throw "$Name must not contain a UTF-8 byte-order mark."
+    }
+    foreach ($byteValue in $Bytes) {
+        if (($byteValue -lt 0x20 -and
+                $byteValue -notin @(0x09, 0x0A) -and
+                -not ($AllowNul -and $byteValue -eq 0x00)) -or
+            $byteValue -eq 0x7F -or $byteValue -eq 0x0D) {
+            throw "$Name contains a prohibited control byte or non-LF newline."
+        }
+    }
+    try {
+        return [Text.UTF8Encoding]::new($false, $true).GetString($Bytes)
+    }
+    catch {
+        throw "$Name is not strict UTF-8."
+    }
+}
+
+function Read-GitBlobByte {
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([byte])]
+    param(
+        [Parameter(Mandatory)][string] $RepositoryRootPath,
+        [Parameter(Mandatory)][string] $BlobId,
+        [Parameter(Mandatory)][int] $MaximumBytes
+    )
+
+    $objSizeResult = Invoke-BoundedProcessByte -FileName 'git' `
+        -ArgumentList @('-C', $RepositoryRootPath, 'cat-file', '-s', $BlobId) `
+        -MaximumBytes 32
+    $strSize = [Text.Encoding]::ASCII.GetString($objSizeResult.Bytes).Trim()
+    $intSize = 0
+    if ($objSizeResult.ExitCode -ne 0 -or
+        -not [int]::TryParse($strSize, [ref] $intSize) -or
+        $intSize -gt $MaximumBytes) {
+        throw "Authorized blob $BlobId exceeds its byte limit."
+    }
+    $objResult = Invoke-BoundedProcessByte -FileName 'git' `
+        -ArgumentList @('-C', $RepositoryRootPath, 'cat-file', 'blob', $BlobId) `
+        -MaximumBytes $intSize
+    if ($objResult.ExitCode -ne 0) {
+        throw "Could not read authorized blob $BlobId."
+    }
+    return [byte[]] $objResult.Bytes
+}
+
+function Assert-NoDuplicateJsonProperty {
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([void])]
+    param([Parameter(Mandatory)][System.Text.Json.JsonElement] $Element)
+
+    if ($Element.ValueKind -eq [System.Text.Json.JsonValueKind]::Object) {
+        $setNames = [Collections.Generic.HashSet[string]]::new(
+            [StringComparer]::Ordinal
+        )
+        foreach ($objProperty in $Element.EnumerateObject()) {
+            if (-not $setNames.Add($objProperty.Name)) {
+                throw "Authorization JSON contains duplicate property $($objProperty.Name)."
+            }
+            Assert-NoDuplicateJsonProperty -Element $objProperty.Value
+        }
+    }
+    elseif ($Element.ValueKind -eq [System.Text.Json.JsonValueKind]::Array) {
+        foreach ($objItem in $Element.EnumerateArray()) {
+            Assert-NoDuplicateJsonProperty -Element $objItem
+        }
+    }
+}
+
+function Assert-ExactPropertySet {
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory)][object] $InputObject,
+        [Parameter(Mandatory)][string[]] $PropertyName,
+        [Parameter(Mandatory)][string] $Name
+    )
+
+    $arrActual = @($InputObject.PSObject.Properties.Name | Sort-Object)
+    $arrExpected = @($PropertyName | Sort-Object)
+    if ($arrActual.Count -ne $arrExpected.Count -or
+        [string]::Join("`n", $arrActual) -cne
+            [string]::Join("`n", $arrExpected)) {
+        throw "$Name has an unexpected property set."
+    }
+}
+
+function Assert-CandidateSyntax {
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory)][string] $Syntax,
+        [Parameter(Mandatory)][string] $Text,
+        [Parameter(Mandatory)][string] $Path
+    )
+
+    if ($Syntax -ceq 'powershell') {
+        $objTokens = $null
+        $arrErrors = $null
+        [void] [Management.Automation.Language.Parser]::ParseInput(
+            $Text,
+            $Path,
+            [ref] $objTokens,
+            [ref] $arrErrors
+        )
+        if ($arrErrors.Count -gt 0) {
+            throw "$Path has invalid PowerShell syntax."
+        }
+        return
+    }
+    if ($Syntax -ceq 'yaml') {
+        $strNodeSource = @'
+const yaml = require('js-yaml');
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', () => {
+  yaml.load(input, { schema: yaml.FAILSAFE_SCHEMA, json: false });
+});
+'@
+        $objStartInfo = [Diagnostics.ProcessStartInfo]::new('node')
+        $objStartInfo.UseShellExecute = $false
+        $objStartInfo.CreateNoWindow = $true
+        $objStartInfo.RedirectStandardInput = $true
+        $objStartInfo.RedirectStandardOutput = $true
+        $objStartInfo.RedirectStandardError = $true
+        $objStartInfo.ArgumentList.Add('-e')
+        $objStartInfo.ArgumentList.Add($strNodeSource)
+        $objProcess = [Diagnostics.Process]::new()
+        $objProcess.StartInfo = $objStartInfo
+        if (-not $objProcess.Start()) {
+            throw 'Could not start the trusted YAML parser.'
+        }
+        $objOutputTask = $objProcess.StandardOutput.ReadToEndAsync()
+        $objErrorTask = $objProcess.StandardError.ReadToEndAsync()
+        $objProcess.StandardInput.Write($Text)
+        $objProcess.StandardInput.Close()
+        if (-not $objProcess.WaitForExit(10000)) {
+            $objProcess.Kill($true)
+            throw 'The trusted YAML parser exceeded its time limit.'
+        }
+        $strOutput = $objOutputTask.GetAwaiter().GetResult()
+        $strError = $objErrorTask.GetAwaiter().GetResult()
+        if ([Text.Encoding]::UTF8.GetByteCount($strOutput + $strError) -gt 65536) {
+            throw 'The trusted YAML parser output exceeded 65536 bytes.'
+        }
+        if ($objProcess.ExitCode -ne 0) {
+            throw "$Path has invalid YAML syntax."
+        }
+        return
+    }
+    if ($Syntax -cne 'markdown') {
+        throw "$Path declares an unsupported syntax class."
+    }
+}
+
+function Assert-SemanticInvariant {
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory)][string] $Invariant,
+        [Parameter(Mandatory)][string] $Text,
+        [Parameter(Mandatory)][string] $Path
+    )
+
+    if ($Invariant -ceq 'exact-maintenance-production-call-is-gated') {
+        $arrTokens = $null
+        $arrParseErrors = $null
+        $objAst = [Management.Automation.Language.Parser]::ParseInput(
+            $Text,
+            [ref] $arrTokens,
+            [ref] $arrParseErrors
+        )
+        $arrCalls = @($objAst.FindAll({
+                    param($objNode)
+                    $objNode -is [Management.Automation.Language.CommandAst] -and
+                    $objNode.GetCommandName() -ceq
+                        'Get-TrustRootRangeMutationFailure'
+                }, $true))
+        $intProductionSwitchCalls = 0
+        $intSelfTestSwitchCalls = 0
+        foreach ($objCall in $arrCalls) {
+            $boolHasPrivateSwitch = @($objCall.CommandElements |
+                    Where-Object {
+                        $_ -is [Management.Automation.Language.CommandParameterAst] -and
+                        $_.ParameterName -ceq
+                            'ExactAuthorizedMaintenanceProductionCall'
+                    }).Count -eq 1
+            if (-not $boolHasPrivateSwitch) {
+                continue
+            }
+            $boolHasSelfTestAncestor = $false
+            $objParent = $objCall.Parent
+            while ($null -ne $objParent) {
+                if ($objParent -is
+                    [Management.Automation.Language.IfStatementAst] -and
+                    $objParent.Extent.Text -cmatch '^if \(\$SelfTest\)') {
+                    $boolHasSelfTestAncestor = $true
+                    break
+                }
+                $objParent = $objParent.Parent
+            }
+            if ($boolHasSelfTestAncestor) {
+                $intSelfTestSwitchCalls++
+            }
+            else {
+                $intProductionSwitchCalls++
+            }
+        }
+        $strAuthorizedFixturePattern =
+            '(?s)\$arrAuthorizedFixtureFailures = @\(\s+' +
+            'Get-TrustRootRangeMutationFailure\s+`.*?' +
+            '-RepositoryRelativePath \$script:arrTrustRootPaths\s+\)'
+        if ($arrParseErrors.Count -ne 0 -or
+            $Text -cnotmatch
+                '(?s)if \(\$ExactAuthorizedMaintenanceProductionCall -and\s+' +
+                '-not \$script:boolTrustedMaintenanceAuthorizationValidated\) ' +
+                "\{\s+throw 'The production maintenance call requires exact " +
+                "trusted authorization\.'" -or
+            $Text -cnotmatch
+                '(?s)if \(\$ExactAuthorizedMaintenanceProductionCall -and\s+' +
+                '\$script:boolTrustedMaintenanceAuthorizationValidated\) ' +
+                '\{\s+return' -or
+            $intProductionSwitchCalls -ne 1 -or
+            $intSelfTestSwitchCalls -ne 2 -or
+            $Text -cnotmatch $strAuthorizedFixturePattern -or
+            ([regex]::Match(
+                    $Text,
+                    $strAuthorizedFixturePattern
+                ).Value.Contains(
+                    '-ExactAuthorizedMaintenanceProductionCall',
+                    [StringComparison]::Ordinal
+                )) -or
+            $Text -cnotmatch
+                'An unauthorized production maintenance call did not fail closed\.') {
+            throw "$Path does not satisfy semantic invariant $Invariant."
+        }
+        return
+    }
+
+    if ($Invariant -ceq 'legacy-transition-marker-is-inert-data') {
+        $arrTokens = $null
+        $arrParseErrors = $null
+        $objAst = [Management.Automation.Language.Parser]::ParseInput(
+            $Text,
+            [ref] $arrTokens,
+            [ref] $arrParseErrors
+        )
+        $arrScopedName = @(
+            'script:strLegacyMetadataRangeCompatibilityMarker',
+            'script:strLegacyStyleGuideRationaleCompatibilityMarker',
+            'script:strLegacyOperationalLintGuideCompatibilityMarker'
+        )
+        $arrUnqualifiedName = @(
+            'strLegacyMetadataRangeCompatibilityMarker',
+            'strLegacyStyleGuideRationaleCompatibilityMarker',
+            'strLegacyOperationalLintGuideCompatibilityMarker'
+        )
+        $arrAssignments = @($objAst.FindAll({
+                    param($objNode)
+                    $objNode -is
+                        [Management.Automation.Language.AssignmentStatementAst] -and
+                    $objNode.Left -is
+                        [Management.Automation.Language.VariableExpressionAst]
+                }, $true))
+        $arrScopedAssignments = @($arrAssignments | Where-Object {
+                $arrScopedName -ccontains $_.Left.VariablePath.UserPath
+            })
+        $arrUnqualifiedAssignments = @($arrAssignments | Where-Object {
+                $arrUnqualifiedName -ccontains $_.Left.VariablePath.UserPath
+            })
+        $strExactBlockPattern =
+            '(?m)^# Trusted-bootstrap compatibility data; do not use as active policy\.$' +
+            '\n\$script:strLegacyMetadataRangeCompatibilityMarker =\n' +
+            "    'metadata-range-transition-policy-v1'\n" +
+            '\$script:strLegacyStyleGuideRationaleCompatibilityMarker =\n' +
+            "    'style-guide-rationale-metadata-policy-v1'\n" +
+            '\$script:strLegacyOperationalLintGuideCompatibilityMarker =\n' +
+            "    'operational-lint-guide-metadata-policy-v1'$"
+        $boolExactOccurrenceInventory = $true
+        foreach ($strScopedName in $arrScopedName) {
+            if ([regex]::Matches(
+                    $Text,
+                    [regex]::Escape([char] 36 + $strScopedName)
+                ).Count -ne 2) {
+                $boolExactOccurrenceInventory = $false
+            }
+        }
+        if ($arrParseErrors.Count -ne 0 -or
+            $arrScopedAssignments.Count -ne 3 -or
+            @($arrScopedAssignments.Left.VariablePath.UserPath |
+                    Sort-Object -Unique).Count -ne 3 -or
+            $arrUnqualifiedAssignments.Count -ne 0 -or
+            -not $boolExactOccurrenceInventory -or
+            $Text -cnotmatch $strExactBlockPattern -or
+            $Text.Contains(
+                'PSUseDeclaredVarsMoreThanAssignments',
+                [StringComparison]::Ordinal
+            )) {
+            throw "$Path does not satisfy semantic invariant $Invariant."
+        }
+        return
+    }
+
+    $hashtablePatterns = @{
+        'docs-status-lifecycle-values' =
+            'Draft \| Proposed \| Active \| Accepted \| Superseded \| Deprecated'
+        'docs-owner-enforcer-relationship' =
+            '(?m)^- `\.github/instructions/docs\.instructions\.md` owns these ' +
+            'documentation rules\.$\n^- `\.github/workflows/' +
+            'Test-AgentInstructions\.ps1` is a non-owner enforcement mechanism\. ' +
+            'It checks the named owner at the exact input revision and rejects ' +
+            'stale repository-specific documentation claims\.$'
+        'extracted-self-test-is-invoked' =
+            '& \(Join-Path \$strRepositoryRootPath \$strExtractedSelfTestPath\)'
+        'extracted-self-test-version-and-topology' =
+            '(?s)# Version: 1\.2\.20260831\.0.*Get-CreatedRefBoundaryContext'
+        'metadata-history-validates-parent-edges' =
+            'function Get-GovernedMetadataHistoryFailure'
+        'new-ref-boundary-cap-is-64' =
+            '\$intMetadataMaximumBoundaries = 64'
+        'pr-merge-bases-use-all-and-cap' =
+            'merge-base --all'
+        'trusted-maintenance-switch-is-explicit' =
+            '\$TrustedMaintenanceAuthorizationValidated'
+        'verifier-reads-trusted-revision-manifest' =
+            'ls-tree\s+`?\s*\$TrustedRevision\s+--\s+\$AuthorizationManifestPath'
+        'workflow-checkout-is-trusted-sha' =
+            'ref: \$\{\{ github\.sha \}\}'
+        'workflow-permissions-are-read-only' =
+            'permissions:\s+contents: read'
+        'workflow-persist-credentials-is-false' =
+            'persist-credentials: false'
+        'workflow-uses-trusted-authorization-output' =
+            'TrustedMaintenanceAuthorizationValidated'
+    }
+    if (-not $hashtablePatterns.ContainsKey($Invariant) -or
+        $Text -cnotmatch $hashtablePatterns[$Invariant]) {
+        throw "$Path does not satisfy semantic invariant $Invariant."
+    }
+}
+
+if ($AuthorizationManifestPath -cne $strAuthorizationPath) {
+    throw 'The authorization manifest path is not the fixed trusted path.'
+}
+foreach ($strRevision in @($TrustedRevision, $BaseRevision, $HeadRevision)) {
+    if ($strRevision -cnotmatch $strObjectIdPattern) {
+        throw "Authorization received an invalid commit ID: $strRevision"
+    }
+    & git -C $RepositoryRootPath cat-file -e "$strRevision`^{commit}" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Authorization commit is unavailable: $strRevision"
+    }
+}
+$strCheckedOutRevision = [string] (& git -C $RepositoryRootPath `
+        rev-parse --verify 'HEAD^{commit}')
+if ($LASTEXITCODE -ne 0 -or $strCheckedOutRevision.Trim() -cne $TrustedRevision) {
+    throw 'The checked-out trusted revision does not match the authenticated revision.'
+}
+if ($AuthorizationApplicabilityOnly) {
+    $arrMergeBases = @(
+        & git -C $RepositoryRootPath merge-base --all `
+            $BaseRevision $HeadRevision 2>$null |
+            ForEach-Object { ([string] $_).Trim() }
+    )
+    if ($LASTEXITCODE -ne 0 -or $arrMergeBases.Count -lt 1 -or
+        $arrMergeBases.Count -gt 64 -or
+        @($arrMergeBases | Where-Object {
+                $_ -cnotmatch $strObjectIdPattern
+            }).Count -gt 0) {
+        throw 'The authorization applicability merge-base set is indeterminate.'
+    }
+    $boolTrustRootChanged = $false
+    foreach ($strMergeBase in $arrMergeBases) {
+        & git -C $RepositoryRootPath diff --quiet --no-ext-diff --no-textconv `
+            $strMergeBase $HeadRevision -- @arrTrustRootPaths
+        if ($LASTEXITCODE -eq 1) {
+            $boolTrustRootChanged = $true
+        }
+        elseif ($LASTEXITCODE -ne 0) {
+            throw 'Could not inspect trust-root maintenance applicability.'
+        }
+    }
+    Write-Output $boolTrustRootChanged
+    return
+}
+$strManifestEntry = [string] (& git -C $RepositoryRootPath ls-tree `
+        $TrustedRevision -- $AuthorizationManifestPath)
+if ($LASTEXITCODE -ne 0 -or
+    $strManifestEntry -cnotmatch '^100644 blob ([0-9a-f]{40})\t') {
+    throw 'The trusted revision authorization manifest is not one regular blob.'
+}
+$strManifestBlob = $Matches[1]
+$arrManifestBytes = @(Read-GitBlobByte -RepositoryRootPath $RepositoryRootPath `
+        -BlobId $strManifestBlob -MaximumBytes $intManifestMaximumBytes)
+$strManifestText = ConvertFrom-StrictUtf8Text -Bytes $arrManifestBytes `
+    -Name 'The trusted authorization manifest'
+try {
+    $objJsonDocument = [System.Text.Json.JsonDocument]::Parse($strManifestText)
+    Assert-NoDuplicateJsonProperty -Element $objJsonDocument.RootElement
+    $objManifest = ConvertFrom-Json -InputObject $strManifestText
+}
+catch {
+    throw 'The trusted authorization manifest is malformed JSON.'
+}
+Assert-ExactPropertySet -InputObject $objManifest -Name 'The authorization manifest' `
+    -PropertyName @(
+        'schema_version', 'authorization_id', 'candidate', 'limits',
+        'allowed_paths'
+    )
+if ($objManifest.schema_version -ne 1 -or
+    [string] $objManifest.authorization_id -cnotmatch
+        '^[a-z0-9][a-z0-9-]{0,127}$') {
+    throw 'The authorization manifest identity is invalid.'
+}
+Assert-ExactPropertySet -InputObject $objManifest.candidate -Name 'The candidate identity' `
+    -PropertyName @('base_commit', 'head_commit', 'head_tree', 'parent_commits')
+if ($objManifest.candidate.base_commit -cne $BaseRevision -or
+    $objManifest.candidate.head_commit -cne $HeadRevision -or
+    [string] $objManifest.candidate.head_tree -cnotmatch $strObjectIdPattern) {
+    throw 'The event commits do not match the exact authorization.'
+}
+$strHeadTree = [string] (& git -C $RepositoryRootPath rev-parse `
+        --verify "$HeadRevision`^{tree}")
+if ($LASTEXITCODE -ne 0 -or $strHeadTree.Trim() -cne $objManifest.candidate.head_tree) {
+    throw 'The candidate tree does not match the exact authorization.'
+}
+$arrActualParents = @(
+    ([string] (& git -C $RepositoryRootPath rev-list --parents -n 1 $HeadRevision)).Trim() `
+        -split '\s+' | Select-Object -Skip 1
+)
+$arrAuthorizedParents = @($objManifest.candidate.parent_commits)
+if ($arrAuthorizedParents.Count -gt 64 -or
+    @($arrAuthorizedParents | Where-Object {
+            [string] $_ -cnotmatch $strObjectIdPattern
+        }).Count -gt 0) {
+    throw 'The authorized parent commit list is invalid.'
+}
+if ([string]::Join("`n", $arrActualParents) -cne
+    [string]::Join("`n", $arrAuthorizedParents)) {
+    throw 'The candidate parent commits do not match the exact authorization.'
+}
+Assert-ExactPropertySet -InputObject $objManifest.limits -Name 'The authorization limits' `
+    -PropertyName @('maximum_paths', 'maximum_blob_bytes', 'maximum_manifest_bytes')
+if ($objManifest.limits.maximum_paths -gt $intCandidateMaximumPaths -or
+    $objManifest.limits.maximum_paths -lt 1 -or
+    $objManifest.limits.maximum_blob_bytes -gt $intCandidateMaximumBlobBytes -or
+    $objManifest.limits.maximum_blob_bytes -lt 1 -or
+    $objManifest.limits.maximum_manifest_bytes -ne $intManifestMaximumBytes) {
+    throw 'The authorization limits exceed the trusted verifier limits.'
+}
+$arrAllowedPaths = @($objManifest.allowed_paths)
+if ($arrAllowedPaths.Count -lt 1 -or
+    $arrAllowedPaths.Count -gt $objManifest.limits.maximum_paths) {
+    throw 'The authorization path count is outside its limit.'
+}
+$setAllowedPaths = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::Ordinal
+)
+foreach ($objPath in $arrAllowedPaths) {
+    Assert-ExactPropertySet -InputObject $objPath -Name 'An authorized path' `
+        -PropertyName @(
+            'path', 'mode', 'blob', 'bytes', 'sha256', 'encoding',
+            'syntax', 'semantic_invariants'
+        )
+    $strPath = [string] $objPath.path
+    if ([IO.Path]::IsPathRooted($strPath) -or
+        $strPath.Contains('\', [StringComparison]::Ordinal) -or
+        $strPath -match '(^|/)\.\.?(/|$)' -or
+        $strPath.IndexOfAny([char[]] @("`0", "`r", "`n", "`t")) -ge 0 -or
+        -not $setAllowedPaths.Add($strPath) -or
+        $strPath -ceq $AuthorizationManifestPath) {
+        throw 'The authorization contains an unsafe, duplicate, or self-authorizing path.'
+    }
+    if ($objPath.mode -cne '100644' -or
+        $objPath.blob -cnotmatch $strObjectIdPattern -or
+        $objPath.bytes -lt 0 -or
+        $objPath.bytes -gt $objManifest.limits.maximum_blob_bytes -or
+        $objPath.sha256 -cnotmatch '^[0-9a-f]{64}$' -or
+        $objPath.encoding -cne 'utf-8-no-bom-lf') {
+        throw "$strPath has an invalid authorized object contract."
+    }
+    $strTreeEntry = [string] (& git -C $RepositoryRootPath ls-tree `
+            $HeadRevision -- $strPath)
+    if ($LASTEXITCODE -ne 0 -or
+        $strTreeEntry -cnotmatch '^([0-7]{6}) blob ([0-9a-f]{40})\t(.+)$' -or
+        $Matches[1] -cne $objPath.mode -or
+        $Matches[2] -cne $objPath.blob -or
+        $Matches[3] -cne $strPath) {
+        throw "$strPath is missing, linked, deleted, or has a mismatched Git identity."
+    }
+    $arrBlobBytes = @(Read-GitBlobByte -RepositoryRootPath $RepositoryRootPath `
+            -BlobId $objPath.blob `
+            -MaximumBytes ($objManifest.limits.maximum_blob_bytes + 1))
+    if ($arrBlobBytes.Count -ne $objPath.bytes) {
+        throw "$strPath has a mismatched byte count."
+    }
+    $strSha256 = [Convert]::ToHexString(
+        [Security.Cryptography.SHA256]::HashData([byte[]] $arrBlobBytes)
+    ).ToLowerInvariant()
+    if ($strSha256 -cne $objPath.sha256) {
+        throw "$strPath has a mismatched SHA-256 value."
+    }
+    $strText = ConvertFrom-StrictUtf8Text -Bytes $arrBlobBytes -Name $strPath
+    Assert-CandidateSyntax -Syntax $objPath.syntax -Text $strText -Path $strPath
+    $arrInvariants = @($objPath.semantic_invariants)
+    if ($arrInvariants.Count -lt 1 -or
+        @($arrInvariants | Where-Object {
+                $_ -isnot [string] -or [string]::IsNullOrWhiteSpace($_)
+            }).Count -gt 0 -or
+        @($arrInvariants | Sort-Object -Unique).Count -ne $arrInvariants.Count) {
+        throw "$strPath has missing or duplicate semantic invariants."
+    }
+    foreach ($strInvariant in $arrInvariants) {
+        Assert-SemanticInvariant -Invariant $strInvariant -Text $strText -Path $strPath
+    }
+    if ($strPath -ceq $strVerifierPath) {
+        $strTrustedVerifierEntry = [string] (& git -C $RepositoryRootPath ls-tree `
+                $TrustedRevision -- $strVerifierPath)
+        if ($LASTEXITCODE -ne 0 -or
+            $strTrustedVerifierEntry -cnotmatch '^100644 blob ([0-9a-f]{40})\t' -or
+            $Matches[1] -cne $objPath.blob) {
+            throw 'The candidate verifier differs from the trusted verifier that authorizes it.'
+        }
+    }
+}
+
+$objDiff = Invoke-BoundedProcessByte -FileName 'git' -MaximumBytes 1048576 `
+    -ArgumentList @(
+        '-C', $RepositoryRootPath, 'diff', '--name-status', '-z', '--no-renames',
+        '--no-ext-diff', '--no-textconv', $BaseRevision, $HeadRevision, '--'
+    )
+if ($objDiff.ExitCode -ne 0) {
+    throw 'Could not enumerate the exact candidate path set.'
+}
+$strDiff = ConvertFrom-StrictUtf8Text -Bytes $objDiff.Bytes `
+    -Name 'The candidate path list' -AllowNul
+$arrDiffFields = @($strDiff -split "`0" | Where-Object { $_ -cne '' })
+if ($arrDiffFields.Count % 2 -ne 0) {
+    throw 'The candidate path list is malformed.'
+}
+$setChangedPaths = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::Ordinal
+)
+for ($intIndex = 0; $intIndex -lt $arrDiffFields.Count; $intIndex += 2) {
+    if ($arrDiffFields[$intIndex] -cnotin @('A', 'M') -or
+        -not $setChangedPaths.Add($arrDiffFields[$intIndex + 1])) {
+        throw 'The candidate contains a deleted, renamed, duplicate, or malformed path.'
+    }
+}
+if ($setChangedPaths.Count -ne $setAllowedPaths.Count) {
+    throw 'The candidate changed-path count does not match the authorization.'
+}
+foreach ($strChangedPath in $setChangedPaths) {
+    if (-not $setAllowedPaths.Contains($strChangedPath)) {
+        throw "The candidate contains unauthorized path $strChangedPath."
+    }
+}
+
+Write-Output $true

--- a/.github/workflows/Test-TrustRootAuthorization.ps1
+++ b/.github/workflows/Test-TrustRootAuthorization.ps1
@@ -23,7 +23,7 @@
 # .OUTPUTS
 # [System.Boolean] True only for the exact authorized candidate.
 # .NOTES
-# Version: 1.0.20260902.1
+# Version: 1.0.20260902.2
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([bool])]
@@ -577,6 +577,12 @@ function Assert-SemanticInvariant {
             '(?s)function Get-CreatedRefMetadataBaselineRevision.*?' +
             '\$strCreatedRefMetadataBaselineRevision =\s+' +
             'Get-CreatedRefMetadataBaselineRevision'
+        'created-ref-paths-use-endpoint-boundary' =
+            '(?s)function Read-GitPublishedEndpointChangedPath.*?' +
+            'elseif \(\$BaselineAbsent -and ' +
+            '\$arrBoundaries\.Count -eq 1\).*?' +
+            '''diff''.*?\$arrBoundaries\[0\], \$FinalRevision.*?' +
+            'A created ref with introduced commits must have one boundary'
         'docs-status-lifecycle-values' =
             'Draft \| Proposed \| Active \| Accepted \| Superseded \| Deprecated'
         'docs-owner-enforcer-relationship' =

--- a/.github/workflows/Test-TrustRootAuthorization.ps1
+++ b/.github/workflows/Test-TrustRootAuthorization.ps1
@@ -23,7 +23,7 @@
 # .OUTPUTS
 # [System.Boolean] True only for the exact authorized candidate.
 # .NOTES
-# Version: 1.0.20260902.2
+# Version: 1.0.20260902.3
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([bool])]
@@ -535,14 +535,14 @@ function Assert-SemanticInvariant {
             'const evidence = process.env.PUSH_COMMIT_EVIDENCE;',
             'Buffer.byteLength(evidence, "utf8") > 1048576',
             'commits = JSON.parse(evidence);',
-            '!Array.isArray(commits) || commits.length > 2048',
+            '!Array.isArray(commits) || commits.length >= 2048',
             '!/^[0-9a-f]{40}$/.test(entry.id)',
             'seenCommitIds.has(entry.id)',
             'if (ids.length > 0 &&',
             'ids[ids.length - 1] !== process.env.PUSH_AFTER_SHA',
             '(ids.length > 0 ? "\n" : ""), "utf8");',
             'fetch_depth=$((push_commit_count + 1))',
-            'test "${fetch_depth}" -le 2049',
+            'test "${fetch_depth}" -le 2048',
             "destination_local_ref='refs/remotes/event/created-destination'",
             '--no-write-fetch-head --no-recurse-submodules origin',
             '"${PUSH_REF}:${destination_local_ref}"',

--- a/.github/workflows/Test-TrustRootAuthorization.ps1
+++ b/.github/workflows/Test-TrustRootAuthorization.ps1
@@ -12,6 +12,10 @@
 # The exact authorized candidate base commit.
 # .PARAMETER HeadRevision
 # The exact authorized candidate head commit.
+# .PARAMETER AuthorizationApplicabilityOnly
+# When this switch is set, the script checks only whether the authorization
+# applies to the candidate. It returns one Boolean value and does not perform
+# the full authorization validation.
 # .PARAMETER AuthorizationManifestPath
 # The fixed trusted-revision authorization path.
 # .EXAMPLE
@@ -23,7 +27,7 @@
 # .OUTPUTS
 # [System.Boolean] True only for the exact authorized candidate.
 # .NOTES
-# Version: 1.0.20260902.3
+# Version: 1.0.20260902.4
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([bool])]

--- a/.github/workflows/agent-instructions.yml
+++ b/.github/workflows/agent-instructions.yml
@@ -401,15 +401,9 @@ jobs:
           AGENT_INSTRUCTION_EVENT_HEAD_DISTINCT: >-
             ${{ github.event_name == 'push' && github.event.created &&
               toJson(github.event.head_commit.distinct) || '' }}
-          AGENT_INSTRUCTION_PUSH_COMMIT_COUNT: >-
-            ${{ github.event_name == 'push' && github.event.created &&
-              toJson(github.event.size) || '' }}
-          AGENT_INSTRUCTION_PUSH_DISTINCT_COMMIT_COUNT: >-
-            ${{ github.event_name == 'push' && github.event.created &&
-              toJson(github.event.distinct_size) || '' }}
           AGENT_INSTRUCTION_PUSH_COMMIT_EVIDENCE: >-
             ${{ github.event_name == 'push' && github.event.created &&
-              toJson(github.event.commits.*.id) || '' }}
+              toJson(github.event.commits) || '' }}
           AGENT_INSTRUCTION_OTHER_REF_EVIDENCE: >-
             ${{ steps.created-push-boundary.outputs.other_ref_evidence || '' }}
         run: >-
@@ -432,9 +426,6 @@ jobs:
           -DestinationRef $env:AGENT_INSTRUCTION_DESTINATION_REF
           -EventHeadRevision $env:AGENT_INSTRUCTION_EVENT_HEAD_REVISION
           -EventHeadDistinct $env:AGENT_INSTRUCTION_EVENT_HEAD_DISTINCT
-          -PushCommitCount $env:AGENT_INSTRUCTION_PUSH_COMMIT_COUNT
-          -PushDistinctCommitCount `
-          $env:AGENT_INSTRUCTION_PUSH_DISTINCT_COMMIT_COUNT
           -PushCommitEvidenceJson `
           $env:AGENT_INSTRUCTION_PUSH_COMMIT_EVIDENCE
           -OtherRefEvidenceJson `

--- a/.github/workflows/agent-instructions.yml
+++ b/.github/workflows/agent-instructions.yml
@@ -79,10 +79,10 @@ jobs:
           $arrDecision = @(
               & ./.github/workflows/Test-AgentInstructions.ps1 `
                   -PushApplicabilityOnly `
-                  -RangeBaseRevision $env:PUSH_BEFORE_SHA `
-                  -RangeHeadRevision $env:PUSH_AFTER_SHA `
-                  -RangeIsNewRef:([bool]::Parse($env:PUSH_CREATED)) `
-                  -RangeIsDeletedRef:([bool]::Parse($env:PUSH_DELETED)) `
+                  -PublishedBaselineRevision $env:PUSH_BEFORE_SHA `
+                  -PublishedFinalRevision $env:PUSH_AFTER_SHA `
+                  -PublishedBaselineAbsent:([bool]::Parse($env:PUSH_CREATED)) `
+                  -PublishedFinalDeleted:([bool]::Parse($env:PUSH_DELETED)) `
                   -EventName 'push'
           )
           if ($arrDecision.Count -ne 1 -or
@@ -122,9 +122,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_ACTION: ${{ github.event.action }}
-          PR_PREVIOUS_HEAD_SHA: >-
-            ${{ github.event.action == 'synchronize' && github.event.before || '' }}
         run: |
           set -euo pipefail
           [[ "${PR_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]
@@ -138,21 +135,6 @@ jobs:
           fetched_head="$(git rev-parse --verify \
             'refs/remotes/event/pr-head^{commit}')"
           test "${fetched_head}" = "${PR_HEAD_SHA}"
-          if [[ "${PR_ACTION}" = 'synchronize' ]]; then
-            [[ "${PR_PREVIOUS_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]
-            [[ ! "${PR_PREVIOUS_HEAD_SHA}" =~ ^0{40}$ ]]
-            test "${PR_PREVIOUS_HEAD_SHA}" != "${PR_HEAD_SHA}"
-            GIT_CONFIG_COUNT=1 \
-              GIT_CONFIG_KEY_0="http.${GITHUB_SERVER_URL}/.extraheader" \
-              GIT_CONFIG_VALUE_0="Authorization: Basic ${authorization}" \
-              git fetch --no-tags --no-recurse-submodules origin \
-                "${PR_PREVIOUS_HEAD_SHA}:refs/remotes/event/pr-previous-head"
-            fetched_previous_head="$(git rev-parse --verify \
-              'refs/remotes/event/pr-previous-head^{commit}')"
-            test "${fetched_previous_head}" = "${PR_PREVIOUS_HEAD_SHA}"
-          else
-            test -z "${PR_PREVIOUS_HEAD_SHA}"
-          fi
           unset authorization
           git diff --quiet --no-ext-diff
           git diff --cached --quiet --no-ext-diff
@@ -192,60 +174,43 @@ jobs:
             ${{ github.event_name == 'pull_request_target' &&
               github.event.pull_request.head.sha ||
               github.event_name == 'push' && github.event.after || '' }}
-          AGENT_INSTRUCTION_RANGE_BASE: >-
+          AGENT_INSTRUCTION_PUBLISHED_BASELINE: >-
             ${{ github.event_name == 'pull_request_target' &&
               github.event.pull_request.base.sha ||
               github.event_name == 'push' && github.event.before || '' }}
-          AGENT_INSTRUCTION_RANGE_HEAD: >-
+          AGENT_INSTRUCTION_PUBLISHED_FINAL: >-
             ${{ github.event_name == 'pull_request_target' &&
               github.event.pull_request.head.sha ||
               github.event_name == 'push' && github.event.after || '' }}
-          AGENT_INSTRUCTION_RANGE_IS_NEW_REF: >-
+          AGENT_INSTRUCTION_PUBLISHED_BASELINE_ABSENT: >-
             ${{ github.event_name == 'push' && github.event.created || false }}
-          AGENT_INSTRUCTION_RANGE_IS_DELETED_REF: >-
+          AGENT_INSTRUCTION_PUBLISHED_FINAL_DELETED: >-
             ${{ github.event_name == 'push' && github.event.deleted || false }}
           AGENT_INSTRUCTION_TRUSTED_EVENT_TIMESTAMP: >-
             ${{ github.event_name == 'push' &&
-              github.event.repository.pushed_at || '' }}
+              github.event.repository.pushed_at ||
+              github.event_name == 'pull_request_target' &&
+              github.event.pull_request.updated_at || '' }}
           AGENT_INSTRUCTION_EVENT_NAME: >-
             ${{ (github.event_name == 'pull_request_target' ||
               github.event_name == 'push') && github.event_name || '' }}
           AGENT_INSTRUCTION_PULL_REQUEST_ACTION: >-
             ${{ github.event_name == 'pull_request_target' &&
               github.event.action || '' }}
-          AGENT_INSTRUCTION_PREVIOUS_HEAD_REVISION: >-
-            ${{ github.event_name == 'pull_request_target' &&
-              github.event.action == 'synchronize' && github.event.before || '' }}
           AGENT_INSTRUCTION_PULL_REQUEST_BASE_CHANGED: >-
             ${{ github.event_name == 'pull_request_target' &&
               github.event.action == 'edited' &&
               github.event.changes.base.ref.from != '' && 'true' || '' }}
-          AGENT_INSTRUCTION_EVENT_HEAD_REVISION: >-
-            ${{ github.event_name == 'push' &&
-              github.event.head_commit.id || '' }}
-          AGENT_INSTRUCTION_EVENT_HEAD_DISTINCT: >-
-            ${{ github.event_name == 'push' &&
-              toJSON(github.event.head_commit.distinct) || '' }}
-          AGENT_INSTRUCTION_NEW_REF_COMMIT_COUNT: >-
-            ${{ github.event_name == 'push' && github.event.created &&
-              github.event.size || '' }}
-          AGENT_INSTRUCTION_NEW_REF_COMMITS_JSON: >-
-            ${{ github.event_name == 'push' && github.event.created &&
-              toJSON(github.event.commits.*.id) || '' }}
         run: >-
           ./.github/workflows/Test-AgentInstructions.ps1 -SelfTest
           -InputRevision $env:AGENT_INSTRUCTION_INPUT_REVISION
-          -RangeBaseRevision $env:AGENT_INSTRUCTION_RANGE_BASE
-          -RangeHeadRevision $env:AGENT_INSTRUCTION_RANGE_HEAD
-          -RangeIsNewRef:([bool]::Parse($env:AGENT_INSTRUCTION_RANGE_IS_NEW_REF))
-          -RangeIsDeletedRef:([bool]::Parse(
-          $env:AGENT_INSTRUCTION_RANGE_IS_DELETED_REF))
+          -PublishedBaselineRevision $env:AGENT_INSTRUCTION_PUBLISHED_BASELINE
+          -PublishedFinalRevision $env:AGENT_INSTRUCTION_PUBLISHED_FINAL
+          -PublishedBaselineAbsent:([bool]::Parse(
+          $env:AGENT_INSTRUCTION_PUBLISHED_BASELINE_ABSENT))
+          -PublishedFinalDeleted:([bool]::Parse(
+          $env:AGENT_INSTRUCTION_PUBLISHED_FINAL_DELETED))
           -TrustedEventTimestamp $env:AGENT_INSTRUCTION_TRUSTED_EVENT_TIMESTAMP
           -EventName $env:AGENT_INSTRUCTION_EVENT_NAME
           -PullRequestAction $env:AGENT_INSTRUCTION_PULL_REQUEST_ACTION
-          -PreviousHeadRevision $env:AGENT_INSTRUCTION_PREVIOUS_HEAD_REVISION
           -PullRequestBaseChanged $env:AGENT_INSTRUCTION_PULL_REQUEST_BASE_CHANGED
-          -EventHeadRevision $env:AGENT_INSTRUCTION_EVENT_HEAD_REVISION
-          -EventHeadDistinct $env:AGENT_INSTRUCTION_EVENT_HEAD_DISTINCT
-          -NewRefCommitCount $env:AGENT_INSTRUCTION_NEW_REF_COMMIT_COUNT
-          -NewRefCommitEvidenceJson $env:AGENT_INSTRUCTION_NEW_REF_COMMITS_JSON

--- a/.github/workflows/agent-instructions.yml
+++ b/.github/workflows/agent-instructions.yml
@@ -151,6 +151,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PUSH_REF: ${{ github.ref }}
           PUSH_AFTER_SHA: ${{ github.event.after }}
+          PUSH_COMMIT_EVIDENCE: ${{ toJson(github.event.commits) }}
         run: |
           set -euo pipefail
           export LC_ALL=C
@@ -166,8 +167,57 @@ jobs:
           raw_refs_after="$(mktemp)"
           sorted_refs="$(mktemp)"
           evidence_rows="$(mktemp)"
+          push_commit_ids_file="$(mktemp)"
+          push_commit_count_file="$(mktemp)"
           trap 'rm -f "${raw_refs}" "${raw_refs_after}" \
-            "${sorted_refs}" "${evidence_rows}"' EXIT
+            "${sorted_refs}" "${evidence_rows}" \
+            "${push_commit_ids_file}" "${push_commit_count_file}"' EXIT
+          if ! node -e '
+            const fs = require("fs");
+            const evidence = process.env.PUSH_COMMIT_EVIDENCE;
+            if (typeof evidence !== "string" ||
+                Buffer.byteLength(evidence, "utf8") > 1048576) {
+              throw new Error("Push commit evidence is missing or oversized.");
+            }
+            let commits;
+            try {
+              commits = JSON.parse(evidence);
+            } catch {
+              throw new Error("Push commit evidence is malformed JSON.");
+            }
+            if (!Array.isArray(commits) || commits.length > 2048) {
+              throw new Error("Push commit evidence is not a bounded array.");
+            }
+            const seenCommitIds = new Set();
+            const ids = commits.map((entry) => {
+              if (entry === null || typeof entry !== "object" ||
+                  Array.isArray(entry) ||
+                  typeof entry.id !== "string" ||
+                  !/^[0-9a-f]{40}$/.test(entry.id) ||
+                  seenCommitIds.has(entry.id)) {
+                throw new Error("Push commit evidence has an invalid or duplicate ID.");
+              }
+              seenCommitIds.add(entry.id);
+              return entry.id;
+            });
+            if (ids.length > 0 &&
+                ids[ids.length - 1] !== process.env.PUSH_AFTER_SHA) {
+              throw new Error("Push commit evidence does not end at the event head.");
+            }
+            fs.writeFileSync(process.argv[1], ids.join("\n") +
+              (ids.length > 0 ? "\n" : ""), "utf8");
+            fs.writeFileSync(process.argv[2], `${ids.length}\n`, "utf8");
+          ' "${push_commit_ids_file}" "${push_commit_count_file}"; then
+            echo 'Push commit evidence parsing failed.' >&2
+            exit 1
+          fi
+          mapfile -t push_commit_ids <"${push_commit_ids_file}"
+          IFS= read -r push_commit_count <"${push_commit_count_file}"
+          [[ "${push_commit_count}" =~ ^[0-9]+$ ]]
+          test "${push_commit_count}" -eq "${#push_commit_ids[@]}"
+          fetch_depth=$((push_commit_count + 1))
+          test "${fetch_depth}" -ge 1
+          test "${fetch_depth}" -le 2049
           authorization="$(printf 'x-access-token:%s' "${GITHUB_TOKEN}" |
             base64 -w 0)"
           set +e
@@ -253,6 +303,24 @@ jobs:
           done
           test "${destination_count}" -eq 1
           test "${#remote_names[@]}" -le 256
+
+          destination_local_ref='refs/remotes/event/created-destination'
+          if git show-ref --verify --quiet "${destination_local_ref}"; then
+            echo 'The created destination evidence ref already exists.' >&2
+            exit 1
+          fi
+          GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0="http.${GITHUB_SERVER_URL}/.extraheader" \
+            GIT_CONFIG_VALUE_0="Authorization: Basic ${authorization}" \
+            timeout 60s git fetch --depth="${fetch_depth}" --no-tags \
+              --no-write-fetch-head --no-recurse-submodules origin \
+              "${PUSH_REF}:${destination_local_ref}"
+          fetched_destination="$(git rev-parse --verify \
+            "${destination_local_ref}^{commit}")"
+          test "${fetched_destination}" = "${PUSH_AFTER_SHA}"
+          for push_commit_id in "${push_commit_ids[@]}"; do
+            git cat-file -e "${push_commit_id}^{commit}"
+          done
 
           if test "${#fetch_arguments[@]}" -gt 0; then
             GIT_CONFIG_COUNT=1 \

--- a/.github/workflows/agent-instructions.yml
+++ b/.github/workflows/agent-instructions.yml
@@ -33,7 +33,8 @@ jobs:
           token: ${{ github.token }}
           persist-credentials: false
           clean: true
-          fetch-depth: 0
+          fetch-depth: >-
+            ${{ github.event_name == 'push' && github.event.created && 1 || 0 }}
           fetch-tags: false
           show-progress: true
           lfs: false
@@ -79,10 +80,10 @@ jobs:
           $arrDecision = @(
               & ./.github/workflows/Test-AgentInstructions.ps1 `
                   -PushApplicabilityOnly `
-                  -RangeBaseRevision $env:PUSH_BEFORE_SHA `
-                  -RangeHeadRevision $env:PUSH_AFTER_SHA `
-                  -RangeIsNewRef:([bool]::Parse($env:PUSH_CREATED)) `
-                  -RangeIsDeletedRef:([bool]::Parse($env:PUSH_DELETED)) `
+                  -PublishedBaselineRevision $env:PUSH_BEFORE_SHA `
+                  -PublishedFinalRevision $env:PUSH_AFTER_SHA `
+                  -PublishedBaselineAbsent:([bool]::Parse($env:PUSH_CREATED)) `
+                  -PublishedFinalDeleted:([bool]::Parse($env:PUSH_DELETED)) `
                   -EventName 'push'
           )
           if ($arrDecision.Count -ne 1 -or
@@ -122,9 +123,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_ACTION: ${{ github.event.action }}
-          PR_PREVIOUS_HEAD_SHA: >-
-            ${{ github.event.action == 'synchronize' && github.event.before || '' }}
         run: |
           set -euo pipefail
           [[ "${PR_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]
@@ -138,22 +136,146 @@ jobs:
           fetched_head="$(git rev-parse --verify \
             'refs/remotes/event/pr-head^{commit}')"
           test "${fetched_head}" = "${PR_HEAD_SHA}"
-          if [[ "${PR_ACTION}" = 'synchronize' ]]; then
-            [[ "${PR_PREVIOUS_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]
-            [[ ! "${PR_PREVIOUS_HEAD_SHA}" =~ ^0{40}$ ]]
-            test "${PR_PREVIOUS_HEAD_SHA}" != "${PR_HEAD_SHA}"
+          unset authorization
+          git diff --quiet --no-ext-diff
+          git diff --cached --quiet --no-ext-diff
+
+      - name: Authenticate created push boundary refs as data
+        id: created-push-boundary
+        if: >-
+          github.event_name == 'push' && github.event.created &&
+          !github.event.deleted &&
+          steps.push-applicability.outputs.required == 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PUSH_REF: ${{ github.ref }}
+          PUSH_AFTER_SHA: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+          [[ "${PUSH_REF}" =~ ^refs/heads/.+ ]]
+          [[ "${PUSH_AFTER_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          git check-ref-format "${PUSH_REF}"
+          if git show-ref --verify --quiet "${PUSH_REF}"; then
+            echo 'The created destination ref was present before discovery.' >&2
+            exit 1
+          fi
+
+          raw_refs="$(mktemp)"
+          raw_refs_after="$(mktemp)"
+          evidence_rows="$(mktemp)"
+          trap 'rm -f "${raw_refs}" "${raw_refs_after}" "${evidence_rows}"' EXIT
+          authorization="$(printf 'x-access-token:%s' "${GITHUB_TOKEN}" |
+            base64 -w 0)"
+          set +e
+          GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0="http.${GITHUB_SERVER_URL}/.extraheader" \
+            GIT_CONFIG_VALUE_0="Authorization: Basic ${authorization}" \
+            timeout 30s git ls-remote --refs --heads --tags origin |
+            head -c 1048577 >"${raw_refs}"
+          pipeline_status=("${PIPESTATUS[@]}")
+          set -e
+          test "${pipeline_status[1]}" -eq 0
+          if test "$(wc -c <"${raw_refs}")" -gt 1048576; then
+            echo 'Remote ref evidence exceeded 1048576 bytes.' >&2
+            exit 1
+          fi
+          test "${pipeline_status[0]}" -eq 0
+
+          mapfile -t remote_rows < <(sort "${raw_refs}")
+          if test "${#remote_rows[@]}" -gt 257; then
+            echo 'Remote ref evidence exceeded 256 other refs.' >&2
+            exit 1
+          fi
+          destination_count=0
+          fetch_arguments=()
+          remote_names=()
+          remote_objects=()
+          for row in "${remote_rows[@]}"; do
+            object="${row%%$'\t'*}"
+            ref="${row#*$'\t'}"
+            [[ "${object}" =~ ^[0-9a-f]{40}$ ]]
+            [[ "${ref}" =~ ^refs/(heads|tags)/.+ ]]
+            test "${object}"$'\t'"${ref}" = "${row}"
+            git check-ref-format "${ref}"
+            if test "${ref}" = "${PUSH_REF}"; then
+              destination_count=$((destination_count + 1))
+              test "${object}" = "${PUSH_AFTER_SHA}"
+              continue
+            fi
+            remote_names+=("${ref}")
+            remote_objects+=("${object}")
+            raw_index=$((${#remote_names[@]} - 1))
+            printf -v raw_local_ref \
+              'refs/remotes/event/created-enumerated-%04d' "${raw_index}"
+            if git show-ref --verify --quiet "${raw_local_ref}"; then
+              echo 'A created-ref evidence destination already exists.' >&2
+              exit 1
+            fi
+            fetch_arguments+=("${ref}:${raw_local_ref}")
+          done
+          test "${destination_count}" -eq 1
+          test "${#remote_names[@]}" -le 256
+
+          if test "${#fetch_arguments[@]}" -gt 0; then
             GIT_CONFIG_COUNT=1 \
               GIT_CONFIG_KEY_0="http.${GITHUB_SERVER_URL}/.extraheader" \
               GIT_CONFIG_VALUE_0="Authorization: Basic ${authorization}" \
-              git fetch --no-tags --no-recurse-submodules origin \
-                "${PR_PREVIOUS_HEAD_SHA}:refs/remotes/event/pr-previous-head"
-            fetched_previous_head="$(git rev-parse --verify \
-              'refs/remotes/event/pr-previous-head^{commit}')"
-            test "${fetched_previous_head}" = "${PR_PREVIOUS_HEAD_SHA}"
-          else
-            test -z "${PR_PREVIOUS_HEAD_SHA}"
+              timeout 60s git fetch --no-tags --no-write-fetch-head \
+                --no-recurse-submodules origin "${fetch_arguments[@]}"
           fi
+          set +e
+          GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0="http.${GITHUB_SERVER_URL}/.extraheader" \
+            GIT_CONFIG_VALUE_0="Authorization: Basic ${authorization}" \
+            timeout 30s git ls-remote --refs --heads --tags origin |
+            head -c 1048577 >"${raw_refs_after}"
+          pipeline_status=("${PIPESTATUS[@]}")
+          set -e
+          test "${pipeline_status[1]}" -eq 0
+          test "$(wc -c <"${raw_refs_after}")" -le 1048576
+          test "${pipeline_status[0]}" -eq 0
+          cmp --silent "${raw_refs}" "${raw_refs_after}"
           unset authorization
+
+          evidence_index=0
+          for raw_index in "${!remote_names[@]}"; do
+            printf -v raw_local_ref \
+              'refs/remotes/event/created-enumerated-%04d' "${raw_index}"
+            resolved_object="$(git rev-parse --verify \
+              "${raw_local_ref}^{object}")"
+            test "${resolved_object}" = "${remote_objects[raw_index]}"
+            if ! resolved_commit="$(git rev-parse --verify \
+              "${raw_local_ref}^{commit}" 2>/dev/null)"; then
+              continue
+            fi
+            printf -v evidence_local_ref \
+              'refs/remotes/event/created-other-%04d' "${evidence_index}"
+            if git show-ref --verify --quiet "${evidence_local_ref}"; then
+              echo 'A normalized created-ref evidence destination exists.' >&2
+              exit 1
+            fi
+            git update-ref "${evidence_local_ref}" "${resolved_object}" ''
+            printf '%s\t%s\t%s\t%s\n' \
+              "${remote_names[raw_index]}" "${resolved_object}" \
+              "${resolved_commit}" "${evidence_local_ref}" >>"${evidence_rows}"
+            evidence_index=$((evidence_index + 1))
+          done
+          test "${evidence_index}" -le 256
+
+          other_ref_evidence="$(node -e '
+            const fs = require("fs");
+            const rows = fs.readFileSync(process.argv[1], "utf8")
+              .split("\n").filter(Boolean).map((row) => {
+                const [ref, object, commit, local_ref] = row.split("\t");
+                if (!ref || !object || !commit || !local_ref) throw Error();
+                return { ref, object, commit, local_ref };
+              });
+            process.stdout.write(JSON.stringify(rows));
+          ' "${evidence_rows}")"
+          test "$(printf '%s' "${other_ref_evidence}" | wc -c)" -le 131072
+          printf 'other_ref_evidence=%s\n' "${other_ref_evidence}" >>"${GITHUB_OUTPUT}"
           git diff --quiet --no-ext-diff
           git diff --cached --quiet --no-ext-diff
 
@@ -182,70 +304,138 @@ jobs:
           npm ci --ignore-scripts --no-audit --fund=false
           --include=dev --package-lock=true
 
+      - name: Validate exact trust-root maintenance as inert data
+        id: trust-root-authorization
+        if: github.event_name == 'pull_request_target'
+        shell: pwsh
+        env:
+          TRUSTED_REVISION: ${{ github.sha }}
+          CANDIDATE_BASE_REVISION: ${{ github.event.pull_request.base.sha }}
+          CANDIDATE_HEAD_REVISION: ${{ github.event.pull_request.head.sha }}
+        run: |
+          $arrApplicability = @(
+              & ./.github/workflows/Test-TrustRootAuthorization.ps1 `
+                  -RepositoryRootPath $PWD `
+                  -TrustedRevision $env:TRUSTED_REVISION `
+                  -BaseRevision $env:CANDIDATE_BASE_REVISION `
+                  -HeadRevision $env:CANDIDATE_HEAD_REVISION `
+                  -AuthorizationApplicabilityOnly
+          )
+          if ($arrApplicability.Count -ne 1 -or
+              $arrApplicability[0] -isnot [bool]) {
+              throw 'Trust-root applicability did not return one exact Boolean.'
+          }
+          $boolAuthorized = $false
+          if ($arrApplicability[0]) {
+              $arrAuthorization = @(
+                  & ./.github/workflows/Test-TrustRootAuthorization.ps1 `
+                      -RepositoryRootPath $PWD `
+                      -TrustedRevision $env:TRUSTED_REVISION `
+                      -BaseRevision $env:CANDIDATE_BASE_REVISION `
+                      -HeadRevision $env:CANDIDATE_HEAD_REVISION
+              )
+              if ($arrAuthorization.Count -ne 1 -or
+                  $arrAuthorization[0] -isnot [bool] -or
+                  -not $arrAuthorization[0]) {
+                  throw 'Trust-root authorization did not return one exact true result.'
+              }
+              $boolAuthorized = $true
+          }
+          [System.IO.File]::AppendAllText(
+              $env:GITHUB_OUTPUT,
+              "authorized=$($boolAuthorized.ToString().ToLowerInvariant())`n",
+              [System.Text.UTF8Encoding]::new($false)
+          )
+
       - name: Validate instruction capacity and capabilities
         if: >-
           github.event_name != 'push' ||
           steps.push-applicability.outputs.required == 'true'
         shell: pwsh
         env:
+          AGENT_INSTRUCTION_AUTHORIZATION_BASE: >-
+            ${{ github.event_name == 'pull_request_target' &&
+              github.event.pull_request.base.sha || '' }}
+          AGENT_INSTRUCTION_AUTHORIZATION_HEAD: >-
+            ${{ github.event_name == 'pull_request_target' &&
+              github.event.pull_request.head.sha || '' }}
+          AGENT_INSTRUCTION_TRUST_MAINTENANCE_AUTHORIZED: >-
+            ${{ steps.trust-root-authorization.outputs.authorized || 'false' }}
           AGENT_INSTRUCTION_INPUT_REVISION: >-
             ${{ github.event_name == 'pull_request_target' &&
               github.event.pull_request.head.sha ||
               github.event_name == 'push' && github.event.after || '' }}
-          AGENT_INSTRUCTION_RANGE_BASE: >-
+          AGENT_INSTRUCTION_PUBLISHED_BASELINE: >-
             ${{ github.event_name == 'pull_request_target' &&
               github.event.pull_request.base.sha ||
               github.event_name == 'push' && github.event.before || '' }}
-          AGENT_INSTRUCTION_RANGE_HEAD: >-
+          AGENT_INSTRUCTION_PUBLISHED_FINAL: >-
             ${{ github.event_name == 'pull_request_target' &&
               github.event.pull_request.head.sha ||
               github.event_name == 'push' && github.event.after || '' }}
-          AGENT_INSTRUCTION_RANGE_IS_NEW_REF: >-
+          AGENT_INSTRUCTION_PUBLISHED_BASELINE_ABSENT: >-
             ${{ github.event_name == 'push' && github.event.created || false }}
-          AGENT_INSTRUCTION_RANGE_IS_DELETED_REF: >-
+          AGENT_INSTRUCTION_PUBLISHED_FINAL_DELETED: >-
             ${{ github.event_name == 'push' && github.event.deleted || false }}
           AGENT_INSTRUCTION_TRUSTED_EVENT_TIMESTAMP: >-
             ${{ github.event_name == 'push' &&
-              github.event.repository.pushed_at || '' }}
+              github.event.repository.pushed_at ||
+              github.event_name == 'pull_request_target' &&
+              github.event.pull_request.updated_at || '' }}
           AGENT_INSTRUCTION_EVENT_NAME: >-
             ${{ (github.event_name == 'pull_request_target' ||
               github.event_name == 'push') && github.event_name || '' }}
           AGENT_INSTRUCTION_PULL_REQUEST_ACTION: >-
             ${{ github.event_name == 'pull_request_target' &&
               github.event.action || '' }}
-          AGENT_INSTRUCTION_PREVIOUS_HEAD_REVISION: >-
-            ${{ github.event_name == 'pull_request_target' &&
-              github.event.action == 'synchronize' && github.event.before || '' }}
           AGENT_INSTRUCTION_PULL_REQUEST_BASE_CHANGED: >-
             ${{ github.event_name == 'pull_request_target' &&
               github.event.action == 'edited' &&
               github.event.changes.base.ref.from != '' && 'true' || '' }}
+          AGENT_INSTRUCTION_DESTINATION_REF: >-
+            ${{ github.event_name == 'push' && github.event.created &&
+              github.ref || '' }}
           AGENT_INSTRUCTION_EVENT_HEAD_REVISION: >-
-            ${{ github.event_name == 'push' &&
+            ${{ github.event_name == 'push' && github.event.created &&
               github.event.head_commit.id || '' }}
           AGENT_INSTRUCTION_EVENT_HEAD_DISTINCT: >-
-            ${{ github.event_name == 'push' &&
-              toJSON(github.event.head_commit.distinct) || '' }}
-          AGENT_INSTRUCTION_NEW_REF_COMMIT_COUNT: >-
             ${{ github.event_name == 'push' && github.event.created &&
-              github.event.size || '' }}
-          AGENT_INSTRUCTION_NEW_REF_COMMITS_JSON: >-
+              toJson(github.event.head_commit.distinct) || '' }}
+          AGENT_INSTRUCTION_PUSH_COMMIT_COUNT: >-
             ${{ github.event_name == 'push' && github.event.created &&
-              toJSON(github.event.commits.*.id) || '' }}
+              toJson(github.event.size) || '' }}
+          AGENT_INSTRUCTION_PUSH_DISTINCT_COMMIT_COUNT: >-
+            ${{ github.event_name == 'push' && github.event.created &&
+              toJson(github.event.distinct_size) || '' }}
+          AGENT_INSTRUCTION_PUSH_COMMIT_EVIDENCE: >-
+            ${{ github.event_name == 'push' && github.event.created &&
+              toJson(github.event.commits.*.id) || '' }}
+          AGENT_INSTRUCTION_OTHER_REF_EVIDENCE: >-
+            ${{ steps.created-push-boundary.outputs.other_ref_evidence || '' }}
         run: >-
           ./.github/workflows/Test-AgentInstructions.ps1 -SelfTest
+          -AuthorizationBaseRevision $env:AGENT_INSTRUCTION_AUTHORIZATION_BASE
+          -AuthorizationHeadRevision $env:AGENT_INSTRUCTION_AUTHORIZATION_HEAD
+          -TrustedMaintenanceAuthorizationValidated:([bool]::Parse(
+          $env:AGENT_INSTRUCTION_TRUST_MAINTENANCE_AUTHORIZED))
           -InputRevision $env:AGENT_INSTRUCTION_INPUT_REVISION
-          -RangeBaseRevision $env:AGENT_INSTRUCTION_RANGE_BASE
-          -RangeHeadRevision $env:AGENT_INSTRUCTION_RANGE_HEAD
-          -RangeIsNewRef:([bool]::Parse($env:AGENT_INSTRUCTION_RANGE_IS_NEW_REF))
-          -RangeIsDeletedRef:([bool]::Parse(
-          $env:AGENT_INSTRUCTION_RANGE_IS_DELETED_REF))
+          -PublishedBaselineRevision $env:AGENT_INSTRUCTION_PUBLISHED_BASELINE
+          -PublishedFinalRevision $env:AGENT_INSTRUCTION_PUBLISHED_FINAL
+          -PublishedBaselineAbsent:([bool]::Parse(
+          $env:AGENT_INSTRUCTION_PUBLISHED_BASELINE_ABSENT))
+          -PublishedFinalDeleted:([bool]::Parse(
+          $env:AGENT_INSTRUCTION_PUBLISHED_FINAL_DELETED))
           -TrustedEventTimestamp $env:AGENT_INSTRUCTION_TRUSTED_EVENT_TIMESTAMP
           -EventName $env:AGENT_INSTRUCTION_EVENT_NAME
           -PullRequestAction $env:AGENT_INSTRUCTION_PULL_REQUEST_ACTION
-          -PreviousHeadRevision $env:AGENT_INSTRUCTION_PREVIOUS_HEAD_REVISION
           -PullRequestBaseChanged $env:AGENT_INSTRUCTION_PULL_REQUEST_BASE_CHANGED
+          -DestinationRef $env:AGENT_INSTRUCTION_DESTINATION_REF
           -EventHeadRevision $env:AGENT_INSTRUCTION_EVENT_HEAD_REVISION
           -EventHeadDistinct $env:AGENT_INSTRUCTION_EVENT_HEAD_DISTINCT
-          -NewRefCommitCount $env:AGENT_INSTRUCTION_NEW_REF_COMMIT_COUNT
-          -NewRefCommitEvidenceJson $env:AGENT_INSTRUCTION_NEW_REF_COMMITS_JSON
+          -PushCommitCount $env:AGENT_INSTRUCTION_PUSH_COMMIT_COUNT
+          -PushDistinctCommitCount `
+          $env:AGENT_INSTRUCTION_PUSH_DISTINCT_COMMIT_COUNT
+          -PushCommitEvidenceJson `
+          $env:AGENT_INSTRUCTION_PUSH_COMMIT_EVIDENCE
+          -OtherRefEvidenceJson `
+          $env:AGENT_INSTRUCTION_OTHER_REF_EVIDENCE

--- a/.github/workflows/agent-instructions.yml
+++ b/.github/workflows/agent-instructions.yml
@@ -185,7 +185,7 @@ jobs:
             } catch {
               throw new Error("Push commit evidence is malformed JSON.");
             }
-            if (!Array.isArray(commits) || commits.length > 2048) {
+            if (!Array.isArray(commits) || commits.length >= 2048) {
               throw new Error("Push commit evidence is not a bounded array.");
             }
             const seenCommitIds = new Set();
@@ -217,7 +217,7 @@ jobs:
           test "${push_commit_count}" -eq "${#push_commit_ids[@]}"
           fetch_depth=$((push_commit_count + 1))
           test "${fetch_depth}" -ge 1
-          test "${fetch_depth}" -le 2049
+          test "${fetch_depth}" -le 2048
           authorization="$(printf 'x-access-token:%s' "${GITHUB_TOKEN}" |
             base64 -w 0)"
           set +e

--- a/.github/workflows/agent-instructions.yml
+++ b/.github/workflows/agent-instructions.yml
@@ -164,8 +164,10 @@ jobs:
 
           raw_refs="$(mktemp)"
           raw_refs_after="$(mktemp)"
+          sorted_refs="$(mktemp)"
           evidence_rows="$(mktemp)"
-          trap 'rm -f "${raw_refs}" "${raw_refs_after}" "${evidence_rows}"' EXIT
+          trap 'rm -f "${raw_refs}" "${raw_refs_after}" \
+            "${sorted_refs}" "${evidence_rows}"' EXIT
           authorization="$(printf 'x-access-token:%s' "${GITHUB_TOKEN}" |
             base64 -w 0)"
           set +e
@@ -183,7 +185,41 @@ jobs:
           fi
           test "${pipeline_status[0]}" -eq 0
 
-          mapfile -t remote_rows < <(sort "${raw_refs}")
+          if ! node -e '
+            const fs = require("fs");
+            const { TextDecoder } = require("util");
+            const decoder = new TextDecoder("utf-8", { fatal: true });
+            const text = decoder.decode(fs.readFileSync(process.argv[1]));
+            if (text.includes("\r") ||
+                (text.length > 0 && !text.endsWith("\n"))) {
+              throw new Error("Remote ref evidence has invalid line endings.");
+            }
+            const rows = text.length === 0 ? [] :
+              text.slice(0, -1).split("\n");
+            const seenRefs = new Set();
+            const parsed = rows.map((row) => {
+              const fields = row.split("\t");
+              if (fields.length !== 2 ||
+                  !/^[0-9a-f]{40}$/.test(fields[0]) ||
+                  !/^refs\/(heads|tags)\/.+/.test(fields[1]) ||
+                  seenRefs.has(fields[1])) {
+                throw new Error("Remote ref evidence is malformed or duplicate.");
+              }
+              seenRefs.add(fields[1]);
+              return { object: fields[0], ref: fields[1], row };
+            });
+            const compareOrdinal = (left, right) =>
+              left < right ? -1 : left > right ? 1 : 0;
+            parsed.sort((left, right) =>
+              compareOrdinal(left.ref, right.ref));
+            fs.writeFileSync(process.argv[2],
+              parsed.map((entry) => entry.row).join("\n") +
+              (parsed.length > 0 ? "\n" : ""), "utf8");
+          ' "${raw_refs}" "${sorted_refs}"; then
+            echo 'Remote ref evidence parsing or ordinal sorting failed.' >&2
+            exit 1
+          fi
+          mapfile -t remote_rows <"${sorted_refs}"
           if test "${#remote_rows[@]}" -gt 257; then
             echo 'Remote ref evidence exceeded 256 other refs.' >&2
             exit 1


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

## Summary

This pull request corrects issue #176 by replacing complete-history metadata transition enforcement with one published-baseline-to-final-state evaluation. Internal topic commits do not decide document metadata validity. A genuinely invalid published final state still fails.

The change keeps the graph-wide trust-root mutation audit, parser safety, repository containment, bounded Git-object reads, exact workflow-revision controls, event and ref guards, future-date rejection, and failure truth.

## Review base and landing relationship

The review base is the stable branch `agent/issue-177-advisory-extension-60-days` at commit `70bf7522233a6c8558809a2c2fc22be83a23a7b9` and tree `3b38f51097bc0a3da2efcac34eee5fad39181719`.

PR #178 was closed as superseded without merge because its two advisory blobs were already present on `main`. Its branch remains the immutable review anchor for this candidate. This pull request does not claim that the metadata repair has landed on `main`. Promotion must retain current `main` trust state and the reviewed product bytes in one controlled two-parent merge.

## Exact candidate identity

| Item | Identity |
| --- | --- |
| Candidate commit | `eca453edf39c9b3e9c705ae68929c9fff214503c` |
| Candidate tree | `24160117814d7bd4cab932c9c5a85949bac5f7de` |
| Candidate parent | `2ff3adc246f24eb2d3557fb28b64366e43b2e9d5` |
| Review base | `70bf7522233a6c8558809a2c2fc22be83a23a7b9` |
| Outgoing history | 21 commits, including one two-parent reconciliation commit |

The reconciliation commit `019b38183267f79b188893306e1b474b7156f785` joins the original PR history with the validated repair history without force. Commit `8d36d4f19e2dc3d5dde9d18fb11b2222eeb05b10` removes the residual per-commit metadata-history consumer. Commits `8e710114dd9f4a58be27ea0ee73fc75e57bddc91` and `aa5c292126265b13b5d5d15847ed708b1b091d7e` implement the final metadata, ADR, and timeless trust-invariant corrections. Commit `7a1b81472328cb7a8bebfdcd140dbb87ea67c804` advances the validator revision after the trusted same-day preflight repair. Commit `f90f1178208a671c2eadbe8f5643a3ae66e3e1d1` closes five final-state validation gaps. Commit `45f5eec95b79163c3b7962527e0a5bf22d5bf997` makes created-ref path discovery compare authenticated endpoint trees and adds a transient-path regression fixture. Commit `9b23928f5ee52d0a886ba46396ff5d66daf196b6` aligns the created-push truncation boundary and enforces revision arithmetic for metadata-only transitions. Commit `36f5e87c01a9b2a355cf552136d108804f608a65` documents the authorization applicability-only mode and requires a complete top-level parameter-help inventory. Commit `69d901352b4ba55c4b2544b2a7bacabe43caf190` rejects operative duplicate ADR status headings and fields, preserves ordinary status prose, and documents the exact legacy migration boundary. Commit `2ff3adc246f24eb2d3557fb28b64366e43b2e9d5` advances the documentation revision required for the published same-day follow-up. Final commit `eca453edf39c9b3e9c705ae68929c9fff214503c` closes the reviewed Markdown-table evasion by projecting table rows from the locked parser and rejecting a nonempty `Status` or `Decision Status` field outside canonical Metadata.

## Changed paths

Exactly five mode-`100644` paths differ from the review base.

| Path | Git blob | Bytes | SHA-256 |
| --- | --- | ---: | --- |
| `.github/instructions/docs.instructions.md` | `4424e4d6588984fdd2db5f4108ffae75fe886b4a` | 46,230 | `979d1913f3c27f8a2b2d9447b7c07de7f385375838e0b970e8aad6b769abcbf8` |
| `.github/workflows/Test-AgentInstructions.SelfTest.ps1` | `7d2a9d19d701df269014fff82daeb1086c976105` | 36,926 | `d5c1971120e7888bf40cd070655bb8721011cc0059d8f96e98ab425cfbd6c214` |
| `.github/workflows/Test-AgentInstructions.ps1` | `abfe2acade185e3245921fccc3809b2919a5208c` | 483,227 | `1d9a4d5b9ed8107821b1894d2f4a439f53eb30493dbd14926c585cb6fe42d8c9` |
| `.github/workflows/Test-TrustRootAuthorization.ps1` | `a3b9dc855a2cfcbdd21722f6fdfd17474dcdb1a2` | 38,270 | `e8f0d902c549b8dea128b47e5c56b5aa3333106d11ef8b2de38a45ad71433ba7` |
| `.github/workflows/agent-instructions.yml` | `1354dfbc2dcab3ba5cc3dba0c502efbbf6ce485f` | 24,273 | `9857211565f7876c136b00fa6aa344347dc5ae1120e32946b2c5a3e0f54e29b4` |

No dependency file, repository setting, credential, or unrelated document changes.

## Provenance and disposition

The clause analysis used PS commit `34fb7eb492c46cdf9949a52c357a5dd04f873dab` and pinned template commit `ec067b893bb8ac6f7bf2491f0cf8b38ce66fe5b6`. It classified 62 relevant clauses with no uncertainty.

| Clause group | Final disposition |
| --- | --- |
| `T1-01` | Retain the PSStyleGuide visible-header exception. |
| `T1-02` | Delete only the duplicate validator-catalog mandate. |
| `MS-01`, `MS-05`, `MS-06`, `MS-13`, `MS-14`, `MS-16` | Retain the template semantics. |
| `MS-02`–`MS-04`, `MS-07`–`MS-12` | Modify legacy transition wording to the published-baseline and finalization-point model. |
| `MS-15` | Retain the repository adaptation because PSStyleGuide has no template auto-fix workflow. |
| `UV-01`–`UV-07` | Retain URL, placeholder, and PSStyleGuide policy-owner semantics. |
| `UV-08` | Delete the documentation-to-validator architecture and exact-input coupling sentence. |
| `ADR-01` | Use one Tier 1 lifecycle `Status` with `Proposed`, `Accepted`, `Superseded`, or `Deprecated`. |
| `ADR-02` | Delete the second narrative decision-status representation. |
| `ADR-03`–`ADR-07` | Retain decision content and date semantics. |
| `PH-01`–`PH-07`, `PH-09`, `PH-10` | Retain the unresolved normative placeholder prohibition, remedies, scope, and contextual exceptions. |
| `PH-08` | Delete only the PS-only manual-inspection process mandate. |

## Behavioral contract

- Pull requests compare the base branch's published document state with the final PR head.
- Pushes compare the before and after published states.
- Internal topic, work-in-progress, and iteration commits do not determine metadata validity.
- When the published baseline has the same `major.minor.YYYYMMDD` tuple at revision `N`, the final revision must be exactly `N + 1`.
- When a higher-order version segment changes, or no published baseline exists, the final revision must be `0`.
- Revision arithmetic also applies when only the metadata header changes. An unchanged tuple and revision remain valid when rendered content is unchanged.
- Date, major, minor, and revision regressions fail independently.
- A changed published document must use the authenticated event's UTC date. An unchanged document does not need a date-only edit.
- Created-reference evidence is bounded, authenticated, and derived from exact event and remote-ref identities. With one outside-parent boundary, the validator compares that boundary tree with the final tree, so a path created and deleted during internal iteration is not a published change. A zero-introduction ref yields no changed paths, a genuine root uses its final tree, and multiple boundaries fail closed.
- The workflow rejects `commits.length >= 2048` because a created-push payload at the 2,048-object service cap can be truncated. Accepted payloads contain at most 2,047 objects, so the derived fetch depth cannot exceed 2,048.
- Trust-root paths remain checked across endpoint trees, roots, merge commits, parent edges, and every commit in the authorized candidate history. Ordinary pull requests use the normal trust-root audit unless the exact trusted authorization succeeds.
- The trust-root verifier documents that applicability-only mode returns one Boolean and does not perform full authorization validation. Its self-test requires exactly one top-level `.PARAMETER` help entry for each declared parameter.
- The extracted self-test runs from the trusted workflow revision.
- Documentation retains one policy owner without documenting validator architecture or exact-input coupling.
- New and changed ADRs use one lifecycle `Status` with the four documented decision values. An operative level-two heading that contains the whole word `Status`, a field-like status label, or a Markdown table row with a nonempty value adjacent to a `Status` or `Decision Status` label outside canonical Metadata fails validation. Inline emphasis and code formatting cannot hide a table label. Fenced examples, HTML comments, unrelated table labels, empty table values, and ordinary status prose remain allowed. Unchanged published legacy ADR bytes remain valid until their next change; that change must migrate the ADR to the single Tier 1 `Status` field and remove each separate status field or section.

## Protected documents unchanged

The following five documents are byte-identical to the review base: `.github/workflows/MARKDOWN-LINTING-IMPLEMENTATION.md` (`bed8c585a495c3cab2875cac036a5717acd82bb6`), `.github/workflows/scripts-README.md` (`0350d4979fd5ba109ba4dbb910e1593debd0138d`), `docs/ISSUE_EVALUATION_PROMPT.md` (`6835e35d318e3f8af8f48ba0d7d773f10475918b`), `docs/decisions/0001-accept-in-repository-trust-root.md` (`0386f596033b6871f01bb4c7c8f471b1087476bd`), and `docs/decisions/0002-accept-unverifiable-baseline-provenance.md` (`63c4682c034e78d408c0f862bed29a5d6a17b267`).

## Validation

| Validation | Result |
| --- | --- |
| PowerShell parser | 0 errors |
| PSScriptAnalyzer | 0 warning or error findings |
| Parser-manifest contract and mutation suite | Pass |
| Agent-instruction contract and mutation suite | Pass on final candidate |
| Exact trusted authorization | `True` for trusted `096470173445afd7a9f28e64e582610a5acf5c79`, base `70bf7522233a6c8558809a2c2fc22be83a23a7b9`, and candidate `eca453edf39c9b3e9c705ae68929c9fff214503c` |
| Workflow-policy validator | Exit 0; 57 cases passed |
| Markdown lint | 0 findings on the affected candidate Markdown and the final PR body |
| Pre-commit | Two full passes of all 10 hooks succeeded on candidate `69d901352b4ba55c4b2544b2a7bacabe43caf190`; the exact agent-instruction contract and mutation suite passed on final candidate `eca453edf39c9b3e9c705ae68929c9fff214503c`. Final local all-hook attempts did not complete because `actionlint` hung on the unchanged agent workflow; this hang is not treated as success. |
| GitHub Actions and shell validation | `actionlint` structural validation passed; ShellCheck passed all 11 effective Bash or sh blocks after excluding only independently refuted `SC2016` for an intentional single-quoted Node template literal; 10 blocks use an explicit Bash or sh shell |
| `git diff --check` | Exit 0 |
| Final push Agent validation | Run `33662462720`: success |
| Final trusted PR-target Agent validation | Run `33662466241`: success; exact authorization passed |
| Push and PR Dev container validation | Runs `33662462901` and `33662470007`: success |

Run `33596399720` on predecessor head `aa5c292126265b13b5d5d15847ed708b1b091d7e` failed because trusted `main` retained a temporary self-test for the deleted owner/enforcer coupling. Trusted commit `24ed379bdc21130538cae6cfc24be339633433b5` removed only that obsolete self-test, retained owner-path validation, and advanced the script version. Trusted commit `91298444ac0b4b5ef90402ee8cd8de70909c7fd2` retains full-history authorization checks and adds the endpoint-boundary semantic invariant. Trusted commit `455157c8476665285a5f37ab7afa4db78bc88810` aligns the workflow boundary invariant and authorizes candidate `9b23928f5ee52d0a886ba46396ff5d66daf196b6`. Trusted commit `f19b19d3cdbc7033e3187e9ecbf659ddbeba40ab` adds the applicability-only help and authorizes candidate `36f5e87c01a9b2a355cf552136d108804f608a65`. Trusted commit `12a6a1a6b3f838e3368e51ce2bb7ebe9109bf256` authorizes ADR-policy repair candidate `69d901352b4ba55c4b2544b2a7bacabe43caf190`; its four `main` workflows succeeded: Agent `33648305083`, Build `33648305137`, Dev container `33648304979`, and Markdown `33648305140`. Push Agent run `33649005798` then correctly rejected that candidate because the changed documentation retained same-day revision `0`. Candidate `2ff3adc246f24eb2d3557fb28b64366e43b2e9d5` changes only that field to revision `1`. Trusted commit `2d0d8f03177d66f5cb93f1c9d575c466bd8845b0` authorizes that corrected candidate; its four `main` workflows succeeded: Agent `33652316973`, Build `33652316828`, Dev container `33652316889`, and Markdown `33652316765`. Trusted commit `096470173445afd7a9f28e64e582610a5acf5c79` authorizes final candidate `eca453edf39c9b3e9c705ae68929c9fff214503c`; its four `main` workflows succeeded: Agent `33661958003`, Build `33661958025`, Dev container `33661958024`, and Markdown `33661958050`. Failed run `33649005798` remains failure evidence and is not treated as success.

Two local pre-commit attempts failed because the locked Node parser subprocess ended with Windows access-violation-style exits: one earlier attempt ended with `-1073741819`, and one final-repair attempt closed prematurely twice with `-1073740791` and `-1073740940`. Unchanged-byte retries passed. Two complete passes on candidate `69d901352b4ba55c4b2544b2a7bacabe43caf190` and one complete pass on trusted bootstrap `12a6a1a6b3f838e3368e51ce2bb7ebe9109bf256` succeeded. Two concurrent final all-hook attempts and one isolated retry did not complete because local `actionlint` hung while reading the unchanged `.github/workflows/agent-instructions.yml`; the verified orphan processes were stopped, and the incomplete attempts are not treated as success. The final exact CI-context contract and mutation suite passed locally, and all four final PR checks passed remotely. One production-validator harness attempt supplied a local-offset Git timestamp and was rejected before product validation; the same instant normalized to UTC `Z` passed.

## Issue relationships

Addresses #176. Do not close #176 until the reviewed result is promoted to `main` and landed validation succeeds.

Related to #172 without closing it. Related to closed PR #178 and completed issue #177 without reopening either one.

## Risk and rollback

The main integration risk is controlled promotion from the stable review base to current `main`. Promotion must preserve the reviewed document and validator blobs and retain current trusted workflow state.

Before promotion, close this pull request or move its branch only with an ordinary forward commit. Do not force-update it. After promotion, revert the promotion merge commit if landed validation fails. Do not treat an expired advisory result, skipped required check, or red CI result as success.
