### PR TITLE
fix: support legacy Copilot review toolchain

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -88,21 +88,32 @@ jobs:
             fi
           done
 
-          root_manifest_present=false
-          root_lock_present=false
-          [[ -f package.json && ! -L package.json ]] && \
-            root_manifest_present=true
-          [[ -f package-lock.json && ! -L package-lock.json ]] && \
-            root_lock_present=true
+          classify_npm_input() {
+            if [[ -L "$1" ]]; then
+              printf 'symlink'
+            elif [[ -f "$1" ]]; then
+              printf 'regular-file'
+            elif [[ -e "$1" ]]; then
+              printf 'non-regular'
+            else
+              printf 'absent'
+            fi
+          }
 
-          if [[ "${root_manifest_present}" == true && \
-            "${root_lock_present}" == true ]]; then
+          root_manifest_state="$(classify_npm_input package.json)"
+          root_lock_state="$(classify_npm_input package-lock.json)"
+
+          if [[ "${root_manifest_state}" == regular-file && \
+            "${root_lock_state}" == regular-file ]]; then
             echo 'layout=modern' >> "${GITHUB_OUTPUT}"
-          elif [[ ! -e package.json && ! -L package.json && \
-            ! -e package-lock.json && ! -L package-lock.json ]]; then
+          elif [[ "${root_manifest_state}" == absent && \
+            "${root_lock_state}" == absent ]]; then
             echo 'layout=legacy' >> "${GITHUB_OUTPUT}"
           else
-            echo '::error::The root npm validation tuple is incomplete or unsafe.'
+            echo '::error::The root npm validation tuple requires both inputs as' \
+              'regular files or both inputs absent;' \
+              "package.json=${root_manifest_state};" \
+              "package-lock.json=${root_lock_state}."
             exit 1
           fi
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -72,7 +72,42 @@ jobs:
             fi
           done
 
-      - name: Set up Node.js
+      - name: Detect locked validation-tool layout
+        id: toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow_manifest='.github/workflows/package.json'
+          workflow_lock='.github/workflows/package-lock.json'
+
+          for required_file in "${workflow_manifest}" "${workflow_lock}"; do
+            if [[ ! -f "${required_file}" || -L "${required_file}" ]]; then
+              echo "::error file=${required_file}::Required locked npm input" \
+                'is missing or is not a regular file.'
+              exit 1
+            fi
+          done
+
+          root_manifest_present=false
+          root_lock_present=false
+          [[ -f package.json && ! -L package.json ]] && \
+            root_manifest_present=true
+          [[ -f package-lock.json && ! -L package-lock.json ]] && \
+            root_lock_present=true
+
+          if [[ "${root_manifest_present}" == true && \
+            "${root_lock_present}" == true ]]; then
+            echo 'layout=modern' >> "${GITHUB_OUTPUT}"
+          elif [[ ! -e package.json && ! -L package.json && \
+            ! -e package-lock.json && ! -L package-lock.json ]]; then
+            echo 'layout=legacy' >> "${GITHUB_OUTPUT}"
+          else
+            echo '::error::The root npm validation tuple is incomplete or unsafe.'
+            exit 1
+          fi
+
+      - name: Set up Node.js for the modern layout
+        if: steps.toolchain.outputs.layout == 'modern'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: package.json
@@ -81,29 +116,71 @@ jobs:
             package-lock.json
             .github/workflows/package-lock.json
 
-      - name: Verify locked Node.js runtime
-        shell: bash
-        run: |
-          set -euo pipefail
-          expected_node="$(node -p 'require("./package.json").engines.node')"
-          expected_npm="$(node -p 'require("./package.json").engines.npm')"
-          test "$(node --version)" = "v${expected_node}"
-          test "$(npm --version)" = "${expected_npm}"
+      - name: Set up Node.js for the legacy layout
+        if: steps.toolchain.outputs.layout == 'legacy'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: .github/workflows/package-lock.json
 
-      - name: Install both locked Node.js validation tuples
+      - name: Verify selected Node.js runtime
         shell: bash
+        env:
+          TOOLCHAIN_LAYOUT: ${{ steps.toolchain.outputs.layout }}
         run: |
           set -euo pipefail
-          npm ci --ignore-scripts --no-audit --fund=false --include=dev
+          if [[ "${TOOLCHAIN_LAYOUT}" == modern ]]; then
+            expected_node="$(node -p \
+              'require("./package.json").engines.node')"
+            expected_npm="$(node -p \
+              'require("./package.json").engines.npm')"
+            test "$(node --version)" = "v${expected_node}"
+            test "$(npm --version)" = "${expected_npm}"
+          elif [[ "${TOOLCHAIN_LAYOUT}" == legacy ]]; then
+            test "$(node -p 'process.versions.node.split(".")[0]')" = '20'
+          else
+            echo '::error::The validation-tool layout is unsupported.'
+            exit 1
+          fi
+
+      - name: Install locked Node.js validation tools
+        shell: bash
+        env:
+          TOOLCHAIN_LAYOUT: ${{ steps.toolchain.outputs.layout }}
+        run: |
+          set -euo pipefail
+          if [[ "${TOOLCHAIN_LAYOUT}" == modern ]]; then
+            npm ci --ignore-scripts --no-audit --fund=false --include=dev
+          elif [[ "${TOOLCHAIN_LAYOUT}" != legacy ]]; then
+            echo '::error::The validation-tool layout is unsupported.'
+            exit 1
+          fi
           npm ci --ignore-scripts --no-audit --fund=false --include=dev \
             --prefix .github/workflows
 
       - name: Verify locked dependency trees and immutable manifests
         shell: bash
+        env:
+          TOOLCHAIN_LAYOUT: ${{ steps.toolchain.outputs.layout }}
         run: |
           set -euo pipefail
-          npm ls --all
+          if [[ "${TOOLCHAIN_LAYOUT}" == modern ]]; then
+            npm ls --all
+            immutable_inputs=(
+              package.json
+              package-lock.json
+              .github/workflows/package.json
+              .github/workflows/package-lock.json
+            )
+          elif [[ "${TOOLCHAIN_LAYOUT}" == legacy ]]; then
+            immutable_inputs=(
+              .github/workflows/package.json
+              .github/workflows/package-lock.json
+            )
+          else
+            echo '::error::The validation-tool layout is unsupported.'
+            exit 1
+          fi
           npm --prefix .github/workflows ls --all
-          git diff --exit-code -- package.json package-lock.json \
-            .github/workflows/package.json \
-            .github/workflows/package-lock.json
+          git diff --exit-code -- "${immutable_inputs[@]}"


### PR DESCRIPTION
## Summary

- detect whether a reviewed head uses the current root-plus-workflow npm layout or the valid legacy workflow-only layout
- keep exact Node/npm verification and both locked installs for current heads
- use the repository-approved Node 20 release line and the workflow-local lock for legacy heads
- reject missing, incomplete, alternate, or symlinked npm install inputs

This restores Copilot code review setup for long-lived planning PRs such as #182 without adding unrelated package files to those branches or merging unrelated default-branch history into them.

## Validation

- `pre-commit run actionlint --files .github/workflows/copilot-setup-steps.yml`
- `pre-commit run yamllint --files .github/workflows/copilot-setup-steps.yml`
- layout detector against current modern checkout: exit 0
- layout detector against PR #182 legacy checkout: exit 0
- `npm run test:agent-instructions`
- `pre-commit run --all-files` (two consecutive passes)
- `git diff --check`

## References

- [actions/setup-node advanced usage](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md)